### PR TITLE
facilitator: update libprio dependency branch

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -337,7 +337,7 @@ checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
 [[package]]
 name = "libprio-rs"
 version = "0.1.0"
-source = "git+https://github.com/abetterinternet/libprio-rs#c0a62779b6ad7642edbb99d84c32d57ea9d132d3"
+source = "git+https://github.com/abetterinternet/libprio-rs?branch=main#2b442cdb31aac1796e5da70006cb3c0f81a766f3"
 dependencies = [
  "aes-ctr",
  "aes-gcm",

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -10,7 +10,7 @@ avro-rs = "0.11.0"
 base64 = "0.12.3"
 chrono = "0.4"
 clap = "2.33.3"
-libprio-rs = { git = "https://github.com/abetterinternet/libprio-rs"}
+libprio-rs = { git = "https://github.com/abetterinternet/libprio-rs", branch = "main" }
 rand = "0.7"
 ring = "0.16.15"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Bad news: the build broke because we changed the default branch of
libprio-rs to main, and eventually deleted the master branch, so the
dependency became unresolvable.
Good news: our CI setup works!