### PR TITLE
OIDC auth for accessing S3 buckets

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -185,6 +185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "chunked_transfer"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7477065d45a8fe57167bf3cf8bcd3729b54cfcb81cca49bda2d038ea89ae82ca"
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +305,33 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "cookie"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1373a16a4937bc34efec7b391f9c1500c30b8478a701a4f44c9165cc0475a6e0"
+dependencies = [
+ "percent-encoding",
+ "time 0.2.22",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3818dfca4b0cb5211a659bbcbb94225b7127407b2b135e650d717bfb78ab10d3"
+dependencies = [
+ "cookie",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_json",
+ "time 0.2.22",
+ "url",
+]
 
 [[package]]
 name = "core-foundation"
@@ -436,12 +475,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.24"
+name = "error-chain"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
 dependencies = [
- "cfg-if",
+ "version_check",
 ]
 
 [[package]]
@@ -458,7 +497,6 @@ dependencies = [
  "hyper-rustls 0.21.0",
  "prio",
  "rand 0.7.3",
- "reqwest",
  "ring",
  "rusoto_core",
  "rusoto_mock",
@@ -468,6 +506,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "ureq",
  "uuid",
  "vergen",
 ]
@@ -808,12 +847,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
-
-[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -894,22 +927,6 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-
-[[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "mio"
@@ -1014,16 +1031,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -1137,6 +1144,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36e28516df94f3dd551a587da5357459d9b36d945a7c37c3557928c1c2ff2a2c"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
+dependencies = [
+ "error-chain",
+ "idna",
+ "lazy_static",
+ "regex",
+ "url",
+]
+
+[[package]]
+name = "qstring"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d464fae65fff2680baf48019211ce37aaec0c78e9264c84a3e484717f965104e"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -1268,42 +1297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
-dependencies = [
- "base64 0.12.3",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls 0.21.0",
- "ipnet",
- "js-sys",
- "lazy_static",
- "log",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.18.1",
- "serde",
- "serde_urlencoded",
- "tokio",
- "tokio-rustls 0.14.1",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
- "winreg",
 ]
 
 [[package]]
@@ -1958,7 +1951,6 @@ dependencies = [
  "mio",
  "mio-named-pipes",
  "mio-uds",
- "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -2066,15 +2058,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2125,6 +2108,25 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed21e32e4e3ff89891022affaa7091c3a164d5049cb3872f1cf0fd6ccd9fc8f7"
+dependencies = [
+ "base64 0.13.0",
+ "chunked_transfer",
+ "cookie",
+ "cookie_store",
+ "log",
+ "once_cell",
+ "qstring",
+ "rustls 0.18.1",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
 
 [[package]]
 name = "url"
@@ -2198,8 +2200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -2216,18 +2216,6 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -2281,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+checksum = "0f20dea7535251981a9670857150d571846545088359b28e4951d350bdaf179f"
 dependencies = [
  "webpki",
 ]
@@ -2321,15 +2309,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winreg"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
-dependencies = [
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "ws2_32-sys"

--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -430,6 +430,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "dtoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "facilitator"
 version = "0.1.0"
 dependencies = [
@@ -443,10 +458,12 @@ dependencies = [
  "hyper-rustls 0.21.0",
  "prio",
  "rand 0.7.3",
+ "reqwest",
  "ring",
  "rusoto_core",
  "rusoto_mock",
  "rusoto_s3",
+ "rusoto_sts",
  "serde",
  "tempfile",
  "thiserror",
@@ -761,6 +778,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,6 +806,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itoa"
@@ -844,6 +878,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +894,22 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
@@ -958,6 +1014,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1205,6 +1271,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
+dependencies = [
+ "base64 0.12.3",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls 0.21.0",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.18.1",
+ "serde",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls 0.14.1",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1426,22 @@ dependencies = [
  "sha2",
  "time 0.2.22",
  "tokio",
+]
+
+[[package]]
+name = "rusoto_sts"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3815b8c0fc1c50caf9e87603f23daadfedb18d854de287b361c69f68dc9d49e0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "rusoto_core",
+ "serde_urlencoded",
+ "tempfile",
+ "xml-rs",
 ]
 
 [[package]]
@@ -1513,6 +1631,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "serde",
+ "url",
 ]
 
 [[package]]
@@ -1807,6 +1937,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+
+[[package]]
 name = "tokio"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +1958,7 @@ dependencies = [
  "mio",
  "mio-named-pipes",
  "mio-uds",
+ "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -1929,6 +2066,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +2125,17 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+dependencies = [
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "uuid"
@@ -2023,6 +2198,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
  "cfg-if",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -2039,6 +2216,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2091,6 +2280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,6 +2321,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "ws2_32-sys"

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -16,9 +16,11 @@ hyper = "0.13.8"
 hyper-rustls = "0.21.0"
 prio = "0.2"
 rand = "0.7"
+reqwest = { version = "0.10.8", default_features = false, features = ["rustls-tls", "blocking"] }
 ring = { version = "0.16.15", features = ["std"] }
 rusoto_core = { version = "0.45.0", default_features = false, features = ["rustls"] }
 rusoto_s3 = { version = "0.45.0", default_features = false, features = ["rustls"] }
+rusoto_sts = { version = "0.45.0", default_features = false, features = ["rustls"] }
 serde = { version = "1.0", features = ["derive"] }
 tempfile = "3.1.0"
 thiserror = "1.0"

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -16,7 +16,6 @@ hyper = "0.13.8"
 hyper-rustls = "0.21.0"
 prio = "0.2"
 rand = "0.7"
-reqwest = { version = "0.10.8", default_features = false, features = ["rustls-tls", "blocking"] }
 ring = { version = "0.16.15", features = ["std"] }
 rusoto_core = { version = "0.45.0", default_features = false, features = ["rustls"] }
 rusoto_s3 = { version = "0.45.0", default_features = false, features = ["rustls"] }
@@ -25,6 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 tempfile = "3.1.0"
 thiserror = "1.0"
 tokio = { version = "0.2", features = ["rt-core", "io-util"] }
+ureq = "1.5.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [build-dependencies]

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -122,6 +122,17 @@ fn main() -> Result<(), anyhow::Error> {
                         ),
                 )
                 .arg(
+                    Arg::with_name("s3-use-ambient-credentials")
+                        .long("s3-use-ambient-credentials")
+                        .help(
+                            "If present, authentication to S3 will try to use \
+                            credentials found in environment variables or \
+                            ~/.aws/. If omitted, OIDC credentials will be \
+                            obtained from the GKE metadata service and the \
+                            AWS_ROLE_ARN environment variable.",
+                        ),
+                )
+                .arg(
                     Arg::with_name("aggregation-id")
                         .long("aggregation-id")
                         .value_name("ID")
@@ -350,6 +361,17 @@ fn main() -> Result<(), anyhow::Error> {
                             filesystem path or an S3 bucket, formatted as \
                             \"s3://{region}/{bucket-name}\"",
                         ),
+                )
+                .arg(
+                    Arg::with_name("s3-use-ambient-credentials")
+                        .long("s3-use-ambient-credentials")
+                        .help(
+                            "If present, authentication to S3 will try to use \
+                            credentials found in environment variables or \
+                            ~/.aws/. If omitted, OIDC credentials will be \
+                            obtained from the GKE metadata service and the \
+                            AWS_ROLE_ARN environment variable.",
+                        ),
                 ),
         )
         .subcommand(
@@ -463,6 +485,17 @@ fn main() -> Result<(), anyhow::Error> {
                             "Bucket into which sum parts are to be written. May be either a \
                             local filesystem path or an S3 bucket, formatted \
                             as \"s3://{region}/{bucket-name}\"",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("s3-use-ambient-credentials")
+                        .long("s3-use-ambient-credentials")
+                        .help(
+                            "If present, authentication to S3 will try to use \
+                            credentials found in environment variables or \
+                            ~/.aws/. If omitted, OIDC credentials will be \
+                            obtained from the GKE metadata service and the \
+                            AWS_ROLE_ARN environment variable.",
                         ),
                 )
                 .arg(
@@ -715,6 +748,7 @@ fn transport_for_output_path(arg: &str, matches: &ArgMatches) -> Result<Box<dyn 
     match path {
         StoragePath::S3Path { region, bucket } => Ok(Box::new(S3Transport::new(
             Region::from_str(region)?,
+            matches.is_present("s3-use-ambient-credentials"),
             bucket.to_string(),
         ))),
         StoragePath::LocalPath(path) => Ok(Box::new(LocalFileTransport::new(

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -122,14 +122,14 @@ fn main() -> Result<(), anyhow::Error> {
                         ),
                 )
                 .arg(
-                    Arg::with_name("s3-use-ambient-credentials")
-                        .long("s3-use-ambient-credentials")
+                    Arg::with_name("s3-use-credentials-from-gke-metadata")
+                        .long("s3-use-credentials-from-gke-metadata")
                         .help(
                             "If present, authentication to S3 will try to use \
-                            credentials found in environment variables or \
-                            ~/.aws/. If omitted, OIDC credentials will be \
-                            obtained from the GKE metadata service and the \
-                            AWS_ROLE_ARN environment variable.",
+                            an OIDC auth token obtained from the GKE metadata \
+                            service and the AWS_ROLE_ARN environment variable. \
+                            If omitted, uses credentials found in environment \
+                            variables or ~/.aws/.",
                         ),
                 )
                 .arg(
@@ -363,14 +363,14 @@ fn main() -> Result<(), anyhow::Error> {
                         ),
                 )
                 .arg(
-                    Arg::with_name("s3-use-ambient-credentials")
-                        .long("s3-use-ambient-credentials")
+                    Arg::with_name("s3-use-credentials-from-gke-metadata")
+                        .long("s3-use-credentials-from-gke-metadata")
                         .help(
                             "If present, authentication to S3 will try to use \
-                            credentials found in environment variables or \
-                            ~/.aws/. If omitted, OIDC credentials will be \
-                            obtained from the GKE metadata service and the \
-                            AWS_ROLE_ARN environment variable.",
+                            an OIDC auth token obtained from the GKE metadata \
+                            service and the AWS_ROLE_ARN environment variable. \
+                            If omitted, uses credentials found in environment \
+                            variables or ~/.aws/.",
                         ),
                 ),
         )
@@ -488,14 +488,14 @@ fn main() -> Result<(), anyhow::Error> {
                         ),
                 )
                 .arg(
-                    Arg::with_name("s3-use-ambient-credentials")
-                        .long("s3-use-ambient-credentials")
+                    Arg::with_name("s3-use-credentials-from-gke-metadata")
+                        .long("s3-use-credentials-from-gke-metadata")
                         .help(
                             "If present, authentication to S3 will try to use \
-                            credentials found in environment variables or \
-                            ~/.aws/. If omitted, OIDC credentials will be \
-                            obtained from the GKE metadata service and the \
-                            AWS_ROLE_ARN environment variable.",
+                            an OIDC auth token obtained from the GKE metadata \
+                            service and the AWS_ROLE_ARN environment variable. \
+                            If omitted, uses credentials found in environment \
+                            variables or ~/.aws/.",
                         ),
                 )
                 .arg(
@@ -748,7 +748,7 @@ fn transport_for_output_path(arg: &str, matches: &ArgMatches) -> Result<Box<dyn 
     match path {
         StoragePath::S3Path { region, bucket } => Ok(Box::new(S3Transport::new(
             Region::from_str(region)?,
-            matches.is_present("s3-use-ambient-credentials"),
+            matches.is_present("s3-use-credentials-from-gke-metadata"),
             bucket.to_string(),
         ))),
         StoragePath::LocalPath(path) => Ok(Box::new(LocalFileTransport::new(

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -64,7 +64,8 @@ provider "google-beta" {
 }
 
 provider "aws" {
-  # aws_s3_bucket resources will be created in the region specified here
+  # aws_s3_bucket resources will be created in the region specified in this
+  # provider.
   # https://github.com/hashicorp/terraform/issues/12512
   region  = var.aws_region
   profile = var.aws_profile

--- a/terraform/modules/facilitator/facilitator.tf
+++ b/terraform/modules/facilitator/facilitator.tf
@@ -1,0 +1,95 @@
+variable "peer_share_processor_name" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "gcp_project" {
+  type = string
+}
+
+# This is the role in AWS we use to construct policy on the S3 buckets. It is
+# configured to allow access to the GCP service account for this facilitator via
+# Web Identity Federation
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
+resource "aws_iam_role" "bucket_role" {
+  name = "prio-${var.environment}-${var.peer_share_processor_name}-bucket-role"
+  # We currently use a single role per facilitator to gate read/write access to
+  # all buckets. We could use audiences to define more roles for read/write on
+  # each of the ingestion, validation and sum part buckets.
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html
+  assume_role_policy = <<ROLE
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "accounts.google.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "accounts.google.com:sub": "${module.kubernetes.service_account_unique_id}"
+        }
+      }
+    }
+  ]
+}
+ROLE
+
+  tags = {
+    environment = "prio-${var.environment}"
+  }
+}
+
+locals {
+  ingestion_bucket_name  = "prio-${var.environment}-${var.peer_share_processor_name}-ingestion"
+  validation_bucket_name = "prio-${var.environment}-${var.peer_share_processor_name}-validation"
+  sum_part_bucket_name   = "prio-${var.environment}-${var.peer_share_processor_name}-sum-part"
+}
+
+resource "aws_s3_bucket" "buckets" {
+  for_each = toset([
+    local.ingestion_bucket_name, local.validation_bucket_name, local.sum_part_bucket_name
+  ])
+  bucket = each.key
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_role.bucket_role.arn}"
+      },
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:PutObject",
+        "s3:ListMultipartUploadParts",
+        "s3:ListBucketMultipartUploads",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${each.key}/*",
+        "arn:aws:s3:::${each.key}"
+      ]
+    }
+  ]
+}
+POLICY
+  tags = {
+    environment = var.environment
+  }
+}
+
+module "kubernetes" {
+  source                    = "../../modules/kubernetes/"
+  peer_share_processor_name = var.peer_share_processor_name
+  gcp_project               = var.gcp_project
+  environment               = var.environment
+  ingestion_bucket          = "${aws_s3_bucket.buckets[local.ingestion_bucket_name].region}/${aws_s3_bucket.buckets[local.ingestion_bucket_name].bucket}"
+  ingestion_bucket_role     = aws_iam_role.bucket_role.arn
+}

--- a/terraform/modules/facilitator/facilitator.tf
+++ b/terraform/modules/facilitator/facilitator.tf
@@ -22,6 +22,10 @@ resource "aws_iam_role" "bucket_role" {
   # all buckets. We could define more GCP service accounts and corresponding AWS
   # IAM roles for read/write on each of the ingestion, validation and sum part
   # buckets.
+  # Since azp is set in the auth token Google generates, we must check oaud in
+  # the role assumption policy, and the value must match what we request when
+  # requesting tokens from the GKE metadata service in
+  # S3Transport::new_with_client
   # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html
   assume_role_policy = <<ROLE
 {
@@ -36,7 +40,7 @@ resource "aws_iam_role" "bucket_role" {
       "Condition": {
         "StringEquals": {
           "accounts.google.com:sub": "${module.kubernetes.service_account_unique_id}",
-          "accounts.google.com:aud": "sts.amazonaws.com/${data.aws_caller_identity.current.account_id}"
+          "accounts.google.com:oaud": "sts.amazonaws.com/${data.aws_caller_identity.current.account_id}"
         }
       }
     }

--- a/terraform/modules/gke/gke.tf
+++ b/terraform/modules/gke/gke.tf
@@ -10,6 +10,10 @@ variable "gcp_region" {
   type = string
 }
 
+variable "gcp_project" {
+  type = string
+}
+
 variable "machine_type" {
   type = string
 }
@@ -38,6 +42,12 @@ resource "google_container_cluster" "cluster" {
     cluster_ipv4_cidr_block  = ""
     services_ipv4_cidr_block = ""
   }
+  # Enables workload identity, which enables containers to authenticate as GCP
+  # service accounts which may then be used to authenticate to AWS S3.
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+  workload_identity_config {
+    identity_namespace = "${var.gcp_project}.svc.id.goog"
+  }
 }
 
 resource "google_container_node_pool" "worker_nodes" {
@@ -59,6 +69,11 @@ resource "google_container_node_pool" "worker_nodes" {
       "logging-write",
       "monitoring"
     ]
+    # Configures nodes to obtain workload identity from GKE metadata service
+    # https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
   }
 }
 

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -21,6 +21,19 @@ variable "execution_manager_version" {
   default = "0.1.0"
 }
 
+variable "gcp_project" {
+  type = string
+}
+
+variable "ingestion_bucket" {
+  type = string
+}
+
+variable "ingestion_bucket_role" {
+  type = string
+}
+
+# Each facilitator is created in its own namespace
 resource "kubernetes_namespace" "namespace" {
   metadata {
     name = var.peer_share_processor_name
@@ -28,6 +41,78 @@ resource "kubernetes_namespace" "namespace" {
       environment = var.environment
     }
   }
+}
+
+# Workload identity[1] lets us map GCP service accounts to Kubernetes service
+# accounts. We need this so that pods can use GCP API, but also AWS APIs like S3
+# via Web Identity Federation. To use the credentials, the container must fetch
+# the authentication token from the instance metadata service. Kubernetes has
+# features for automatically providing a service account token (e.g. via a
+# a mounted volume[2]), but that would be a token for the *Kubernetes* level
+# service account, and not the one we can present to AWS.
+# [1] https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+# [2] https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection
+
+# For each facilitator, we first create a GCP service account.
+resource "google_service_account" "execution_manager" {
+  provider = google-beta
+  # The Account ID must be unique across the whole GCP project, and not just the
+  # namespace. It must also be less than 30 characters, so we can't concatenate
+  # environment and PHA name to get something unique. Instead, we generate a
+  # random string.
+  account_id   = "prio-${random_string.account_id.result}"
+  display_name = "prio-${var.environment}-${var.peer_share_processor_name}-execution-manager"
+}
+
+resource "random_string" "account_id" {
+  length  = 16
+  upper   = false
+  number  = false
+  special = false
+}
+
+# This is the Kubernetes-level service account which we associate with the GCP
+# service account above.
+resource "kubernetes_service_account" "execution_manager" {
+  metadata {
+    name      = "${var.peer_share_processor_name}-execution-manager"
+    namespace = var.peer_share_processor_name
+    annotations = {
+      environment = var.environment
+      # This annotation is necessary for the Kubernetes-GCP service account
+      # mapping. See step 6 in
+      # https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to
+      "iam.gke.io/gcp-service-account" = google_service_account.execution_manager.email
+    }
+  }
+}
+
+# This carefully constructed string lets us refer to the Kubernetes service
+# account in GCP-level policies, below. See step 5 in
+# https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to
+locals {
+  service_account = "serviceAccount:${var.gcp_project}.svc.id.goog[${kubernetes_namespace.namespace.metadata[0].name}/${kubernetes_service_account.execution_manager.metadata[0].name}]"
+}
+
+# Allows the Kubernetes service account to impersonate the GCP service account.
+resource "google_service_account_iam_binding" "execution-manager-workload" {
+  provider           = google-beta
+  service_account_id = google_service_account.execution_manager.name
+  role               = "roles/iam.workloadIdentityUser"
+  members = [
+    local.service_account
+  ]
+}
+
+# Allows the Kubernetes service account to request auth tokens for the GCP
+# service account.
+resource "google_service_account_iam_binding" "execution-manager-token" {
+  provider           = google-beta
+  service_account_id = google_service_account.execution_manager.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  members = [
+    local.service_account
+  ]
 }
 
 resource "kubernetes_cron_job" "execution_manager" {
@@ -40,25 +125,48 @@ resource "kubernetes_cron_job" "execution_manager" {
     }
   }
   spec {
-    schedule = "*/10 * * * *"
+    schedule                  = "*/10 * * * *"
+    failed_jobs_history_limit = 3
     job_template {
       metadata {}
       spec {
         template {
           metadata {}
           spec {
-            # Credentials are needed to pull images from Google Container Registry
-            automount_service_account_token = true
             container {
-              # For now just have the facilitator print its help text
               name  = "facilitator"
               image = "${var.container_registry}/${var.execution_manager_image}:${var.execution_manager_version}"
-              args  = ["--help"]
+              # Write sample data to exercise writing into S3.
+              args = [
+                "generate-ingestion-sample",
+                "--aggregation-id", "fake-1",
+                "--batch-id", "eb03ef04-5f05-4a64-95b2-ca1b841b6885",
+                "--date", "2020/09/11/21/11",
+                "--facilitator-output", "s3://${var.ingestion_bucket}",
+                "--pha-output", "/tmp/sample-pha"
+              ]
+              env {
+                name  = "AWS_ROLE_ARN"
+                value = var.ingestion_bucket_role
+              }
             }
-            restart_policy = "OnFailure"
+            # If we use any other restart policy, then when the job is finally
+            # deemed to be a failure, Kubernetes will destroy the job, pod and
+            # container(s) virtually immediately. This can cause us to lose logs
+            # if the container is reaped before the GKE logging agent can upload
+            # logs. Since this is a cronjob and we will retry anyway, we use
+            # "Never".
+            # https://kubernetes.io/docs/concepts/workloads/controllers/job/#handling-pod-and-container-failures
+            # https://github.com/kubernetes/kubernetes/issues/74848
+            restart_policy       = "Never"
+            service_account_name = kubernetes_service_account.execution_manager.metadata[0].name
           }
         }
       }
     }
   }
+}
+
+output "service_account_unique_id" {
+  value = google_service_account.execution_manager.unique_id
 }

--- a/terraform/variables/demo-gcp.tfvars
+++ b/terraform/variables/demo-gcp.tfvars
@@ -3,3 +3,4 @@ gcp_region                 = "us-west1"
 gcp_project                = "prio-bringup-290620"
 machine_type               = "e2-small"
 peer_share_processor_names = ["test-pha-1", "test-pha-2"]
+aws_region                 = "us-west-1"


### PR DESCRIPTION
This commit teaches facilitator to make authenticated calls to Amazon S3
using a GCP service account wired into Kubernetes pods using GKE
Workload Identity. The Terraform module also now creates ingestion,
validation and sum part buckets for each facilitator instance in a
cluster, with appropriate policies and IAM roles to permit our
facilitator/data share processors in GCP to write objects to them.