### PR TITLE
Remove Some Clones

### DIFF
--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -37,7 +37,7 @@ impl<'a> BatchIntaker<'a> {
     ) -> Result<BatchIntaker<'a>> {
         Ok(BatchIntaker {
             ingestion_batch: BatchReader::new_ingestion(
-                aggregation_name.clone(),
+                aggregation_name,
                 batch_id,
                 date,
                 ingestion_transport,

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -113,7 +113,7 @@ pub fn generate_ingestion_sample(
 
             let facilitator_header_signature = facilitator_ingestion_batch.put_header(
                 &IngestionHeader {
-                    batch_uuid: batch_uuid.clone(),
+                    batch_uuid: *batch_uuid,
                     name: aggregation_name.to_owned(),
                     bins: dim,
                     epsilon: epsilon,
@@ -132,7 +132,7 @@ pub fn generate_ingestion_sample(
 
     let pha_header_signature = pha_ingestion_batch.put_header(
         &IngestionHeader {
-            batch_uuid: batch_uuid.clone(),
+            batch_uuid: *batch_uuid,
             name: aggregation_name.to_owned(),
             bins: dim,
             epsilon: epsilon,


### PR DESCRIPTION
This small patch removes some calls to `clone` for types that are either pointers or implement `Copy`.