### PR TITLE
Terraform: Kubernetes secrets, renames, manifests, construction of all necessary data share processors, deploy tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is ISRG's implementation server components for [Prio](https://crypto.stanford.edu/prio/), the privacy preserving statistics aggregation system.
 
-`avro-schema` contains [Avro](https://avro.apache.org/docs/current/index.html) schema definitions for interoperation with other actors in the Prio system. `facilitator` contains the Rust implementation of ISRG's Prio facilitation server. `terraform` contains a Terraform module for deploying facilitator servers.
+`avro-schema` contains [Avro](https://avro.apache.org/docs/current/index.html) schema definitions for interoperation with other actors in the Prio system. `facilitator` contains the Rust implementation of ISRG's Prio facilitation server. `terraform` contains a Terraform module for deploying data share processor servers.
 
 ## Releases
 

--- a/deploy-tool/.gitignore
+++ b/deploy-tool/.gitignore
@@ -1,0 +1,1 @@
+deploy-tool

--- a/deploy-tool/main.go
+++ b/deploy-tool/main.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// This tool consumes the output of `terraform apply`, generating keys and then
+// populating specific manifests and Kubernetes secrets with appropriate values.
+// We do this in this tool because if we generated secrets via Terraform
+// resources, the secret values would appear in the Terraform state file. The
+// struct definitions here MUST be kept in sync with the output variable in
+// terraform/modules/facilitator/facilitator.tf and the corresponding structs in
+// facilitator/src/manifest.rs.
+
+// BatchSigningKey represents a public key used for batch signing.
+type BatchSigningKey struct {
+	// PublicKey is the PEM armored base64 encoding of the ASN.1 encoding of the
+	// PKIX SubjectPublicKeyInfo structure. It must be an ECDSA P256 key.
+	PublicKey string `json:"public-key"`
+	// Expiration is the ISO 8601 encoded UTC date at which this key expires.
+	Expiration string
+}
+
+// SpecificManifest represents the manifest file advertised by a data share
+// processor. See the design document for the full specification.
+// https://docs.google.com/document/d/1MdfM3QT63ISU70l63bwzTrxr93Z7Tv7EDjLfammzo6Q/edit#heading=h.3j8dgxqo5h68
+type SpecificManifest struct {
+	// Format is the version of the manifest.
+	Format float64 `json:"format"`
+	// IngestionBucket is the region+name of the bucket that the data share
+	// processor which owns the manifest reads ingestion batches from.
+	IngestionBucket string `json:"ingestion-bucket"`
+	// ValidationBucket is the region+name of the bucket that the data share
+	// processor which owns the manifest writes validation batches to.
+	ValidationBucket string `json:"validation-bucket"`
+	// SumPartBucket is the region+name of the bucket that the data share
+	// processor which owns the manifest writes sum parts to.
+	SumPartBucket string `json:"sum-part-bucket"`
+	// BatchSigningKeys maps key identifiers to batch signing public keys. These
+	// are the keys used by the data share processor which owns the manifest to
+	// sign batches.
+	BatchSigningKeys map[string]BatchSigningKey `json:"batch-signing-keys"`
+	// PacketEncryptionCertificates maps key identifiers to packet encryption
+	// certificates. The values are PEM encoded X.509 certificates, which
+	// contain the public key corresponding to the private key that the data
+	// share processor which owns the manifest uses to decrypt ingestion share
+	// packets.
+	PacketEncryptionCertificates map[string]string `json:"packet-encryption-certificates"`
+}
+
+// TerraformOutput represents the JSON output from `terraform apply` or
+// `terraform output --json`. This struct must match the output variables
+// defined in terraform/main.tf, though it only need describe the output
+// variables this program is interested in.
+type TerraformOutput struct {
+	ManifestBucket struct {
+		Value string
+	} `json:"manifest_bucket"`
+	SpecificManifests struct {
+		Value map[string]SpecificManifest
+	} `json:"specific_manifests"`
+}
+
+func generateKeyPair(dataShareProcessorName, keyName string) (*ecdsa.PrivateKey, error) {
+	ecdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ECDSA P256 key: %w", err)
+	}
+
+	pkcs8PrivateKey, err := x509.MarshalPKCS8PrivateKey(ecdsaKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ECDSA key to PKCS#8 document: %w", err)
+	}
+
+	// Put the private keys into Kubernetes secrets. There's no straightforward
+	// way to update a secret value using kubectl, so we use the trick from[1].
+	// There's no particular reason to use `-o=json` but we must set some output
+	// format or nothing is written to stdout.
+	// [1] https://blog.atomist.com/updating-a-kubernetes-secret-or-configmap/
+	//
+	// We can't provide the base64 encoding of the key to --from-literal because
+	// then kubectl would base64 the base64, so we have to write the b64 to a
+	// temp file and then provide that to --from-file.
+	log.Printf("updating Kubernetes secret %s/%s", dataShareProcessorName, keyName)
+	tempFile, err := ioutil.TempFile("", "pkcs8-private-key-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp file: %v", err)
+	}
+	defer tempFile.Close()
+	defer os.Remove(tempFile.Name())
+
+	base64PrivateKey := base64.StdEncoding.EncodeToString(pkcs8PrivateKey)
+	if err := ioutil.WriteFile(tempFile.Name(), []byte(base64PrivateKey), 0644); err != nil {
+		return nil, fmt.Errorf("failed to write out PKCS#8 private key: %v", err)
+	}
+
+	secretArgument := fmt.Sprintf("--from-file=signing_key=%s", tempFile.Name())
+	kubectlCreate := exec.Command("kubectl", "-n", dataShareProcessorName, "create",
+		"secret", "generic", keyName, secretArgument, "--dry-run=client", "-o=json")
+	kubectlApply := exec.Command("kubectl", "apply", "-f", "-")
+	read, write := io.Pipe()
+	kubectlApply.Stdin = read
+	kubectlCreate.Stdout = write
+
+	// Do this async because if we don't close `kubectl create`'s stdout,
+	// `kubectl apply` will never make progress.
+	go func() {
+		defer write.Close()
+		if err := kubectlCreate.Run(); err != nil {
+			log.Fatalf("failed to run kubectl create: %v", err)
+		}
+	}()
+
+	if output, err := kubectlApply.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("failed to run kubectl apply: %v\nCombined output: %s", err, output)
+	}
+
+	return ecdsaKey, nil
+}
+
+func main() {
+	var terraformOutput TerraformOutput
+
+	err := json.NewDecoder(os.Stdin).Decode(&terraformOutput)
+	if err != nil {
+		log.Fatalf("failed to parse specific manifests: %v", err)
+	}
+
+	for dataShareProcessorName, manifest := range terraformOutput.SpecificManifests.Value {
+		newBatchSigningKeys := map[string]BatchSigningKey{}
+		for name, batchSigningKey := range manifest.BatchSigningKeys {
+			if batchSigningKey.PublicKey != "" {
+				newBatchSigningKeys[name] = batchSigningKey
+				continue
+			}
+			log.Printf("generating ECDSA P256 key %s", name)
+			privateKey, err := generateKeyPair(dataShareProcessorName, name)
+			if err != nil {
+				log.Fatalf("%s", err)
+			}
+
+			pkixPublic, err := x509.MarshalPKIXPublicKey(privateKey.Public())
+			if err != nil {
+				log.Fatalf("failed to marshal ECDSA public key to PKIX: %v", err)
+			}
+
+			block := pem.Block{
+				Type:  "PUBLIC KEY",
+				Bytes: []byte(pkixPublic),
+			}
+
+			newBatchSigningKeys[name] = BatchSigningKey{
+				PublicKey:  string(pem.EncodeToMemory(&block)),
+				Expiration: time.Now().UTC().Format(time.RFC3339),
+			}
+		}
+
+		manifest.BatchSigningKeys = newBatchSigningKeys
+
+		newCertificates := map[string]string{}
+		for name, packetEncryptionCertificate := range manifest.PacketEncryptionCertificates {
+			if packetEncryptionCertificate != "" {
+				newCertificates[name] = packetEncryptionCertificate
+				continue
+			}
+			log.Printf("generating and certifying P256 key %s", name)
+			_, err := generateKeyPair(dataShareProcessorName, name)
+			if err != nil {
+				log.Fatalf("%s", err)
+			}
+
+			// TODO(timg) get certificate over the key, insert it here
+			newCertificates[name] = "TODO get certificate"
+		}
+
+		manifest.PacketEncryptionCertificates = newCertificates
+
+		// Put the specific manifests into the manifest bucket. Users of this
+		// tool already need to have gsutil and valid Google Cloud credentials
+		// to be able to use the Makefile, so execing out to gsutil saves us the
+		// trouble of pulling in the gcloud SDK.
+		destination := fmt.Sprintf("gs://%s/%s.json",
+			terraformOutput.ManifestBucket.Value, dataShareProcessorName)
+		log.Printf("uploading specific manifest %s", destination)
+		gsutil := exec.Command("gsutil", "-h",
+			"Content-Type:application/json", "cp", "-", destination)
+		stdin, err := gsutil.StdinPipe()
+		if err != nil {
+			log.Fatalf("could not get pipe to gsutil stdin: %v", err)
+		}
+
+		// Do this async becuase if we don't close gsutil's stdin, it will
+		// never be able to get started.
+		go func() {
+			defer stdin.Close()
+			log.Printf("uploading manifest %+v", manifest)
+			manifestEncoder := json.NewEncoder(stdin)
+			if err := manifestEncoder.Encode(manifest); err != nil {
+				log.Fatalf("failed to encode manifest into gsutil stdin: %v", err)
+			}
+		}()
+
+		if output, err := gsutil.CombinedOutput(); err != nil {
+			log.Fatalf("gsutil failed: %v\noutput: %s", err, output)
+		}
+	}
+}

--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -439,6 +439,7 @@ dependencies = [
  "derivative",
  "hyper",
  "hyper-rustls 0.21.0",
+ "pem",
  "prio",
  "rand 0.7.3",
  "reqwest",
@@ -448,6 +449,7 @@ dependencies = [
  "rusoto_s3",
  "rusoto_sts",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1032,6 +1034,17 @@ name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "pem"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59698ea79df9bf77104aefd39cc3ec990cb9693fb59c3b0a70ddf2646fdffb4b"
+dependencies = [
+ "base64 0.12.3",
+ "once_cell",
+ "regex",
+]
 
 [[package]]
 name = "percent-encoding"

--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -413,6 +413,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
+name = "dtoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a51b8cf747471cb9499b6d59e59b0444f4c90eba8968c4e44874e92b5b64ace2"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "facilitator"
 version = "0.1.0"
 dependencies = [
@@ -426,10 +441,12 @@ dependencies = [
  "hyper-rustls 0.21.0",
  "prio",
  "rand 0.7.3",
+ "reqwest",
  "ring",
  "rusoto_core",
  "rusoto_mock",
  "rusoto_s3",
+ "rusoto_sts",
  "serde",
  "tempfile",
  "thiserror",
@@ -744,6 +761,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +789,12 @@ checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itoa"
@@ -827,6 +861,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +877,22 @@ name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "mio"
@@ -941,6 +997,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1188,6 +1254,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
+dependencies = [
+ "base64 0.12.3",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls 0.21.0",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.18.1",
+ "serde",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls 0.14.1",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1409,22 @@ dependencies = [
  "sha2",
  "time 0.2.22",
  "tokio",
+]
+
+[[package]]
+name = "rusoto_sts"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3815b8c0fc1c50caf9e87603f23daadfedb18d854de287b361c69f68dc9d49e0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "rusoto_core",
+ "serde_urlencoded",
+ "tempfile",
+ "xml-rs",
 ]
 
 [[package]]
@@ -1496,6 +1614,18 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "serde",
+ "url",
 ]
 
 [[package]]
@@ -1780,6 +1910,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+
+[[package]]
 name = "tokio"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +1931,7 @@ dependencies = [
  "mio",
  "mio-named-pipes",
  "mio-uds",
+ "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -1902,6 +2039,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+dependencies = [
+ "matches",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1934,6 +2098,17 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+dependencies = [
+ "idna",
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "uuid"
@@ -1996,6 +2171,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
  "cfg-if",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -2012,6 +2189,18 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2064,6 +2253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2294,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "ws2_32-sys"

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -14,14 +14,16 @@ clap = "2.33.3"
 derivative = "2.1.1"
 hyper = "0.13.8"
 hyper-rustls = "0.21.0"
+pem = "0.8"
 prio = "0.2"
 rand = "0.7"
-reqwest = { version = "0.10.8", default_features = false, features = ["rustls-tls", "blocking"] }
+reqwest = { version = "0.10.8", default_features=false, features = ["blocking", "rustls-tls"] }
 ring = { version = "0.16.15", features = ["std"] }
 rusoto_core = { version = "0.45.0", default_features = false, features = ["rustls"] }
 rusoto_s3 = { version = "0.45.0", default_features = false, features = ["rustls"] }
 rusoto_sts = { version = "0.45.0", default_features = false, features = ["rustls"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tempfile = "3.1.0"
 thiserror = "1.0"
 tokio = { version = "0.2", features = ["rt-core", "io-util"] }

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -16,9 +16,11 @@ hyper = "0.13.8"
 hyper-rustls = "0.21.0"
 prio = "0.2"
 rand = "0.7"
+reqwest = { version = "0.10.8", default_features = false, features = ["rustls-tls", "blocking"] }
 ring = { version = "0.16.15", features = ["std"] }
 rusoto_core = { version = "0.45.0", default_features = false, features = ["rustls"] }
 rusoto_s3 = { version = "0.45.0", default_features = false, features = ["rustls"] }
+rusoto_sts = { version = "0.45.0", default_features = false, features = ["rustls"] }
 serde = { version = "1.0", features = ["derive"] }
 tempfile = "3.1.0"
 thiserror = "1.0"

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -219,6 +219,7 @@ fn main() -> Result<(), anyhow::Error> {
                 .arg(
                     Arg::with_name("ingestor-private-key")
                         .long("ingestor-private-key")
+                        .env("INGESTION_BATCH_SIGNING_KEY")
                         .value_name("B64")
                         .help(
                             "Base64 encoded ECDSA P256 private key for the \

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -122,6 +122,17 @@ fn main() -> Result<(), anyhow::Error> {
                         ),
                 )
                 .arg(
+                    Arg::with_name("s3-use-ambient-credentials")
+                        .long("s3-use-ambient-credentials")
+                        .help(
+                            "If present, authentication to S3 will try to use \
+                            credentials found in environment variables or \
+                            ~/.aws/. If omitted, OIDC credentials will be \
+                            obtained from the GKE metadata service and the \
+                            AWS_ROLE_ARN environment variable.",
+                        ),
+                )
+                .arg(
                     Arg::with_name("aggregation-id")
                         .long("aggregation-id")
                         .value_name("ID")
@@ -350,6 +361,17 @@ fn main() -> Result<(), anyhow::Error> {
                             filesystem path or an S3 bucket, formatted as \
                             \"s3://{region}/{bucket-name}\"",
                         ),
+                )
+                .arg(
+                    Arg::with_name("s3-use-ambient-credentials")
+                        .long("s3-use-ambient-credentials")
+                        .help(
+                            "If present, authentication to S3 will try to use \
+                            credentials found in environment variables or \
+                            ~/.aws/. If omitted, OIDC credentials will be \
+                            obtained from the GKE metadata service and the \
+                            AWS_ROLE_ARN environment variable.",
+                        ),
                 ),
         )
         .subcommand(
@@ -463,6 +485,17 @@ fn main() -> Result<(), anyhow::Error> {
                             "Bucket into which sum parts are to be written. May be either a \
                             local filesystem path or an S3 bucket, formatted \
                             as \"s3://{region}/{bucket-name}\"",
+                        ),
+                )
+                .arg(
+                    Arg::with_name("s3-use-ambient-credentials")
+                        .long("s3-use-ambient-credentials")
+                        .help(
+                            "If present, authentication to S3 will try to use \
+                            credentials found in environment variables or \
+                            ~/.aws/. If omitted, OIDC credentials will be \
+                            obtained from the GKE metadata service and the \
+                            AWS_ROLE_ARN environment variable.",
                         ),
                 )
                 .arg(
@@ -714,6 +747,7 @@ fn transport_for_output_path(arg: &str, matches: &ArgMatches) -> Result<Box<dyn 
     match path {
         StoragePath::S3Path { region, bucket } => Ok(Box::new(S3Transport::new(
             Region::from_str(region)?,
+            matches.is_present("s3-use-ambient-credentials"),
             bucket.to_string(),
         ))),
         StoragePath::LocalPath(path) => Ok(Box::new(LocalFileTransport::new(

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -6,6 +6,7 @@ pub mod aggregation;
 pub mod batch;
 pub mod idl;
 pub mod intake;
+pub mod manifest;
 pub mod sample;
 pub mod test_utils;
 pub mod transport;

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -1,0 +1,329 @@
+use anyhow::{anyhow, Context, Result};
+use reqwest::{blocking::Client, Url};
+use ring::signature::{UnparsedPublicKey, ECDSA_P256_SHA256_FIXED};
+use serde::Deserialize;
+use serde_json::from_reader;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+// See discussion in SpecificManifest::batch_signing_public_key
+const ECDSA_P256_SPKI_PREFIX: &[u8] = &[
+    0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08, 0x2a,
+    0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00,
+];
+
+/// Represents the description of a batch signing key in a specific manifest.
+#[derive(Debug, Deserialize, PartialEq)]
+struct BatchSigningKey {
+    /// The PEM-armored base64 encoding of the ASN.1 encoding of the PKIX
+    /// SubjectPublicKeyInfo structure of an ECDSA P256 key.
+    #[serde(rename = "public-key")]
+    public_key: String,
+    /// The ISO 8601 encoded UTC date at which this key expires.
+    expiration: String,
+}
+
+/// Represents a specific manifest, used to exchange configuration parameters
+/// with peer data share processors. See the design document for the full
+/// specification.
+/// https://docs.google.com/document/d/1MdfM3QT63ISU70l63bwzTrxr93Z7Tv7EDjLfammzo6Q/edit#heading=h.3j8dgxqo5h68
+#[derive(Debug, Deserialize, PartialEq)]
+struct SpecificManifest {
+    /// Format version of the manifest. Versions besides the currently supported
+    /// one are rejected.
+    format: u32,
+    /// Region and name of the ingestion S3 bucket owned by this data share
+    /// processor.
+    #[serde(rename = "ingestion-bucket")]
+    ingestion_bucket: String,
+    /// Region and name of the validation S3 bucket owned by this data share
+    /// processor.
+    #[serde(rename = "validation-bucket")]
+    validation_bucket: String,
+    /// Region and name of the sum part S3 bucket owned by this data share
+    /// processor.]
+    #[serde(rename = "sum-part-bucket")]
+    sum_part_bucket: String,
+    /// Keys used by this data share processor to sign batches.
+    #[serde(rename = "batch-signing-keys")]
+    batch_signing_keys: HashMap<String, BatchSigningKey>,
+    /// Keys used by this data share processor to decrypt ingestion packets. The
+    /// values are a PEM encoded X.509 certificate containing the ECDSA P256
+    /// public key.
+    #[serde(rename = "packet-encryption-certificates")]
+    packet_encryption_certificates: HashMap<String, String>,
+}
+
+impl SpecificManifest {
+    fn from_https(base_path: &str, peer_name: &str) -> Result<SpecificManifest> {
+        let base = Url::parse(base_path).context("failed to parse base path into URL")?;
+        let mut manifest_url = base
+            .join(peer_name)
+            .context("failed to join URL component")?
+            .join("specific-manifest.json")
+            .context("failed to join URL component")?;
+        manifest_url
+            .set_scheme("https")
+            .map_err(|_| anyhow!("failed to set URL scheme to HTTPS"))?;
+
+        // reqwest::blocking::RequestBuilder::send() gives us a Response, which
+        // implements std::io::Read by reading from the response body.
+        // https://docs.rs/reqwest/0.10.8/src/reqwest/blocking/response.rs.html#397-405
+        SpecificManifest::from_reader(
+            Client::new()
+                .get(manifest_url)
+                .send()
+                .context("failed to fetch specific manifest")?,
+        )
+    }
+
+    fn from_file(path: &Path) -> Result<SpecificManifest> {
+        SpecificManifest::from_reader(File::open(path).context("failed to open manifest file")?)
+    }
+
+    fn from_reader<R: Read>(reader: R) -> Result<SpecificManifest> {
+        let manifest: SpecificManifest =
+            from_reader(reader).context("failed to decode JSON specific manifest")?;
+        if manifest.format != 0 {
+            return Err(anyhow!("unsupported manifest format {}", manifest.format));
+        }
+        Ok(manifest)
+    }
+
+    /// Returns the ECDSA P256 public key corresponding to the provided key
+    /// identifier, if it exists in the manifest.
+    fn batch_signing_public_key(&self, identifier: &str) -> Result<UnparsedPublicKey<Vec<u8>>> {
+        let key = self
+            .batch_signing_keys
+            .get(identifier)
+            .context(format!("no value for key {}", identifier))?;
+
+        let pem = pem::parse(&key.public_key)
+            .context(format!("failed to parse key entry {} as PEM", identifier))?;
+        if pem.tag != "PUBLIC KEY" {
+            return Err(anyhow!(
+                "key for identifier {} is not a PEM encoded public key"
+            ));
+        }
+        if pem.contents.len() < ECDSA_P256_SPKI_PREFIX.len() {
+            return Err(anyhow!("PEM contents not long enough to contain ASN.1 encoded ECDSA P256 SubjectPublicKeyInfo"));
+        }
+        if &pem.contents[..ECDSA_P256_SPKI_PREFIX.len()] != ECDSA_P256_SPKI_PREFIX {
+            return Err(anyhow!(
+                "PEM contents are not ASN.1 encoded ECDSA P256 SubjectPublicKeyInfo"
+            ));
+        }
+
+        Ok(UnparsedPublicKey::new(
+            &ECDSA_P256_SHA256_FIXED,
+            Vec::from(&pem.contents[ECDSA_P256_SPKI_PREFIX.len()..]),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{
+        default_ingestor_private_key, DEFAULT_INGESTOR_SUBJECT_PUBLIC_KEY_INFO,
+    };
+    use ring::rand::SystemRandom;
+    use std::io::Cursor;
+
+    #[test]
+    fn load_manifest() {
+        let reader = Cursor::new(format!(
+            r#"
+{{
+    "format": 0,
+    "packet-encryption-certificates": {{
+        "fake-key-1": "who cares"
+    }},
+    "batch-signing-keys": {{
+        "fake-key-2": {{
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----",
+        "purpose": "batch-signing"
+      }}
+    }},
+    "ingestion-bucket": "us-west-1/ingestion",
+    "sum-part-bucket": "us-west-1/sum-part",
+    "validation-bucket": "us-west-1/validation"
+}}
+    "#,
+            DEFAULT_INGESTOR_SUBJECT_PUBLIC_KEY_INFO
+        ));
+        let manifest = SpecificManifest::from_reader(reader).unwrap();
+
+        let mut expected_batch_keys = HashMap::new();
+        expected_batch_keys.insert(
+            "fake-key-2".to_owned(),
+            BatchSigningKey {
+                expiration: "".to_string(),
+                public_key: format!(
+                    "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----",
+                    DEFAULT_INGESTOR_SUBJECT_PUBLIC_KEY_INFO
+                ),
+            },
+        );
+        let mut expected_packet_encryption_certificates = HashMap::new();
+        expected_packet_encryption_certificates
+            .insert("fake-key-1".to_owned(), "who cares".to_owned());
+        let expected_manifest = SpecificManifest {
+            format: 0,
+            batch_signing_keys: expected_batch_keys,
+            packet_encryption_certificates: expected_packet_encryption_certificates,
+            ingestion_bucket: "us-west-1/ingestion".to_string(),
+            validation_bucket: "us-west-1/validation".to_string(),
+            sum_part_bucket: "us-west-1/sum-part".to_string(),
+        };
+        assert_eq!(manifest, expected_manifest);
+        let batch_signing_key = manifest.batch_signing_public_key("fake-key-2").unwrap();
+        let content = b"some content";
+        let signature = default_ingestor_private_key()
+            .sign(&SystemRandom::new(), content)
+            .unwrap();
+        batch_signing_key
+            .verify(content, signature.as_ref())
+            .unwrap();
+    }
+
+    #[test]
+    fn invalid_manifest() {
+        let invalid_manifests = vec![
+            "not-json",
+            "{ \"missing\": \"keys\"}",
+            // No format key
+            r#"
+{
+    "packet-encryption-certificates": {
+        "fake-key-1": "who cares"
+    },
+    "batch-signing-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\nfoo\n-----END PUBLIC KEY-----",
+        "purpose": "batch-signing"
+      }
+    },
+    "ingestion-bucket": "us-west-1/ingestion",
+    "sum-part-bucket": "us-west-1/sum-part",
+    "validation-bucket": "us-west-1/validation"
+}}
+    "#,
+            // Format key with wrong value
+            r#"
+{
+    "format": 1,
+    "packet-encryption-certificates": {
+        "fake-key-1": "who cares"
+    },
+    "batch-signing-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\nfoo\n-----END PUBLIC KEY-----",
+        "purpose": "batch-signing"
+      }
+    },
+    "ingestion-bucket": "us-west-1/ingestion",
+    "sum-part-bucket": "us-west-1/sum-part",
+    "validation-bucket": "us-west-1/validation"
+}}
+    "#,
+            // Format key with wrong type
+            r#"
+{
+    "format": "zero",
+    "packet-encryption-certificates": {
+        "fake-key-1": "who cares"
+    },
+    "batch-signing-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\nfoo\n-----END PUBLIC KEY-----",
+        "purpose": "batch-signing"
+      }
+    },
+    "ingestion-bucket": "us-west-1/ingestion",
+    "sum-part-bucket": "us-west-1/sum-part",
+    "validation-bucket": "us-west-1/validation"
+}}
+    "#,
+        ];
+
+        for invalid_manifest in &invalid_manifests {
+            let reader = Cursor::new(invalid_manifest);
+            SpecificManifest::from_reader(reader).unwrap_err();
+        }
+    }
+
+    #[test]
+    fn invalid_public_key() {
+        let manifests_with_invalid_public_keys = vec![
+            // Wrong PEM block
+            r#"
+{
+    "format": 0,
+    "packet-encryption-certificates": {
+        "fake-key-1": "who cares"
+    },
+    "batch-signing-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN EC PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIKh3MccE1cdSF4pnEb+U0MmGYfkoQzOl2aiaJ6D9ZudqDdGiyA9YSUq3yia56nYJh5mk+HlzTX+AufoNR2bfrg==\n-----END EC PUBLIC KEY-----",
+        "purpose": "batch-signing"
+      }
+    },
+    "ingestion-bucket": "us-west-1/ingestion",
+    "sum-part-bucket": "us-west-1/sum-part",
+    "validation-bucket": "us-west-1/validation"
+}
+    "#,
+            // PEM contents not an ASN.1 SPKI
+            r#"
+{
+    "format": 0,
+    "packet-encryption-certificates": {
+        "fake-key-1": "who cares"
+    },
+    "batch-signing-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\nBIl6j+J6dYttxALdjISDv6ZI4/VWVEhUzaS05LgrsfswmbLOgNt9HUC2E0w+9RqZx3XMkdEHBHfNuCSMpOwofVSq3TfyKwn0NrftKisKKVSaTOt5seJ67P5QL4hxgPWvxw==\n-----END PUBLIC KEY-----",
+        "purpose": "batch-signing"
+      }
+    },
+    "ingestion-bucket": "us-west-1/ingestion",
+    "sum-part-bucket": "us-west-1/sum-part",
+    "validation-bucket": "us-west-1/validation"
+}
+    "#,
+            // PEM contents too short
+            r#"
+{
+    "format": 0,
+    "packet-encryption-certificates": {
+        "fake-key-1": "who cares"
+    },
+    "batch-signing-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\ndG9vIHNob3J0Cg==\n-----END PUBLIC KEY-----",
+        "purpose": "batch-signing"
+      }
+    },
+    "ingestion-bucket": "us-west-1/ingestion",
+    "sum-part-bucket": "us-west-1/sum-part",
+    "validation-bucket": "us-west-1/validation"
+}
+    "#,
+        ];
+        for invalid_manifest in &manifests_with_invalid_public_keys {
+            let reader = Cursor::new(invalid_manifest);
+            let manifest = SpecificManifest::from_reader(reader).unwrap();
+            assert!(manifest.batch_signing_public_key("fake-key-1").is_err());
+        }
+    }
+}

--- a/facilitator/src/test_utils.rs
+++ b/facilitator/src/test_utils.rs
@@ -17,14 +17,31 @@ pub const DEFAULT_INGESTOR_PRIVATE_KEY: &str =
     "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQggoa08rQR90Asvhy5b\
     WIgFBDeGaO8FnVEF3PVpNVmDGChRANCAAQ2mZfm4UC73PkWsYz3Uub6UTIAFQCPGxo\
     uP1O1PlmntOpfLYdvyZDCuenAzv1oCfyToolNArNjwo/+harNn1fs";
+// We have selected PEM armored, ASN.1 encoded PKIX SubjectPublicKeyInfo
+// structures as the means of exchanging public keys with peer servers. However,
+// no Rust crate that we have found gives us an easy way to obtain a PKIX SPKI
+// from the PKCS#8 document format that ring uses for private key serialization.
+// This constant and the other _SUBJECT_PUBLIC_KEY_INFO constants were obtained
+// by placing the corresponding _PRIVATE_KEY constants into a PEM block, and
+// then `openssl ec -inform PEM -outform PEM -in /path/to/PEM/PKCS#8/document
+// -pubout`.
+pub const DEFAULT_INGESTOR_SUBJECT_PUBLIC_KEY_INFO: &str =
+    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENpmX5uFAu9z5FrGM91Lm+lEyABUA\
+    jxsaLj9TtT5Zp7TqXy2Hb8mQwrnpwM79aAn8k6KJTQKzY8KP/oWqzZ9X7A==";
 pub const DEFAULT_FACILITATOR_SIGNING_PRIVATE_KEY: &str =
     "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgeSa+S+tmLupnAEyFK\
     dVuKB99y09YEqW41+8pwP4cTkahRANCAASy7FHcLGnRudVHWga/j2k9nQ3lMvuGE01\
     Q7DEyjyCuuw9YmB3dHvYcRUnxVRI/nF5LvneGim0dC7F1fuRAPeXI";
+pub const DEFAULT_FACILITATOR_SUBJECT_PUBLIC_KEY_INFO: &str =
+    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsuxR3Cxp0bnVR1oGv49pPZ0N5TL7\
+    hhNNUOwxMo8grrsPWJgd3R72HEVJ8VUSP5xeS753hoptHQuxdX7kQD3lyA==";
 pub const DEFAULT_PHA_SIGNING_PRIVATE_KEY: &str =
     "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg1BQjH71U37XLfWqe+\
     /xP8iUrMiHpmUtbj3UfDkhFIrShRANCAAQgqHcxxwTVx1IXimcRv5TQyYZh+ShDM6X\
     ZqJonoP1m52oN0aLID1hJSrfKJrnqdgmHmaT4eXNNf4C5+g1HZt+u";
+pub const DEFAULT_PHA_SUBJECT_PUBLIC_KEY_INFO: &str =
+    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIKh3MccE1cdSF4pnEb+U0MmGYfko\
+    QzOl2aiaJ6D9ZudqDdGiyA9YSUq3yia56nYJh5mk+HlzTX+AufoNR2bfrg==";
 
 /// Constructs an EcdsaKeyPair from the default ingestor server.
 pub fn default_ingestor_private_key() -> EcdsaKeyPair {

--- a/facilitator/src/transport.rs
+++ b/facilitator/src/transport.rs
@@ -2,12 +2,14 @@ use crate::Error;
 use anyhow::{Context, Result};
 use derivative::Derivative;
 use hyper_rustls::HttpsConnector;
-use rusoto_core::credential::DefaultCredentialsProvider;
+use reqwest::blocking::Client;
+use rusoto_core::credential::{DefaultCredentialsProvider, Variable};
 use rusoto_core::{ByteStream, Region};
 use rusoto_s3::{
     AbortMultipartUploadRequest, CompleteMultipartUploadRequest, CompletedMultipartUpload,
     CompletedPart, CreateMultipartUploadRequest, GetObjectRequest, S3Client, UploadPartRequest, S3,
 };
+use rusoto_sts::WebIdentityProvider;
 use std::boxed::Box;
 use std::fs::{create_dir_all, File};
 use std::io::{Read, Write};
@@ -19,6 +21,14 @@ use tokio::{
     io::{AsyncRead, AsyncReadExt},
     runtime::{Builder, Runtime},
 };
+
+// We use workload identity to map GCP service accounts to Kubernetes service
+// accounts and make an auth token for the GCP account available to containers
+// in the GKE metadata service. Sadly we can't use the Kubernetes feature to
+// automount a service account token, because that would provide the token for
+// the *Kubernetes* service account, not the GCP one.
+// See terraform/modules/gke/gke.tf and terraform/modules/kuberenetes/kubernetes.tf
+const METADATA_SERVICE_TOKEN_URL: &str = "http://metadata.google.internal:80/computeMetadata/v1/instance/service-accounts/default/identity";
 
 /// A TransportWriter extends std::io::Write but adds methods that explicitly
 /// allow callers to complete or cancel an upload.
@@ -116,51 +126,102 @@ fn basic_runtime() -> Result<Runtime> {
 pub struct S3Transport {
     region: Region,
     bucket: String,
+    use_ambient_credentials: bool,
     // client_provider allows injection of mock S3Client for testing purposes
-    client_provider: fn(&Region) -> S3Client,
+    client_provider: fn(&Region, bool) -> Result<S3Client>,
 }
 
 impl S3Transport {
-    pub fn new(region: Region, bucket: String) -> S3Transport {
-        S3Transport::new_with_client(region, bucket, |region| {
-            // Rusoto uses Hyper which uses connection pools. The default
-            // timeout for those connections is 90 seconds[1]. Amazon S3's API
-            // closes idle client connections after 20 seconds[2]. If we use a
-            // default client via S3Client::new, this mismatch causes uploads to
-            // fail when Hyper tries to re-use a connection that has been idle
-            // too long. Until this is fixed in Rusoto[3], we construct our own
-            // HTTP client dispatcher whose underlying hyper::Client is
-            // configured to timeout idle connections after 10 seconds. We could
-            // also implement retries on our layer[4].
-            //
-            // [1]: https://docs.rs/hyper/0.13.8/hyper/client/struct.Builder.html#method.pool_idle_timeout
-            // [2]: https://aws.amazon.com/premiumsupport/knowledge-center/s3-socket-connection-timeout-error/
-            // [3]: https://github.com/rusoto/rusoto/issues/1686
-            // [4]: https://github.com/abetterinternet/prio-server/issues/41
-            //
-            // Credentials for authenticating to AWS are automatically sourced
-            // from environment variables or ~/.aws/credentials.
-            // https://github.com/rusoto/rusoto/blob/master/AWS-CREDENTIALS.md
-            let credentials_provider =
-                DefaultCredentialsProvider::new().expect("failed to create credentials provider");
+    pub fn new(region: Region, use_ambient_credentials: bool, bucket: String) -> S3Transport {
+        S3Transport::new_with_client(
+            region,
+            bucket,
+            use_ambient_credentials,
+            |region, use_ambient_credentials| {
+                // Rusoto uses Hyper which uses connection pools. The default
+                // timeout for those connections is 90 seconds[1]. Amazon S3's
+                // API closes idle client connections after 20 seconds[2]. If we
+                // use a default client via S3Client::new, this mismatch causes
+                // uploads to fail when Hyper tries to re-use a connection that
+                // has been idle too long. Until this is fixed in Rusoto[3], we
+                // construct our own HTTP request dispatcher whose underlying
+                // hyper::Client is configured to timeout idle connections after
+                // 10 seconds. We could also implement retries on our layer[4].
+                //
+                // [1]: https://docs.rs/hyper/0.13.8/hyper/client/struct.Builder.html#method.pool_idle_timeout
+                // [2]: https://aws.amazon.com/premiumsupport/knowledge-center/s3-socket-connection-timeout-error/
+                // [3]: https://github.com/rusoto/rusoto/issues/1686
+                // [4]: https://github.com/abetterinternet/prio-server/issues/41
+                let mut builder = hyper::Client::builder();
+                builder.pool_idle_timeout(Duration::from_secs(10));
+                let connector = HttpsConnector::new();
+                let http_client = rusoto_core::HttpClient::from_builder(builder, connector);
 
-            let mut builder = hyper::Client::builder();
-            builder.pool_idle_timeout(Duration::from_secs(10));
-            let connector = HttpsConnector::new();
-            let http_client = rusoto_core::HttpClient::from_builder(builder, connector);
+                if use_ambient_credentials {
+                    // Credentials for authenticating to AWS are automatically
+                    // sourced from environment variables or ~/.aws/credentials.
+                    // https://github.com/rusoto/rusoto/blob/master/AWS-CREDENTIALS.md
+                    let credentials_provider = DefaultCredentialsProvider::new()
+                        .context("failed to create credentials provider")?;
+                    Ok(S3Client::new_with(
+                        http_client,
+                        credentials_provider,
+                        region.clone(),
+                    ))
+                } else {
+                    // When running in GKE, the token used to authenticate to
+                    // AWS S3 is made available via the instance metadata
+                    // service. See terraform/modules/kubernetes/kubernetes.tf
+                    // for discussion.
+                    let token = Client::new()
+                        .get(METADATA_SERVICE_TOKEN_URL)
+                        // The audience query parameter is required by the GKE
+                        // metadata service, but since our role assumption
+                        // policy doesn't check `aud`, it doesn't matter what
+                        // audience we put here (see
+                        // terraform/modules/facilitator/facilitator.tf).
+                        .query(&[("audience", "something")])
+                        .header("Metadata-Flavor", "Google")
+                        .send()
+                        .context("failed to fetch auth token from metadata service")?
+                        .text()
+                        .context("failed to unwrap metadata token")?;
 
-            S3Client::new_with(http_client, credentials_provider, region.clone())
-        })
+                    let credentials_provider = WebIdentityProvider::new(
+                        Variable::with_value(token),
+                        // The AWS role that we are assuming is provided via
+                        // environment variable. See
+                        // terraform/modules/kubernetes/kubernetes.tf
+                        Variable::from_env_var("AWS_ROLE_ARN"),
+                        // The role ARN we assume is already bound to a
+                        // specific facilitator instance, so we don't get much
+                        // from further scoping the role assumption, unless we
+                        // eventually introduce something like a job ID that
+                        // could then show up in AWS-side logs.
+                        // https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-role_session_name.html
+                        Some(Variable::from_env_var_optional("AWS_ROLE_SESSION_NAME")),
+                    );
+
+                    Ok(S3Client::new_with(
+                        http_client,
+                        credentials_provider,
+                        region.clone(),
+                    ))
+                }
+            },
+        )
     }
 
     fn new_with_client(
         region: Region,
         bucket: String,
-        client_provider: fn(&Region) -> S3Client,
+        use_ambient_credentials: bool,
+        client_provider: fn(&Region, bool) -> Result<S3Client>,
     ) -> S3Transport {
         S3Transport {
             region,
             bucket,
+            use_ambient_credentials,
             client_provider,
         }
     }
@@ -169,7 +230,7 @@ impl S3Transport {
 impl Transport for S3Transport {
     fn get(&self, key: &str) -> Result<Box<dyn Read>> {
         let mut runtime = basic_runtime()?;
-        let client = (self.client_provider)(&self.region);
+        let client = (self.client_provider)(&self.region, self.use_ambient_credentials)?;
         let get_output = runtime
             .block_on(client.get_object(GetObjectRequest {
                 bucket: self.bucket.to_owned(),
@@ -187,6 +248,7 @@ impl Transport for S3Transport {
         Ok(Box::new(MultipartUploadWriter::new(
             self.region.clone(),
             self.bucket.to_owned(),
+            self.use_ambient_credentials,
             key.to_string(),
             // Set buffer size to 5 MB, which is the minimum required by Amazon
             // https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
@@ -250,12 +312,13 @@ impl MultipartUploadWriter {
     fn new(
         region: Region,
         bucket: String,
+        use_ambient_credentials: bool,
         key: String,
         minimum_upload_part_size: usize,
-        client_provider: fn(&Region) -> S3Client,
+        client_provider: fn(&Region, bool) -> Result<S3Client>,
     ) -> Result<MultipartUploadWriter> {
         let mut runtime = basic_runtime()?;
-        let client = client_provider(&region);
+        let client = client_provider(&region, use_ambient_credentials)?;
 
         let create_output = runtime
             .block_on(
@@ -546,15 +609,16 @@ mod tests {
         let err = MultipartUploadWriter::new(
             Region::UsWest2,
             String::from(TEST_BUCKET),
+            false,
             String::from(TEST_KEY),
             50,
-            |region| {
-                S3Client::new_with(
+            |region, _| {
+                Ok(S3Client::new_with(
                     MockRequestDispatcher::with_status(401)
                         .with_request_checker(is_create_multipart_upload_request),
                     MockCredentialsProvider,
                     region.clone(),
-                )
+                ))
             },
         )
         .expect_err("expected error");
@@ -572,10 +636,11 @@ mod tests {
         MultipartUploadWriter::new(
             Region::UsWest2,
             String::from(TEST_BUCKET),
+            false,
             String::from(TEST_KEY),
             50,
-            |region| {
-                S3Client::new_with(
+            |region, _| {
+                Ok(S3Client::new_with(
                     MockRequestDispatcher::with_status(200)
                         .with_body(
                             r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -587,7 +652,7 @@ mod tests {
                         .with_request_checker(is_create_multipart_upload_request),
                     MockCredentialsProvider,
                     region.clone(),
-                )
+                ))
             },
         )
         .expect_err("expected error");
@@ -600,9 +665,10 @@ mod tests {
         let mut writer = MultipartUploadWriter::new(
             Region::UsWest2,
             String::from(TEST_BUCKET),
+            false,
             String::from(TEST_KEY),
             50,
-            |region| {
+            |region, _| {
                 let requests = vec![
                     // Response to CreateMultipartUpload
                     MockRequestDispatcher::with_status(200)
@@ -666,11 +732,11 @@ mod tests {
                     MockRequestDispatcher::with_status(400)
                         .with_request_checker(is_complete_multipart_upload_request),
                 ];
-                S3Client::new_with(
+                Ok(S3Client::new_with(
                     MultipleMockRequestDispatcher::new(requests),
                     MockCredentialsProvider,
                     region.clone(),
-                )
+                ))
             },
         )
         .expect("failed to create multipart upload writer");
@@ -695,31 +761,39 @@ mod tests {
 
     #[test]
     fn roundtrip_s3_transport() {
-        let transport =
-            S3Transport::new_with_client(Region::UsWest2, TEST_BUCKET.to_string(), |region| {
-                S3Client::new_with(
+        let transport = S3Transport::new_with_client(
+            Region::UsWest2,
+            TEST_BUCKET.to_string(),
+            false,
+            |region, _| {
+                Ok(S3Client::new_with(
                     // Failed GetObject request
                     MockRequestDispatcher::with_status(404)
                         .with_request_checker(is_get_object_request),
                     MockCredentialsProvider,
                     region.clone(),
-                )
-            });
+                ))
+            },
+        );
 
         let ret = transport.get(TEST_KEY);
         assert!(ret.is_err(), "unexpected return value {:?}", ret.err());
 
-        let transport =
-            S3Transport::new_with_client(Region::UsWest2, TEST_BUCKET.to_string(), |region| {
-                S3Client::new_with(
+        let transport = S3Transport::new_with_client(
+            Region::UsWest2,
+            TEST_BUCKET.to_string(),
+            false,
+            |region, _| {
+                Ok(S3Client::new_with(
                     // Successful GetObject request
                     MockRequestDispatcher::with_status(200)
                         .with_request_checker(is_get_object_request)
                         .with_body("fake-content"),
                     MockCredentialsProvider,
                     region.clone(),
-                )
-            });
+                ))
+            },
+        );
 
         let mut reader = transport
             .get(TEST_KEY)
@@ -728,8 +802,11 @@ mod tests {
         reader.read_to_end(&mut content).expect("failed to read");
         assert_eq!(Vec::from("fake-content"), content);
 
-        let mut transport =
-            S3Transport::new_with_client(Region::UsWest2, TEST_BUCKET.to_string(), |region| {
+        let mut transport = S3Transport::new_with_client(
+            Region::UsWest2,
+            TEST_BUCKET.to_string(),
+            false,
+            |region, _| {
                 let requests = vec![
                     // Response to CreateMultipartUpload
                     MockRequestDispatcher::with_status(200)
@@ -763,12 +840,13 @@ mod tests {
                     MockRequestDispatcher::with_status(204)
                         .with_request_checker(is_abort_multipart_upload_request),
                 ];
-                S3Client::new_with(
+                Ok(S3Client::new_with(
                     MultipleMockRequestDispatcher::new(requests),
                     MockCredentialsProvider,
                     region.clone(),
-                )
-            });
+                ))
+            },
+        );
 
         let mut writer = transport.put(TEST_KEY).unwrap();
         writer.write_all(b"fake-content").unwrap();

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -32,7 +32,7 @@ prep: ## Prepare a new workspace (environment) if needed, configure the tfstate 
 		exit 1; \
 	 fi
 	@echo "$(BOLD)Verifying that the storage bucket $(STORAGE_BUCKET_URL) for remote state exists$(RESET)"
-	@if ! gsutil ls -b  $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; then \
+	@if ! gsutil ls -b $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; then \
 		echo "$(BOLD)Storage bucket $(STORAGE_BUCKET_URL) was not found, creating new bucket with versioning enabled to store tfstate$(RESET)"; \
 		gsutil mb -l $(REGION) $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; \
 		gsutil versioning set on $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; \

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -88,6 +88,7 @@ apply: prep ## Have terraform do the things. This will cost money.
 		-input=false \
 		-refresh=true \
 		-var-file="$(VARS)"
+	@terraform output --json | go run ../deploy-tool/main.go
 
 .PHONY: apply-target
 apply-target: prep ## Have terraform do the things for a specific resource. This will cost money.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,6 @@
 # Prio server Terraform module
 
-This Terraform module manages a [GKE cluster](https://cloud.google.com/kubernetes-engine/docs) which hosts a Prio data share processor. We create one cluster and one node pool in each region in which we operate, and then run each PHA's facilitator instance in its own Kubernetes namespace. Each facilitator consists of a [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) that runs an execution manager.
+This Terraform module manages a [GKE cluster](https://cloud.google.com/kubernetes-engine/docs) which hosts a Prio data share processor. We create one cluster and one node pool in each region in which we operate, and then run each PHA's facilitator instance in its own Kubernetes namespace. Each facilitator consists of a [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) that runs a workflow manager.
 
 You will need these tools:
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,6 @@
 # Prio server Terraform module
 
-This Terraform module manages a [GKE cluster](https://cloud.google.com/kubernetes-engine/docs) which hosts a Prio data share processor. We create one cluster and one node pool in each region in which we operate, and then run each PHA's facilitator instance in its own Kubernetes namespace. Each facilitator consists of a [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) that runs a workflow manager.
+This Terraform module manages a [GKE cluster](https://cloud.google.com/kubernetes-engine/docs) which hosts a Prio data share processor. We create one cluster and one node pool in each region in which we operate, and then run each PHA's data share processor instance in its own Kubernetes namespace. Each data share processor consists of a [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) that runs a workflow manager.
 
 You will need these tools:
 
@@ -22,7 +22,7 @@ If you're having problems, check `gcloud config list` and `kubectl config curren
 
 ## New clusters
 
-To add a facilitator to support a new PHA in an existing region, add their PHA name to the `peer_share_processor_names` variable in the relevant `variables/<environment>.tfvars` file. To bring up a whole new cluster, drop a `your-new-environment.tfvars` file in `variables`, fill in the required variables and use `ENV=your-new-environment make apply` to deploy it. Multiple environments may be deployed to the same GCP region.
+To add a data share processor to support a new PHA in an existing region, add their PHA name to the `peer_share_processor_names` variable in the relevant `variables/<environment>.tfvars` file. To bring up a whole new cluster, drop a `your-new-environment.tfvars` file in `variables`, fill in the required variables and use `ENV=your-new-environment make apply` to deploy it. Multiple environments may be deployed to the same GCP region.
 
 ## kubectl configuration
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -86,9 +86,9 @@ module "gke" {
   machine_type    = var.machine_type
 }
 
-module "facilitator" {
+module "data_share_processors" {
   for_each                  = toset(var.peer_share_processor_names)
-  source                    = "./modules/facilitator"
+  source                    = "./modules/data_share_processor"
   environment               = var.environment
   peer_share_processor_name = each.key
   gcp_project               = var.gcp_project

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,6 +28,11 @@ variable "peer_share_processor_names" {
   type = list(string)
 }
 
+variable "ingestors" {
+  type        = map(string)
+  description = "Map of ingestor names to the URL where their global manifest may be found."
+}
+
 variable "manifest_domain" {
   type        = string
   description = "Domain (plus optional relative path) to which this environment's global and specific manifests should be uploaded."
@@ -94,12 +99,42 @@ module "gke" {
   machine_type    = var.machine_type
 }
 
+# For each peer data share processor, we will receive ingestion batches from two
+# ingestion servers. We create a distinct data share processor instance for each
+# (peer, ingestor) pair.
+# First, we fetch the ingestor global manifests, which yields a map of ingestor
+# name => HTTP content.
+data "http" "ingestor_global_manifests" {
+  for_each = var.ingestors
+  url      = "https://${each.value}/global-manifest.json"
+}
+
+# Then we fetch the single global manifest for all the peer share processors.
+data "http" "peer_share_processor_global_manifest" {
+  url = "https://${var.peer_share_processor_manifest_domain}/global-manifest.json"
+}
+
+# Now, we take the set product of peer share processor names x ingestor names to
+# get the config values for all the data share processors we need to create.
+locals {
+  peer_ingestor_pairs = {
+    for pair in setproduct(toset(var.peer_share_processor_names), keys(var.ingestors)) :
+    "${pair[0]}-${pair[1]}" => {
+      ingestor_aws_role_arn           = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body), "aws-iam-entity", "")
+      ingestor_gcp_service_account_id = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body), "google-service-account", "")
+    }
+  }
+}
+
 module "data_share_processors" {
-  for_each                  = toset(var.peer_share_processor_names)
-  source                    = "./modules/data_share_processor"
-  environment               = var.environment
-  peer_share_processor_name = each.key
-  gcp_project               = var.gcp_project
+  for_each                            = local.peer_ingestor_pairs
+  source                              = "./modules/data_share_processor"
+  environment                         = var.environment
+  data_share_processor_name           = each.key
+  gcp_project                         = var.gcp_project
+  ingestor_aws_role_arn               = each.value.ingestor_aws_role_arn
+  ingestor_google_service_account_id  = each.value.ingestor_gcp_service_account_id
+  peer_share_processor_aws_account_id = jsondecode(data.http.peer_share_processor_global_manifest.body).aws-account-id
 
   depends_on = [module.gke]
 }
@@ -110,4 +145,8 @@ output "manifest_bucket" {
 
 output "gke_kubeconfig" {
   value = "Run this command to update your kubectl config: gcloud container clusters get-credentials ${module.gke.cluster_name} --region ${var.gcp_region}"
+}
+
+output "specific_manifests" {
+  value = { for v in module.data_share_processor : v.data_share_processor_name => v.specific_manifest }
 }

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -11,14 +11,14 @@ variable "gcp_project" {
 }
 
 # This is the role in AWS we use to construct policy on the S3 buckets. It is
-# configured to allow access to the GCP service account for this facilitator via
-# Web Identity Federation
+# configured to allow access to the GCP service account for this data share
+# processor via Web Identity Federation
 # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
 resource "aws_iam_role" "bucket_role" {
   name = "prio-${var.environment}-${var.peer_share_processor_name}-bucket-role"
-  # We currently use a single role per facilitator to gate read/write access to
-  # all buckets. We could use audiences to define more roles for read/write on
-  # each of the ingestion, validation and sum part buckets.
+  # We currently use a single role per data share processor to gate read/write
+  # access to all buckets. We could use audiences to define more roles for
+  # read/write on each of the ingestion, validation and sum part buckets.
   # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html
   assume_role_policy = <<ROLE
 {

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -1,4 +1,4 @@
-variable "peer_share_processor_name" {
+variable "data_share_processor_name" {
   type = string
 }
 
@@ -10,12 +10,32 @@ variable "gcp_project" {
   type = string
 }
 
+variable "ingestor_aws_role_arn" {
+  type = string
+}
+
+variable "ingestor_google_service_account_id" {
+  type = string
+}
+
+variable "peer_share_processor_aws_account_id" {
+  type = string
+}
+
+locals {
+  resource_prefix                  = "${var.environment}-${var.data_share_processor_name}"
+  ingestion_bucket_writer_role_arn = var.ingestor_google_service_account_id != "" ? aws_iam_role.ingestor_bucket_writer_role[0].arn : var.ingestor_aws_role_arn
+  ingestion_bucket_name            = "prio-${local.resource_prefix}-ingestion"
+  validation_bucket_name           = "prio-${local.resource_prefix}-validation"
+  sum_part_bucket_name             = "prio-${local.resource_prefix}-sum-part"
+}
+
 # This is the role in AWS we use to construct policy on the S3 buckets. It is
 # configured to allow access to the GCP service account for this data share
 # processor via Web Identity Federation
 # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
-resource "aws_iam_role" "bucket_role" {
-  name = "prio-${var.environment}-${var.peer_share_processor_name}-bucket-role"
+resource "aws_iam_role" "bucket_owner_role" {
+  name = "prio-${local.resource_prefix}-bucket-role"
   # We currently use a single role per data share processor to gate read/write
   # access to all buckets. We could use audiences to define more roles for
   # read/write on each of the ingestion, validation and sum part buckets.
@@ -39,37 +59,133 @@ resource "aws_iam_role" "bucket_role" {
   ]
 }
 ROLE
-
   tags = {
     environment = "prio-${var.environment}"
   }
 }
 
-locals {
-  ingestion_bucket_name  = "prio-${var.environment}-${var.peer_share_processor_name}-ingestion"
-  validation_bucket_name = "prio-${var.environment}-${var.peer_share_processor_name}-validation"
-  sum_part_bucket_name   = "prio-${var.environment}-${var.peer_share_processor_name}-sum-part"
-}
-
-resource "aws_s3_bucket" "buckets" {
-  for_each = toset([
-    local.ingestion_bucket_name, local.validation_bucket_name, local.sum_part_bucket_name
-  ])
-  bucket = each.key
-  policy = <<POLICY
+# If the ingestor authenticates using a GCP service account, this is the role in
+# AWS that their service account assumes. Note the "count" parameter in the
+# block, which seems to be the Terraform convention to conditionally create
+# resources (c.f. lots of StackOverflow questions and GitHub issues).
+resource "aws_iam_role" "ingestor_bucket_writer_role" {
+  count              = var.ingestor_google_service_account_id != "" ? 1 : 0
+  name               = "prio-${local.resource_prefix}-bucket-writer"
+  assume_role_policy = <<ROLE
 {
   "Version": "2012-10-17",
   "Statement": [
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "${aws_iam_role.bucket_role.arn}"
+        "Federated": "accounts.google.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "accounts.google.com:sub": "${var.ingestor_google_service_account_id}"
+        }
+      }
+    }
+  ]
+}
+ROLE
+  tags = {
+    environment = "prio-${var.environment}"
+  }
+}
+
+# The ingestion bucket for this data share processor. This one is different from
+# the other two in that we must grant write access to the ingestor but no access
+# to the peer share processor.
+resource "aws_s3_bucket" "ingestion_bucket" {
+  bucket = local.ingestion_bucket_name
+  # Force deletion of bucket contents on bucket destroy.
+  force_destroy = true
+  policy        = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${local.ingestion_bucket_writer_role_arn}"
       },
       "Action": [
         "s3:AbortMultipartUpload",
         "s3:PutObject",
         "s3:ListMultipartUploadParts",
-        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketMultipartUploads"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${local.ingestion_bucket_name}/*",
+        "arn:aws:s3:::${local.ingestion_bucket_name}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_role.bucket_owner_role.arn}"
+      },
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${local.ingestion_bucket_name}/*",
+        "arn:aws:s3:::${local.ingestion_bucket_name}"
+      ]
+    }
+  ]
+}
+POLICY
+  tags = {
+    environment = var.environment
+  }
+}
+
+# The validation and sum part buckets for this data share processor, configured
+# to permit the peer share processor to read it. The policy grants read
+# permissions to any role or user in the peer data share processor's AWS account
+# because Amazon S3 won't let you define policies in terms of roles that don't
+# exist. In any case, since we have no control over or insight into role
+# assumption policies in the other account, we gain nothing by specifying
+# anything beyond the AWS account.
+resource "aws_s3_bucket" "other_buckets" {
+  for_each = toset([
+    local.validation_bucket_name, local.sum_part_bucket_name
+  ])
+  bucket = each.key
+  # Force deletion of bucket contents on bucket destroy.
+  force_destroy = true
+  policy        = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_role.bucket_owner_role.arn}"
+      },
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:PutObject",
+        "s3:ListMultipartUploadParts",
+        "s3:ListBucketMultipartUploads"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${each.key}/*",
+        "arn:aws:s3:::${each.key}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "${aws_iam_role.bucket_owner_role.arn}",
+          "${var.peer_share_processor_aws_account_id}"
+        ]
+      },
+      "Action": [
         "s3:GetObject"
       ],
       "Resource": [
@@ -87,9 +203,31 @@ POLICY
 
 module "kubernetes" {
   source                    = "../../modules/kubernetes/"
-  peer_share_processor_name = var.peer_share_processor_name
+  data_share_processor_name = var.data_share_processor_name
   gcp_project               = var.gcp_project
   environment               = var.environment
-  ingestion_bucket          = "${aws_s3_bucket.buckets[local.ingestion_bucket_name].region}/${aws_s3_bucket.buckets[local.ingestion_bucket_name].bucket}"
-  ingestion_bucket_role     = aws_iam_role.bucket_role.arn
+  ingestion_bucket          = "${aws_s3_bucket.ingestion_bucket.region}/${aws_s3_bucket.ingestion_bucket.bucket}"
+  ingestion_bucket_role     = aws_iam_role.bucket_owner_role.arn
+}
+
+output "data_share_processor_name" {
+  value = var.data_share_processor_name
+}
+
+output "specific_manifest" {
+  value = {
+    format            = 0
+    ingestion-bucket  = "${aws_s3_bucket.ingestion_bucket.region}/${aws_s3_bucket.ingestion_bucket.bucket}",
+    validation-bucket = "${aws_s3_bucket.other_buckets[local.validation_bucket_name].region}/${aws_s3_bucket.other_buckets[local.validation_bucket_name].bucket}",
+    sum-part-bucket   = "${aws_s3_bucket.other_buckets[local.sum_part_bucket_name].region}/${aws_s3_bucket.other_buckets[local.sum_part_bucket_name].bucket}",
+    batch-signing-keys = {
+      (module.kubernetes.batch_signing_key) = {
+        public-key = ""
+        expiration = ""
+      }
+    }
+    packet-encryption-certificates = {
+      (module.kubernetes.ingestion_packet_decryption_key) = ""
+    }
+  }
 }

--- a/terraform/modules/facilitator/facilitator.tf
+++ b/terraform/modules/facilitator/facilitator.tf
@@ -1,0 +1,95 @@
+variable "peer_share_processor_name" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "gcp_project" {
+  type = string
+}
+
+# This is the role in AWS we use to construct policy on the S3 buckets. It is
+# configured to allow access to the GCP service account for this facilitator via
+# Web Identity Federation
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
+resource "aws_iam_role" "bucket_role" {
+  name = "prio-${var.environment}-${var.peer_share_processor_name}-bucket-role"
+  # We currently use a single role per facilitator to gate read/write access to
+  # all buckets. We could use audiences to define more roles for read/write on
+  # each of the ingestion, validation and sum part buckets.
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html
+  assume_role_policy = <<ROLE
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "accounts.google.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "accounts.google.com:sub": "${module.kubernetes.service_account_unique_id}"
+        }
+      }
+    }
+  ]
+}
+ROLE
+
+  tags = {
+    environment = "prio-${var.environment}"
+  }
+}
+
+locals {
+  ingestion_bucket_name  = "prio-${var.environment}-${var.peer_share_processor_name}-ingestion"
+  validation_bucket_name = "prio-${var.environment}-${var.peer_share_processor_name}-validation"
+  sum_part_bucket_name   = "prio-${var.environment}-${var.peer_share_processor_name}-sum-part"
+}
+
+resource "aws_s3_bucket" "buckets" {
+  for_each = toset([
+    local.ingestion_bucket_name, local.validation_bucket_name, local.sum_part_bucket_name
+  ])
+  bucket = each.key
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_role.bucket_role.arn}"
+      },
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:PutObject",
+        "s3:ListMultipartUploadParts",
+        "s3:ListBucketMultipartUploads",
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${each.key}/*",
+        "arn:aws:s3:::${each.key}"
+      ]
+    }
+  ]
+}
+POLICY
+  tags = {
+    environment = var.environment
+  }
+}
+
+module "kubernetes" {
+  source                    = "../../modules/kubernetes/"
+  peer_share_processor_name = var.peer_share_processor_name
+  gcp_project               = var.gcp_project
+  environment               = var.environment
+  ingestion_bucket          = "${aws_s3_bucket.buckets[local.ingestion_bucket_name].region}/${aws_s3_bucket.buckets[local.ingestion_bucket_name].bucket}"
+  ingestion_bucket_role     = aws_iam_role.bucket_role.arn
+}

--- a/terraform/modules/gke/gke.tf
+++ b/terraform/modules/gke/gke.tf
@@ -10,6 +10,10 @@ variable "gcp_region" {
   type = string
 }
 
+variable "gcp_project" {
+  type = string
+}
+
 variable "machine_type" {
   type = string
 }
@@ -38,6 +42,12 @@ resource "google_container_cluster" "cluster" {
     cluster_ipv4_cidr_block  = ""
     services_ipv4_cidr_block = ""
   }
+  # Enables workload identity, which enables containers to authenticate as GCP
+  # service accounts which may then be used to authenticate to AWS S3.
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+  workload_identity_config {
+    identity_namespace = "${var.gcp_project}.svc.id.goog"
+  }
 }
 
 resource "google_container_node_pool" "worker_nodes" {
@@ -59,6 +69,11 @@ resource "google_container_node_pool" "worker_nodes" {
       "logging-write",
       "monitoring"
     ]
+    # Configures nodes to obtain workload identity from GKE metadata service
+    # https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
   }
 }
 

--- a/terraform/modules/gke/gke.tf
+++ b/terraform/modules/gke/gke.tf
@@ -48,6 +48,14 @@ resource "google_container_cluster" "cluster" {
   workload_identity_config {
     identity_namespace = "${var.gcp_project}.svc.id.goog"
   }
+  # This enables KMS encryption of the constents of the Kubernetes cluster etcd
+  # instance which among other things, stores Kubernetes secrets, like the keys
+  # used by data share processors to sign batches or decrypt ingestion shares.
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets
+  database_encryption {
+    state    = "ENCRYPTED"
+    key_name = google_kms_crypto_key.etcd_encryption_key.id
+  }
 }
 
 resource "google_container_node_pool" "worker_nodes" {
@@ -75,6 +83,45 @@ resource "google_container_node_pool" "worker_nodes" {
       node_metadata = "GKE_METADATA_SERVER"
     }
   }
+}
+
+# KMS keyring to store etcd encryption key
+resource "google_kms_key_ring" "keyring" {
+  provider = google-beta
+  name     = "${var.resource_prefix}-kms-keyring"
+  # Keyrings can also be zonal, but ours must be regional to match the GKE
+  # cluster.
+  location = var.gcp_region
+}
+
+# KMS key used by GKE cluster to encrypt contents of cluster etcd, crucially to
+# protect Kubernetes secrets.
+resource "google_kms_crypto_key" "etcd_encryption_key" {
+  provider = google-beta
+  name     = "${var.resource_prefix}-etcd-encryption-key"
+  key_ring = google_kms_key_ring.keyring.id
+  purpose  = "ENCRYPT_DECRYPT"
+  # Rotate database encryption key every 90 days. This doesn't reencrypt
+  # existing secrets unless we go touch them.
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets#key_rotation
+  rotation_period = "7776000s"
+}
+
+# We need the project _number_ to construct the GKE service account, below.
+data "google_project" "project" {
+  provider = google-beta
+}
+
+# Permit the GKE service account to use the KMS key. We construct the service
+# account name per the specification in:
+# https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets#grant_permission_to_use_the_key
+resource "google_kms_crypto_key_iam_binding" "etcd-encryption-key-iam-binding" {
+  provider      = google-beta
+  crypto_key_id = google_kms_crypto_key.etcd_encryption_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  members = [
+    "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
+  ]
 }
 
 output "cluster_name" {

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -12,7 +12,9 @@ variable "container_registry" {
 }
 
 variable "workflow_manager_image" {
-  type    = string
+  type = string
+  # This should be "prio-data-share-processor" but we have not yet renamed the
+  # container image
   default = "prio-facilitator"
 }
 
@@ -33,7 +35,7 @@ variable "ingestion_bucket_role" {
   type = string
 }
 
-# Each facilitator is created in its own namespace
+# Each data share processor is created in its own namespace
 resource "kubernetes_namespace" "namespace" {
   metadata {
     name = var.peer_share_processor_name
@@ -53,7 +55,7 @@ resource "kubernetes_namespace" "namespace" {
 # [1] https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
 # [2] https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection
 
-# For each facilitator, we first create a GCP service account.
+# For each data share processor, we first create a GCP service account.
 resource "google_service_account" "workflow_manager" {
   provider = google-beta
   # The Account ID must be unique across the whole GCP project, and not just the

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -21,6 +21,19 @@ variable "execution_manager_version" {
   default = "0.1.0"
 }
 
+variable "gcp_project" {
+  type = string
+}
+
+variable "ingestion_bucket" {
+  type = string
+}
+
+variable "ingestion_bucket_role" {
+  type = string
+}
+
+# Each facilitator is created in its own namespace
 resource "kubernetes_namespace" "namespace" {
   metadata {
     name = var.peer_share_processor_name
@@ -28,6 +41,78 @@ resource "kubernetes_namespace" "namespace" {
       environment = var.environment
     }
   }
+}
+
+# Workload identity[1] lets us map GCP service accounts to Kubernetes service
+# accounts. We need this so that pods can use GCP API, but also AWS APIs like S3
+# via Web Identity Federation. To use the credentials, the container must fetch
+# the authentication token from the instance metadata service. Kubernetes has
+# features for automatically providing a service account token (e.g. via a
+# a mounted volume[2]), but that would be a token for the *Kubernetes* level
+# service account, and not the one we can present to AWS.
+# [1] https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
+# [2] https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection
+
+# For each facilitator, we first create a GCP service account.
+resource "google_service_account" "execution_manager" {
+  provider = google-beta
+  # The Account ID must be unique across the whole GCP project, and not just the
+  # namespace. It must also be less than 30 characters, so we can't concatenate
+  # environment and PHA name to get something unique. Instead, we generate a
+  # random string.
+  account_id   = "prio-${random_string.account_id.result}"
+  display_name = "prio-${var.environment}-${var.peer_share_processor_name}-execution-manager"
+}
+
+resource "random_string" "account_id" {
+  length  = 16
+  upper   = false
+  number  = false
+  special = false
+}
+
+# This is the Kubernetes-level service account which we associate with the GCP
+# service account above.
+resource "kubernetes_service_account" "execution_manager" {
+  metadata {
+    name      = "${var.peer_share_processor_name}-execution-manager"
+    namespace = var.peer_share_processor_name
+    annotations = {
+      environment = var.environment
+      # This annotation is necessary for the Kubernetes-GCP service account
+      # mapping. See step 6 in
+      # https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to
+      "iam.gke.io/gcp-service-account" = google_service_account.execution_manager.email
+    }
+  }
+}
+
+# This carefully constructed string lets us refer to the Kubernetes service
+# account in GCP-level policies, below. See step 5 in
+# https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to
+locals {
+  service_account = "serviceAccount:${var.gcp_project}.svc.id.goog[${kubernetes_namespace.namespace.metadata[0].name}/${kubernetes_service_account.execution_manager.metadata[0].name}]"
+}
+
+# Allows the Kubernetes service account to impersonate the GCP service account.
+resource "google_service_account_iam_binding" "execution-manager-workload" {
+  provider           = google-beta
+  service_account_id = google_service_account.execution_manager.name
+  role               = "roles/iam.workloadIdentityUser"
+  members = [
+    local.service_account
+  ]
+}
+
+# Allows the Kubernetes service account to request auth tokens for the GCP
+# service account.
+resource "google_service_account_iam_binding" "execution-manager-token" {
+  provider           = google-beta
+  service_account_id = google_service_account.execution_manager.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  members = [
+    local.service_account
+  ]
 }
 
 resource "kubernetes_cron_job" "execution_manager" {
@@ -40,25 +125,48 @@ resource "kubernetes_cron_job" "execution_manager" {
     }
   }
   spec {
-    schedule = "*/10 * * * *"
+    schedule                  = "*/10 * * * *"
+    failed_jobs_history_limit = 3
     job_template {
       metadata {}
       spec {
         template {
           metadata {}
           spec {
-            # Credentials are needed to pull images from Google Container Registry
-            automount_service_account_token = true
             container {
-              # For now just have the facilitator print its help text
               name  = "facilitator"
               image = "${var.container_registry}/${var.execution_manager_image}:${var.execution_manager_version}"
-              args  = ["--help"]
+              # Write sample data to exercise writing into S3.
+              args = [
+                "generate-ingestion-sample",
+                "--aggregation-id", "fake-1",
+                "--batch-id", "eb03ef04-5f05-4a64-95b2-ca1b841b6885",
+                "--date", "2020/09/11/21/11",
+                "--facilitator-output", "s3://${var.ingestion_bucket}",
+                "--pha-output", "/tmp/sample-pha"
+              ]
+              env {
+                name  = "AWS_ROLE_ARN"
+                value = var.ingestion_bucket_role
+              }
             }
-            restart_policy = "OnFailure"
+            # If we use any other restart policy, then when the job is finally
+            # deemed to be a failure, Kubernetes will destroy the job, pod and
+            # container(s) virtually immediately. This can cause us to lose logs
+            # if the container is reaped before the GKE logging agent can upload
+            # logs. Since this is a cronjob and we will retry anyway, we use
+            # "Never".
+            # https://kubernetes.io/docs/concepts/workloads/controllers/job/#handling-pod-and-container-failures
+            # https://github.com/kubernetes/kubernetes/issues/74848
+            restart_policy       = "Never"
+            service_account_name = kubernetes_service_account.execution_manager.metadata[0].name
           }
         }
       }
     }
   }
+}
+
+output "service_account_unique_id" {
+  value = google_service_account.execution_manager.unique_id
 }

--- a/terraform/modules/manifest/manifest.tf
+++ b/terraform/modules/manifest/manifest.tf
@@ -1,0 +1,110 @@
+variable "environment" {
+  type = string
+}
+
+variable "gcp_region" {
+  type = string
+}
+
+variable "domain" {
+  type = string
+}
+
+data "aws_caller_identity" "current" {}
+
+# Make a bucket where we will store global and specific manifests and from which
+# peers can fetch them.
+# https://cloud.google.com/cdn/docs/setting-up-cdn-with-bucket
+resource "google_storage_bucket" "manifests" {
+  provider = google-beta
+  name     = "prio-${var.environment}-manifests"
+  location = var.gcp_region
+  # Force deletion of bucket contents on bucket destroy. Bucket contents would
+  # be re-created by a subsequent deploy so no reason to keep them around.
+  force_destroy = true
+  # Disable per-object ACLs. Everything we put in here is meant to be world-
+  # readable and this is also in line with Google's recommendation:
+  # https://cloud.google.com/storage/docs/uniform-bucket-level-access
+  uniform_bucket_level_access = true
+}
+
+# With uniform bucket level access, we must use IAM permissions as ACLs are
+# ignored.
+# https://cloud.google.com/storage/docs/uniform-bucket-level-access
+resource "google_storage_bucket_iam_binding" "public_read" {
+  bucket = google_storage_bucket.manifests.name
+  # We want to allow unauthenticated reads of manifests. This also allows
+  # listing the bucket, which could allow an attacker to enumerate the PHAs
+  # that we have deployed support for. On the other hand, the attacker could
+  # also get that information by reading the tfvars files on GitHub.
+  # https://cloud.google.com/storage/docs/access-control/lists#predefined-acl
+  role = "roles/storage.objectViewer"
+  members = [
+    "allUsers"
+  ]
+}
+
+# Puts this data share processor's global manifest into the bucket.
+resource "google_storage_bucket_object" "global_manifest" {
+  provider     = google-beta
+  name         = "global-manifest.json"
+  bucket       = google_storage_bucket.manifests.name
+  content_type = "application/json"
+  content      = <<MANIFEST
+{
+  "format": 0,
+  "aws-account-id": "${data.aws_caller_identity.current.account_id}"
+}
+MANIFEST
+}
+
+# Now we configure an external HTTPS load balancer backed by the bucket.
+resource "google_compute_managed_ssl_certificate" "manifests" {
+  provider = google-beta
+  name     = "prio-${var.environment}-manifests"
+  managed {
+    domains = [var.domain]
+  }
+}
+
+# Reserve an external IP address for the load balancer.
+# https://cloud.google.com/cdn/docs/setting-up-cdn-with-bucket#ip-address
+# TODO(timg): we should have Terraform configure DNS for the manifest domain so
+# we can point it at this IP address, without which the managed certificate will
+# not work.
+resource "google_compute_global_address" "manifests" {
+  provider = google-beta
+  name     = "prio-${var.environment}-manifests"
+}
+
+resource "google_compute_backend_bucket" "manifests" {
+  provider    = google-beta
+  name        = "prio-${var.environment}-manifest-backend"
+  bucket_name = google_storage_bucket.manifests.name
+  enable_cdn  = true
+}
+
+resource "google_compute_url_map" "manifests" {
+  provider        = google-beta
+  name            = "prio-${var.environment}-manifests"
+  default_service = google_compute_backend_bucket.manifests.id
+}
+
+resource "google_compute_target_https_proxy" "manifests" {
+  provider         = google-beta
+  name             = "prio-${var.environment}-manifests"
+  url_map          = google_compute_url_map.manifests.id
+  ssl_certificates = [google_compute_managed_ssl_certificate.manifests.id]
+}
+
+resource "google_compute_global_forwarding_rule" "manifests" {
+  provider   = google-beta
+  name       = "prio-${var.environment}-manifests"
+  ip_address = google_compute_global_address.manifests.address
+  port_range = "443"
+  target     = google_compute_target_https_proxy.manifests.id
+}
+
+output "bucket" {
+  value = google_storage_bucket.manifests.name
+}

--- a/terraform/variables/demo-gcp.tfvars
+++ b/terraform/variables/demo-gcp.tfvars
@@ -6,3 +6,8 @@ peer_share_processor_names = ["test-pha-1", "test-pha-2"]
 aws_region                 = "us-west-1"
 # Graciously donated by jrenken
 manifest_domain = "portcull.is"
+ingestors = {
+  ingestor-1 = "portcull.is/ingestor-1"
+  ingestor-2 = "portcull.is/ingestor-2"
+}
+peer_share_processor_manifest_domain = "portcull.is/pha-servers"

--- a/terraform/variables/demo-gcp.tfvars
+++ b/terraform/variables/demo-gcp.tfvars
@@ -4,3 +4,5 @@ gcp_project                = "prio-bringup-290620"
 machine_type               = "e2-small"
 peer_share_processor_names = ["test-pha-1", "test-pha-2"]
 aws_region                 = "us-west-1"
+# Graciously donated by jrenken
+manifest_domain = "portcull.is"

--- a/terraform/variables/demo-gcp.tfvars
+++ b/terraform/variables/demo-gcp.tfvars
@@ -3,3 +3,4 @@ gcp_region                 = "us-west1"
 gcp_project                = "prio-bringup-290620"
 machine_type               = "e2-small"
 peer_share_processor_names = ["test-pha-1", "test-pha-2"]
+aws_region                 = "us-west-1"


### PR DESCRIPTION
This PR contains a series of commits that enables us to deploy data share processors in support of arbitrarily many ingestor servers and PHAs. The specific features are discussed in each commit message. There are several missing pieces here (tests on deploy-tool, support in deploy-tool for certifying packet decryption keys, Terraform management of manifest domain and its DNS, inclusion of key-identifier in batch signatures, hooking up peer manifest discovery to arguments on `facilitator`) but I wanted to get all these changes visible to our team because they might inform how the workflow manager will be built, and also so that the remaining tasks could be tackled in parallel.

Partially addresses: #20 #15