### PR TITLE
 Terraform: Kubernetes secrets, renames, manifests, construction of all necessary data share processors, deploy tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is ISRG's implementation server components for [Prio](https://crypto.stanford.edu/prio/), the privacy preserving statistics aggregation system.
 
-`avro-schema` contains [Avro](https://avro.apache.org/docs/current/index.html) schema definitions for interoperation with other actors in the Prio system. `facilitator` contains the Rust implementation of ISRG's Prio facilitation server. `terraform` contains a Terraform module for deploying facilitator servers.
+`avro-schema` contains [Avro](https://avro.apache.org/docs/current/index.html) schema definitions for interoperation with other actors in the Prio system. `facilitator` contains the Rust implementation of ISRG's Prio facilitation server. `terraform` contains a Terraform module for deploying data share processor servers.
 
 ## Releases
 

--- a/deploy-tool/.gitignore
+++ b/deploy-tool/.gitignore
@@ -1,0 +1,1 @@
+deploy-tool

--- a/deploy-tool/main.go
+++ b/deploy-tool/main.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// This tool consumes the output of `terraform apply`, generating keys and then
+// populating specific manifests and Kubernetes secrets with appropriate values.
+// We do this in this tool because if we generated secrets via Terraform
+// resources, the secret values would appear in the Terraform state file. The
+// struct definitions here MUST be kept in sync with the output variable in
+// terraform/modules/facilitator/facilitator.tf and the corresponding structs in
+// facilitator/src/manifest.rs.
+
+// BatchSigningPublicKey represents a public key used for batch signing.
+type BatchSigningPublicKey struct {
+	// PublicKey is the PEM armored base64 encoding of the ASN.1 encoding of the
+	// PKIX SubjectPublicKeyInfo structure. It must be an ECDSA P256 key.
+	PublicKey string `json:"public-key"`
+	// Expiration is the ISO 8601 encoded UTC date at which this key expires.
+	Expiration string `json:"expiration"`
+}
+
+// PacketEncryptionCertificate represents a certificate containing a public key
+// used for packet encryption.
+type PacketEncryptionCertificate struct {
+	// Certificate is the PEM armored X.509 certificate.
+	Certificate string `json:"certificate"`
+}
+
+// SpecificManifest represents the manifest file advertised by a data share
+// processor. See the design document for the full specification.
+// https://docs.google.com/document/d/1MdfM3QT63ISU70l63bwzTrxr93Z7Tv7EDjLfammzo6Q/edit#heading=h.3j8dgxqo5h68
+type SpecificManifest struct {
+	// Format is the version of the manifest.
+	Format float64 `json:"format"`
+	// IngestionBucket is the region+name of the bucket that the data share
+	// processor which owns the manifest reads ingestion batches from.
+	IngestionBucket string `json:"ingestion-bucket"`
+	// PeerValidationBucket is the region+name of the bucket that the data share
+	// processor which owns the manifest reads peer validation batches from.
+	PeerValidationBucket string `json:"peer-validation-bucket"`
+	// BatchSigningPublicKeys maps key identifiers to batch signing public keys.
+	// These are the keys that peers reading batches emitted by this data share
+	// processor use to verify signatures.
+	BatchSigningPublicKeys map[string]BatchSigningPublicKey `json:"batch-signing-public-keys"`
+	// PacketEncryptionCertificates maps key identifiers to packet encryption
+	// certificates. The values are PEM encoded X.509 certificates, which
+	// contain the public key corresponding to the private key that the data
+	// share processor which owns the manifest uses to decrypt ingestion share
+	// packets.
+	PacketEncryptionCertificates map[string]PacketEncryptionCertificate `json:"packet-encryption-certificates"`
+}
+
+// TerraformOutput represents the JSON output from `terraform apply` or
+// `terraform output --json`. This struct must match the output variables
+// defined in terraform/main.tf, though it only need describe the output
+// variables this program is interested in.
+type TerraformOutput struct {
+	ManifestBucket struct {
+		Value string
+	} `json:"manifest_bucket"`
+	SpecificManifests struct {
+		Value map[string]SpecificManifest
+	} `json:"specific_manifests"`
+}
+
+func generateKeyPair(dataShareProcessorName, keyName string) (*ecdsa.PrivateKey, error) {
+	ecdsaKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ECDSA P256 key: %w", err)
+	}
+
+	pkcs8PrivateKey, err := x509.MarshalPKCS8PrivateKey(ecdsaKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ECDSA key to PKCS#8 document: %w", err)
+	}
+
+	// Put the private keys into Kubernetes secrets. There's no straightforward
+	// way to update a secret value using kubectl, so we use the trick from[1].
+	// There's no particular reason to use `-o=json` but we must set some output
+	// format or nothing is written to stdout.
+	// [1] https://blog.atomist.com/updating-a-kubernetes-secret-or-configmap/
+	//
+	// We can't provide the base64 encoding of the key to --from-literal because
+	// then kubectl would base64 the base64, so we have to write the b64 to a
+	// temp file and then provide that to --from-file.
+	log.Printf("updating Kubernetes secret %s/%s", dataShareProcessorName, keyName)
+	tempFile, err := ioutil.TempFile("", "pkcs8-private-key-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp file: %v", err)
+	}
+	defer tempFile.Close()
+	defer os.Remove(tempFile.Name())
+
+	base64PrivateKey := base64.StdEncoding.EncodeToString(pkcs8PrivateKey)
+	if err := ioutil.WriteFile(tempFile.Name(), []byte(base64PrivateKey), 0644); err != nil {
+		return nil, fmt.Errorf("failed to write out PKCS#8 private key: %v", err)
+	}
+
+	secretArgument := fmt.Sprintf("--from-file=signing_key=%s", tempFile.Name())
+	kubectlCreate := exec.Command("kubectl", "-n", dataShareProcessorName, "create",
+		"secret", "generic", keyName, secretArgument, "--dry-run=client", "-o=json")
+	kubectlApply := exec.Command("kubectl", "apply", "-f", "-")
+	read, write := io.Pipe()
+	kubectlApply.Stdin = read
+	kubectlCreate.Stdout = write
+
+	// Do this async because if we don't close `kubectl create`'s stdout,
+	// `kubectl apply` will never make progress.
+	go func() {
+		defer write.Close()
+		if err := kubectlCreate.Run(); err != nil {
+			log.Fatalf("failed to run kubectl create: %v", err)
+		}
+	}()
+
+	if output, err := kubectlApply.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("failed to run kubectl apply: %v\nCombined output: %s", err, output)
+	}
+
+	return ecdsaKey, nil
+}
+
+func main() {
+	var terraformOutput TerraformOutput
+
+	err := json.NewDecoder(os.Stdin).Decode(&terraformOutput)
+	if err != nil {
+		log.Fatalf("failed to parse specific manifests: %v", err)
+	}
+
+	for dataShareProcessorName, manifest := range terraformOutput.SpecificManifests.Value {
+		newBatchSigningPublicKeys := map[string]BatchSigningPublicKey{}
+		for name, batchSigningPublicKey := range manifest.BatchSigningPublicKeys {
+			if batchSigningPublicKey.PublicKey != "" {
+				newBatchSigningPublicKeys[name] = batchSigningPublicKey
+				continue
+			}
+			log.Printf("generating ECDSA P256 key %s", name)
+			privateKey, err := generateKeyPair(dataShareProcessorName, name)
+			if err != nil {
+				log.Fatalf("%s", err)
+			}
+
+			pkixPublic, err := x509.MarshalPKIXPublicKey(privateKey.Public())
+			if err != nil {
+				log.Fatalf("failed to marshal ECDSA public key to PKIX: %v", err)
+			}
+
+			block := pem.Block{
+				Type:  "PUBLIC KEY",
+				Bytes: []byte(pkixPublic),
+			}
+
+			newBatchSigningPublicKeys[name] = BatchSigningPublicKey{
+				PublicKey:  string(pem.EncodeToMemory(&block)),
+				Expiration: time.Now().UTC().Format(time.RFC3339),
+			}
+		}
+
+		manifest.BatchSigningPublicKeys = newBatchSigningPublicKeys
+
+		newCertificates := map[string]PacketEncryptionCertificate{}
+		for name, packetEncryptionCertificate := range manifest.PacketEncryptionCertificates {
+			if packetEncryptionCertificate.Certificate != "" {
+				newCertificates[name] = packetEncryptionCertificate
+				continue
+			}
+			log.Printf("generating and certifying P256 key %s", name)
+			_, err := generateKeyPair(dataShareProcessorName, name)
+			if err != nil {
+				log.Fatalf("%s", err)
+			}
+
+			// TODO(timg) get certificate over the key, insert it here
+			newCertificates[name] = PacketEncryptionCertificate{Certificate: "TODO get certificate"}
+		}
+
+		manifest.PacketEncryptionCertificates = newCertificates
+
+		// Put the specific manifests into the manifest bucket. Users of this
+		// tool already need to have gsutil and valid Google Cloud credentials
+		// to be able to use the Makefile, so execing out to gsutil saves us the
+		// trouble of pulling in the gcloud SDK.
+		destination := fmt.Sprintf("gs://%s/%s.json",
+			terraformOutput.ManifestBucket.Value, dataShareProcessorName)
+		log.Printf("uploading specific manifest %s", destination)
+		gsutil := exec.Command("gsutil", "-h",
+			"Content-Type:application/json", "cp", "-", destination)
+		stdin, err := gsutil.StdinPipe()
+		if err != nil {
+			log.Fatalf("could not get pipe to gsutil stdin: %v", err)
+		}
+
+		// Do this async becuase if we don't close gsutil's stdin, it will
+		// never be able to get started.
+		go func() {
+			defer stdin.Close()
+			log.Printf("uploading manifest %+v", manifest)
+			manifestEncoder := json.NewEncoder(stdin)
+			if err := manifestEncoder.Encode(manifest); err != nil {
+				log.Fatalf("failed to encode manifest into gsutil stdin: %v", err)
+			}
+		}()
+
+		if output, err := gsutil.CombinedOutput(); err != nil {
+			log.Fatalf("gsutil failed: %v\noutput: %s", err, output)
+		}
+	}
+}

--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -495,6 +495,7 @@ dependencies = [
  "derivative",
  "hyper",
  "hyper-rustls 0.21.0",
+ "pem",
  "prio",
  "rand 0.7.3",
  "ring",
@@ -503,6 +504,7 @@ dependencies = [
  "rusoto_s3",
  "rusoto_sts",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1056,6 +1058,17 @@ name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "pem"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59698ea79df9bf77104aefd39cc3ec990cb9693fb59c3b0a70ddf2646fdffb4b"
+dependencies = [
+ "base64 0.12.3",
+ "once_cell",
+ "regex",
+]
 
 [[package]]
 name = "percent-encoding"

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -14,6 +14,7 @@ clap = "2.33.3"
 derivative = "2.1.1"
 hyper = "0.13.8"
 hyper-rustls = "0.21.0"
+pem = "0.8"
 prio = "0.2"
 rand = "0.7"
 ring = { version = "0.16.15", features = ["std"] }
@@ -21,6 +22,7 @@ rusoto_core = { version = "0.45.0", default_features = false, features = ["rustl
 rusoto_s3 = { version = "0.45.0", default_features = false, features = ["rustls"] }
 rusoto_sts = { version = "0.45.0", default_features = false, features = ["rustls"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 tempfile = "3.1.0"
 thiserror = "1.0"
 tokio = { version = "0.2", features = ["rt-core", "io-util"] }

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -219,6 +219,7 @@ fn main() -> Result<(), anyhow::Error> {
                 .arg(
                     Arg::with_name("ingestor-private-key")
                         .long("ingestor-private-key")
+                        .env("INGESTION_BATCH_SIGNING_KEY")
                         .value_name("B64")
                         .help(
                             "Base64 encoded ECDSA P256 private key for the \

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -6,6 +6,7 @@ pub mod aggregation;
 pub mod batch;
 pub mod idl;
 pub mod intake;
+pub mod manifest;
 pub mod sample;
 pub mod test_utils;
 pub mod transport;

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -1,0 +1,336 @@
+use anyhow::{anyhow, Context, Result};
+use ring::signature::{UnparsedPublicKey, ECDSA_P256_SHA256_FIXED};
+use serde::Deserialize;
+use serde_json::from_reader;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+// See discussion in SpecificManifest::batch_signing_public_key
+const ECDSA_P256_SPKI_PREFIX: &[u8] = &[
+    0x30, 0x59, 0x30, 0x13, 0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x02, 0x01, 0x06, 0x08, 0x2a,
+    0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07, 0x03, 0x42, 0x00,
+];
+
+/// Represents the description of a batch signing public key in a specific
+/// manifest.
+#[derive(Debug, Deserialize, PartialEq)]
+struct BatchSigningPublicKey {
+    /// The PEM-armored base64 encoding of the ASN.1 encoding of the PKIX
+    /// SubjectPublicKeyInfo structure of an ECDSA P256 key.
+    #[serde(rename = "public-key")]
+    public_key: String,
+    /// The ISO 8601 encoded UTC date at which this key expires.
+    expiration: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct PacketEncryptionCertificate {
+    /// The PEM-armored base64 encoding of the ASN.1 encoding of an X.509
+    /// certificate containing an ECDSA P256 key.
+    certificate: String,
+}
+
+/// Represents a specific manifest, used to exchange configuration parameters
+/// with peer data share processors. See the design document for the full
+/// specification.
+/// https://docs.google.com/document/d/1MdfM3QT63ISU70l63bwzTrxr93Z7Tv7EDjLfammzo6Q/edit#heading=h.3j8dgxqo5h68
+#[derive(Debug, Deserialize, PartialEq)]
+struct SpecificManifest {
+    /// Format version of the manifest. Versions besides the currently supported
+    /// one are rejected.
+    format: u32,
+    /// Region and name of the ingestion S3 bucket owned by this data share
+    /// processor.
+    #[serde(rename = "ingestion-bucket")]
+    ingestion_bucket: String,
+    /// Region and name of the peer validation S3 bucket owned by this data
+    /// share processor.
+    #[serde(rename = "peer-validation-bucket")]
+    peer_validation_bucket: String,
+    /// Keys used by this data share processor to sign batches.
+    #[serde(rename = "batch-signing-public-keys")]
+    batch_signing_public_keys: HashMap<String, BatchSigningPublicKey>,
+    /// Certificates containing public keys that should be used to encrypt
+    /// ingestion share packets intended for this data share processor.
+    #[serde(rename = "packet-encryption-certificates")]
+    packet_encryption_certificates: HashMap<String, PacketEncryptionCertificate>,
+}
+
+impl SpecificManifest {
+    fn from_https(base_path: &str, peer_name: &str) -> Result<SpecificManifest> {
+        if !base_path.starts_with("https://") {
+            return Err(anyhow!("Manifest must be fetched over HTTPS"));
+        }
+        let manifest_url = format!("{}/{}/specific-manifest.json", base_path, peer_name);
+        let response = ureq::get(&manifest_url)
+            // By default, ureq will wait forever to connect or
+            // read.
+            .timeout_connect(10_000) // ten seconds
+            .timeout_read(10_000) // ten seconds
+            .call();
+        if response.error() {
+            return Err(anyhow!("failed to fetch specific manifest: {:?}", response));
+        }
+        SpecificManifest::from_reader(response.into_reader())
+    }
+
+    fn from_file(path: &Path) -> Result<SpecificManifest> {
+        SpecificManifest::from_reader(File::open(path).context("failed to open manifest file")?)
+    }
+
+    fn from_reader<R: Read>(reader: R) -> Result<SpecificManifest> {
+        let manifest: SpecificManifest =
+            from_reader(reader).context("failed to decode JSON specific manifest")?;
+        if manifest.format != 0 {
+            return Err(anyhow!("unsupported manifest format {}", manifest.format));
+        }
+        Ok(manifest)
+    }
+
+    /// Returns the ECDSA P256 public key corresponding to the provided key
+    /// identifier, if it exists in the manifest.
+    fn batch_signing_public_key(&self, identifier: &str) -> Result<UnparsedPublicKey<Vec<u8>>> {
+        // No Rust crate that we have found gives us an easy way to parse PKIX
+        // SubjectPublicKeyInfo structures to get at the public key which can
+        // then be used in ring::signature. Since we know the keys we deal with
+        // should always be ECDSA P256, we can instead check that the binary
+        // blob inside the PEM has the expected prefix for this kind of key in
+        // this kind of encoding, as suggested in this GitHub issue on ring:
+        // https://github.com/briansmith/ring/issues/881
+        let key = self
+            .batch_signing_public_keys
+            .get(identifier)
+            .context(format!("no value for key {}", identifier))?;
+
+        let pem = pem::parse(&key.public_key)
+            .context(format!("failed to parse key entry {} as PEM", identifier))?;
+        if pem.tag != "PUBLIC KEY" {
+            return Err(anyhow!(
+                "key for identifier {} is not a PEM encoded public key"
+            ));
+        }
+        if pem.contents.len() < ECDSA_P256_SPKI_PREFIX.len() {
+            return Err(anyhow!("PEM contents not long enough to contain ASN.1 encoded ECDSA P256 SubjectPublicKeyInfo"));
+        }
+        if &pem.contents[..ECDSA_P256_SPKI_PREFIX.len()] != ECDSA_P256_SPKI_PREFIX {
+            return Err(anyhow!(
+                "PEM contents are not ASN.1 encoded ECDSA P256 SubjectPublicKeyInfo"
+            ));
+        }
+
+        Ok(UnparsedPublicKey::new(
+            &ECDSA_P256_SHA256_FIXED,
+            Vec::from(&pem.contents[ECDSA_P256_SPKI_PREFIX.len()..]),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::{
+        default_ingestor_private_key, DEFAULT_INGESTOR_SUBJECT_PUBLIC_KEY_INFO,
+    };
+    use ring::rand::SystemRandom;
+    use std::io::Cursor;
+
+    #[test]
+    fn load_manifest() {
+        let reader = Cursor::new(format!(
+            r#"
+{{
+    "format": 0,
+    "packet-encryption-certificates": {{
+        "fake-key-1": {{
+            "certificate": "who cares"
+        }}
+    }},
+    "batch-signing-public-keys": {{
+        "fake-key-2": {{
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----"
+      }}
+    }},
+    "ingestion-bucket": "us-west-1/ingestion",
+    "peer-validation-bucket": "us-west-1/validation"
+}}
+    "#,
+            DEFAULT_INGESTOR_SUBJECT_PUBLIC_KEY_INFO
+        ));
+        let manifest = SpecificManifest::from_reader(reader).unwrap();
+
+        let mut expected_batch_keys = HashMap::new();
+        expected_batch_keys.insert(
+            "fake-key-2".to_owned(),
+            BatchSigningPublicKey {
+                expiration: "".to_string(),
+                public_key: format!(
+                    "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----",
+                    DEFAULT_INGESTOR_SUBJECT_PUBLIC_KEY_INFO
+                ),
+            },
+        );
+        let mut expected_packet_encryption_certificates = HashMap::new();
+        expected_packet_encryption_certificates.insert(
+            "fake-key-1".to_owned(),
+            PacketEncryptionCertificate {
+                certificate: "who cares".to_owned(),
+            },
+        );
+        let expected_manifest = SpecificManifest {
+            format: 0,
+            batch_signing_public_keys: expected_batch_keys,
+            packet_encryption_certificates: expected_packet_encryption_certificates,
+            ingestion_bucket: "us-west-1/ingestion".to_string(),
+            peer_validation_bucket: "us-west-1/validation".to_string(),
+        };
+        assert_eq!(manifest, expected_manifest);
+        let batch_signing_key = manifest.batch_signing_public_key("fake-key-2").unwrap();
+        let content = b"some content";
+        let signature = default_ingestor_private_key()
+            .sign(&SystemRandom::new(), content)
+            .unwrap();
+        batch_signing_key
+            .verify(content, signature.as_ref())
+            .unwrap();
+    }
+
+    #[test]
+    fn invalid_manifest() {
+        let invalid_manifests = vec![
+            "not-json",
+            "{ \"missing\": \"keys\"}",
+            // No format key
+            r#"
+{
+    "packet-encryption-certificates": {
+        "fake-key-1": {
+            "certificate": "who cares"
+        }
+    },
+    "batch-signing-public-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\nfoo\n-----END PUBLIC KEY-----"
+      }
+    },
+    "ingestion-bucket": "us-west-1/ingestion",
+    "peer-validation-bucket": "us-west-1/validation"
+}
+    "#,
+            // Format key with wrong value
+            r#"
+{
+    "format": 1,
+    "packet-encryption-certificates": {
+        "fake-key-1": {
+            "certificate": "who cares"
+        }
+    },
+    "batch-signing-public-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\nfoo\n-----END PUBLIC KEY-----"
+      }
+    },
+    "ingestion-bucket": "us-west-1/ingestion",
+    "peer-validation-bucket": "us-west-1/validation"
+}
+    "#,
+            // Format key with wrong type
+            r#"
+{
+    "format": "zero",
+    "packet-encryption-certificates": {
+        "fake-key-1": {
+            "certificate": "who cares"
+        }
+    },
+    "batch-signing-public-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\nfoo\n-----END PUBLIC KEY-----"
+      }
+    },
+    "ingestion-bucket": "us-west-1/ingestion",
+    "peer-validation-bucket": "us-west-1/validation"
+}
+    "#,
+        ];
+
+        for invalid_manifest in &invalid_manifests {
+            let reader = Cursor::new(invalid_manifest);
+            SpecificManifest::from_reader(reader).unwrap_err();
+        }
+    }
+
+    #[test]
+    fn invalid_public_key() {
+        let manifests_with_invalid_public_keys = vec![
+            // Wrong PEM block
+            r#"
+{
+    "format": 0,
+    "packet-encryption-certificates": {
+        "fake-key-1": {
+            "certificate": "who cares"
+        }
+    },
+    "batch-signing-public-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN EC PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIKh3MccE1cdSF4pnEb+U0MmGYfkoQzOl2aiaJ6D9ZudqDdGiyA9YSUq3yia56nYJh5mk+HlzTX+AufoNR2bfrg==\n-----END EC PUBLIC KEY-----"
+      }
+    },
+    "ingestion-bucket": "us-west-1/ingestion",
+    "peer-validation-bucket": "us-west-1/validation"
+}
+    "#,
+            // PEM contents not an ASN.1 SPKI
+            r#"
+{
+    "format": 0,
+    "packet-encryption-certificates": {
+        "fake-key-1": {
+            "certificate": "who cares"
+        }
+    },
+    "batch-signing-public-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\nBIl6j+J6dYttxALdjISDv6ZI4/VWVEhUzaS05LgrsfswmbLOgNt9HUC2E0w+9RqZx3XMkdEHBHfNuCSMpOwofVSq3TfyKwn0NrftKisKKVSaTOt5seJ67P5QL4hxgPWvxw==\n-----END PUBLIC KEY-----"
+      }
+    },
+    "ingestion-bucket": "us-west-1/ingestion",
+    "peer-validation-bucket": "us-west-1/validation"
+}
+    "#,
+            // PEM contents too short
+            r#"
+{
+    "format": 0,
+    "packet-encryption-certificates": {
+        "fake-key-1": {
+            "certificate": "who cares"
+        }
+    },
+    "batch-signing-public-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\ndG9vIHNob3J0Cg==\n-----END PUBLIC KEY-----"
+      }
+    },
+    "ingestion-bucket": "us-west-1/ingestion",
+    "peer-validation-bucket": "us-west-1/validation"
+}
+    "#,
+        ];
+        for invalid_manifest in &manifests_with_invalid_public_keys {
+            let reader = Cursor::new(invalid_manifest);
+            let manifest = SpecificManifest::from_reader(reader).unwrap();
+            assert!(manifest.batch_signing_public_key("fake-key-1").is_err());
+        }
+    }
+}

--- a/facilitator/src/test_utils.rs
+++ b/facilitator/src/test_utils.rs
@@ -17,14 +17,31 @@ pub const DEFAULT_INGESTOR_PRIVATE_KEY: &str =
     "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQggoa08rQR90Asvhy5b\
     WIgFBDeGaO8FnVEF3PVpNVmDGChRANCAAQ2mZfm4UC73PkWsYz3Uub6UTIAFQCPGxo\
     uP1O1PlmntOpfLYdvyZDCuenAzv1oCfyToolNArNjwo/+harNn1fs";
+// We have selected PEM armored, ASN.1 encoded PKIX SubjectPublicKeyInfo
+// structures as the means of exchanging public keys with peer servers. However,
+// no Rust crate that we have found gives us an easy way to obtain a PKIX SPKI
+// from the PKCS#8 document format that ring uses for private key serialization.
+// This constant and the other _SUBJECT_PUBLIC_KEY_INFO constants were obtained
+// by placing the corresponding _PRIVATE_KEY constants into a PEM block, and
+// then `openssl ec -inform PEM -outform PEM -in /path/to/PEM/PKCS#8/document
+// -pubout`.
+pub const DEFAULT_INGESTOR_SUBJECT_PUBLIC_KEY_INFO: &str =
+    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENpmX5uFAu9z5FrGM91Lm+lEyABUA\
+    jxsaLj9TtT5Zp7TqXy2Hb8mQwrnpwM79aAn8k6KJTQKzY8KP/oWqzZ9X7A==";
 pub const DEFAULT_FACILITATOR_SIGNING_PRIVATE_KEY: &str =
     "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgeSa+S+tmLupnAEyFK\
     dVuKB99y09YEqW41+8pwP4cTkahRANCAASy7FHcLGnRudVHWga/j2k9nQ3lMvuGE01\
     Q7DEyjyCuuw9YmB3dHvYcRUnxVRI/nF5LvneGim0dC7F1fuRAPeXI";
+pub const DEFAULT_FACILITATOR_SUBJECT_PUBLIC_KEY_INFO: &str =
+    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsuxR3Cxp0bnVR1oGv49pPZ0N5TL7\
+    hhNNUOwxMo8grrsPWJgd3R72HEVJ8VUSP5xeS753hoptHQuxdX7kQD3lyA==";
 pub const DEFAULT_PHA_SIGNING_PRIVATE_KEY: &str =
     "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg1BQjH71U37XLfWqe+\
     /xP8iUrMiHpmUtbj3UfDkhFIrShRANCAAQgqHcxxwTVx1IXimcRv5TQyYZh+ShDM6X\
     ZqJonoP1m52oN0aLID1hJSrfKJrnqdgmHmaT4eXNNf4C5+g1HZt+u";
+pub const DEFAULT_PHA_SUBJECT_PUBLIC_KEY_INFO: &str =
+    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIKh3MccE1cdSF4pnEb+U0MmGYfko\
+    QzOl2aiaJ6D9ZudqDdGiyA9YSUq3yia56nYJh5mk+HlzTX+AufoNR2bfrg==";
 
 /// Constructs an EcdsaKeyPair from the default ingestor server.
 pub fn default_ingestor_private_key() -> EcdsaKeyPair {

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -32,7 +32,7 @@ prep: ## Prepare a new workspace (environment) if needed, configure the tfstate 
 		exit 1; \
 	 fi
 	@echo "$(BOLD)Verifying that the storage bucket $(STORAGE_BUCKET_URL) for remote state exists$(RESET)"
-	@if ! gsutil ls -b  $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; then \
+	@if ! gsutil ls -b $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; then \
 		echo "$(BOLD)Storage bucket $(STORAGE_BUCKET_URL) was not found, creating new bucket with versioning enabled to store tfstate$(RESET)"; \
 		gsutil mb -l $(REGION) $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; \
 		gsutil versioning set on $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; \

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -88,6 +88,7 @@ apply: prep ## Have terraform do the things. This will cost money.
 		-input=false \
 		-refresh=true \
 		-var-file="$(VARS)"
+	@terraform output --json | go run ../deploy-tool/main.go
 
 .PHONY: apply-target
 apply-target: prep ## Have terraform do the things for a specific resource. This will cost money.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,6 @@
 # Prio server Terraform module
 
-This Terraform module manages a [GKE cluster](https://cloud.google.com/kubernetes-engine/docs) which hosts a Prio data share processor. We create one cluster and one node pool in each region in which we operate, and then run each PHA's facilitator instance in its own Kubernetes namespace. Each facilitator consists of a [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) that runs an execution manager.
+This Terraform module manages a [GKE cluster](https://cloud.google.com/kubernetes-engine/docs) which hosts a Prio data share processor. We create one cluster and one node pool in each region in which we operate, and then run each PHA's facilitator instance in its own Kubernetes namespace. Each facilitator consists of a [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) that runs a workflow manager.
 
 You will need these tools:
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,6 @@
 # Prio server Terraform module
 
-This Terraform module manages a [GKE cluster](https://cloud.google.com/kubernetes-engine/docs) which hosts a Prio data share processor. We create one cluster and one node pool in each region in which we operate, and then run each PHA's facilitator instance in its own Kubernetes namespace. Each facilitator consists of a [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) that runs a workflow manager.
+This Terraform module manages a [GKE cluster](https://cloud.google.com/kubernetes-engine/docs) which hosts a Prio data share processor. We create one cluster and one node pool in each region in which we operate, and then run each PHA's data share processor instance in its own Kubernetes namespace. Each data share processor consists of a [Kubernetes CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) that runs a workflow manager.
 
 You will need these tools:
 
@@ -22,7 +22,7 @@ If you're having problems, check `gcloud config list` and `kubectl config curren
 
 ## New clusters
 
-To add a facilitator to support a new PHA in an existing region, add their PHA name to the `peer_share_processor_names` variable in the relevant `variables/<environment>.tfvars` file. To bring up a whole new cluster, drop a `your-new-environment.tfvars` file in `variables`, fill in the required variables and use `ENV=your-new-environment make apply` to deploy it. Multiple environments may be deployed to the same GCP region.
+To add a data share processor to support a new PHA in an existing region, add their PHA name to the `peer_share_processor_names` variable in the relevant `variables/<environment>.tfvars` file. To bring up a whole new cluster, drop a `your-new-environment.tfvars` file in `variables`, fill in the required variables and use `ENV=your-new-environment make apply` to deploy it. Multiple environments may be deployed to the same GCP region.
 
 ## kubectl configuration
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -119,27 +119,66 @@ data "http" "peer_share_processor_global_manifest" {
   url = "https://${var.peer_share_processor_manifest_domain}/global-manifest.json"
 }
 
+# While we create a distinct data share processor for each (ingestor, peer data
+# share processor) pair, we only create one packet decryption key for each peer
+# data share processor, and use it for all ingestors. Since the secret must be
+# in a namespace and accessible from both data share processors, that means both
+# data share processors must be in a single Kubernetes namespace, which we
+# create here and pass into the data share processor module.
+resource "kubernetes_namespace" "namespaces" {
+  for_each = toset(var.peer_share_processor_names)
+  metadata {
+    name = each.key
+    annotations = {
+      environment = var.environment
+    }
+  }
+}
+
+resource "kubernetes_secret" "ingestion_packet_decryption_keys" {
+  for_each = toset(var.peer_share_processor_names)
+  metadata {
+    name      = "${var.environment}-${each.key}-ingestion-packet-decryption-key"
+    namespace = kubernetes_namespace.namespaces[each.key].metadata[0].name
+  }
+
+  data = {
+    # See comment on batch_signing_key, above, about the initial value here.
+    decryption_key = "not-a-real-key"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      data["decryption_key"]
+    ]
+  }
+}
+
 # Now, we take the set product of peer share processor names x ingestor names to
 # get the config values for all the data share processors we need to create.
 locals {
   peer_ingestor_pairs = {
     for pair in setproduct(toset(var.peer_share_processor_names), keys(var.ingestors)) :
     "${pair[0]}-${pair[1]}" => {
-      ingestor_aws_role_arn           = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body), "aws-iam-entity", "")
-      ingestor_gcp_service_account_id = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body), "google-service-account", "")
+      kubernetes_namespace                    = kubernetes_namespace.namespaces[pair[0]].metadata[0].name
+      packet_decryption_key_kubernetes_secret = kubernetes_secret.ingestion_packet_decryption_keys[pair[0]].metadata[0].name
+      ingestor_aws_role_arn                   = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body), "aws-iam-entity", "")
+      ingestor_gcp_service_account_id         = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body), "google-service-account", "")
     }
   }
 }
 
 module "data_share_processors" {
-  for_each                            = local.peer_ingestor_pairs
-  source                              = "./modules/data_share_processor"
-  environment                         = var.environment
-  data_share_processor_name           = each.key
-  gcp_project                         = var.gcp_project
-  ingestor_aws_role_arn               = each.value.ingestor_aws_role_arn
-  ingestor_google_service_account_id  = each.value.ingestor_gcp_service_account_id
-  peer_share_processor_aws_account_id = jsondecode(data.http.peer_share_processor_global_manifest.body).aws-account-id
+  for_each                                = local.peer_ingestor_pairs
+  source                                  = "./modules/data_share_processor"
+  environment                             = var.environment
+  data_share_processor_name               = each.key
+  gcp_project                             = var.gcp_project
+  ingestor_aws_role_arn                   = each.value.ingestor_aws_role_arn
+  ingestor_google_service_account_id      = each.value.ingestor_gcp_service_account_id
+  peer_share_processor_aws_account_id     = jsondecode(data.http.peer_share_processor_global_manifest.body).aws-account-id
+  kubernetes_namespace                    = each.value.kubernetes_namespace
+  packet_decryption_key_kubernetes_secret = each.value.packet_decryption_key_kubernetes_secret
 
   depends_on = [module.gke]
 }
@@ -153,5 +192,9 @@ output "gke_kubeconfig" {
 }
 
 output "specific_manifests" {
-  value = { for v in module.data_share_processors : v.data_share_processor_name => v.specific_manifest }
+  value = { for v in module.data_share_processors : v.data_share_processor_name => {
+    kubernetes-namespace = v.kubernetes_namespace
+    specific-manifest    = v.specific_manifest
+    }
+  }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,8 +28,9 @@ variable "peer_share_processor_names" {
   type = list(string)
 }
 
-locals {
-  resource_prefix = "prio-${var.environment}"
+variable "manifest_domain" {
+  type        = string
+  description = "Domain (plus optional relative path) to which this environment's global and specific manifests should be uploaded."
 }
 
 terraform {
@@ -78,10 +79,17 @@ provider "kubernetes" {
   load_config_file       = false
 }
 
+module "manifest" {
+  source      = "./modules/manifest"
+  environment = var.environment
+  gcp_region  = var.gcp_region
+  domain      = var.manifest_domain
+}
+
 module "gke" {
   source          = "./modules/gke"
   environment     = var.environment
-  resource_prefix = local.resource_prefix
+  resource_prefix = "prio-${var.environment}"
   gcp_region      = var.gcp_region
   gcp_project     = var.gcp_project
   machine_type    = var.machine_type
@@ -96,6 +104,11 @@ module "data_share_processors" {
 
   depends_on = [module.gke]
 }
+
+output "manifest_bucket" {
+  value = module.manifest.bucket
+}
+
 output "gke_kubeconfig" {
   value = "Run this command to update your kubectl config: gcloud container clusters get-credentials ${module.gke.cluster_name} --region ${var.gcp_region}"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -87,9 +87,9 @@ module "gke" {
   machine_type    = var.machine_type
 }
 
-module "facilitator" {
+module "data_share_processors" {
   for_each                  = toset(var.peer_share_processor_names)
-  source                    = "./modules/facilitator"
+  source                    = "./modules/data_share_processor"
   environment               = var.environment
   peer_share_processor_name = each.key
   gcp_project               = var.gcp_project

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -1,4 +1,4 @@
-variable "peer_share_processor_name" {
+variable "data_share_processor_name" {
   type = string
 }
 
@@ -10,6 +10,25 @@ variable "gcp_project" {
   type = string
 }
 
+variable "ingestor_aws_role_arn" {
+  type = string
+}
+
+variable "ingestor_google_service_account_id" {
+  type = string
+}
+
+variable "peer_share_processor_aws_account_id" {
+  type = string
+}
+
+locals {
+  resource_prefix                  = "${var.environment}-${var.data_share_processor_name}"
+  ingestion_bucket_writer_role_arn = var.ingestor_google_service_account_id != "" ? aws_iam_role.ingestor_bucket_writer_role[0].arn : var.ingestor_aws_role_arn
+  ingestion_bucket_name            = "prio-${local.resource_prefix}-ingestion"
+  peer_validation_bucket_name      = "prio-${local.resource_prefix}-peer-validation"
+}
+
 data "aws_caller_identity" "current" {}
 
 # This is the role in AWS we use to construct policy on the S3 buckets. It is
@@ -17,7 +36,7 @@ data "aws_caller_identity" "current" {}
 # processor via Web Identity Federation
 # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
 resource "aws_iam_role" "bucket_role" {
-  name = "prio-${var.environment}-${var.peer_share_processor_name}-bucket-role"
+  name = "prio-${local.resource_prefix}-bucket-role"
   # We currently use a single role per facilitator to gate read/write access to
   # all buckets. We could define more GCP service accounts and corresponding AWS
   # IAM roles for read/write on each of the ingestion, validation and sum part
@@ -47,42 +66,132 @@ resource "aws_iam_role" "bucket_role" {
   ]
 }
 ROLE
-
   tags = {
     environment = "prio-${var.environment}"
   }
 }
 
-locals {
-  ingestion_bucket_name  = "prio-${var.environment}-${var.peer_share_processor_name}-ingestion"
-  validation_bucket_name = "prio-${var.environment}-${var.peer_share_processor_name}-validation"
-  sum_part_bucket_name   = "prio-${var.environment}-${var.peer_share_processor_name}-sum-part"
-}
-
-resource "aws_s3_bucket" "buckets" {
-  for_each = toset([
-    local.ingestion_bucket_name, local.validation_bucket_name, local.sum_part_bucket_name
-  ])
-  bucket = each.key
-  policy = <<POLICY
+# If the ingestor authenticates using a GCP service account, this is the role in
+# AWS that their service account assumes. Note the "count" parameter in the
+# block, which seems to be the Terraform convention to conditionally create
+# resources (c.f. lots of StackOverflow questions and GitHub issues).
+resource "aws_iam_role" "ingestor_bucket_writer_role" {
+  count              = var.ingestor_google_service_account_id != "" ? 1 : 0
+  name               = "prio-${local.resource_prefix}-bucket-writer"
+  assume_role_policy = <<ROLE
 {
   "Version": "2012-10-17",
   "Statement": [
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "${aws_iam_role.bucket_role.arn}"
+        "Federated": "accounts.google.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "accounts.google.com:sub": "${var.ingestor_google_service_account_id}"
+        }
+      }
+    }
+  ]
+}
+ROLE
+  tags = {
+    environment = "prio-${var.environment}"
+  }
+}
+
+# The ingestion bucket for this data share processor. This one is different from
+# the other two in that we must grant write access to the ingestor but no access
+# to the peer share processor.
+resource "aws_s3_bucket" "ingestion_bucket" {
+  bucket = local.ingestion_bucket_name
+  # Force deletion of bucket contents on bucket destroy.
+  force_destroy = true
+  policy        = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${local.ingestion_bucket_writer_role_arn}"
       },
       "Action": [
         "s3:AbortMultipartUpload",
         "s3:PutObject",
         "s3:ListMultipartUploadParts",
-        "s3:ListBucketMultipartUploads",
+        "s3:ListBucketMultipartUploads"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${local.ingestion_bucket_name}/*",
+        "arn:aws:s3:::${local.ingestion_bucket_name}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_role.bucket_owner_role.arn}"
+      },
+      "Action": [
         "s3:GetObject"
       ],
       "Resource": [
-        "arn:aws:s3:::${each.key}/*",
-        "arn:aws:s3:::${each.key}"
+        "arn:aws:s3:::${local.ingestion_bucket_name}/*",
+        "arn:aws:s3:::${local.ingestion_bucket_name}"
+      ]
+    }
+  ]
+}
+POLICY
+  tags = {
+    environment = var.environment
+  }
+}
+
+# The peer validation bucket for this data share processor, configured to permit
+# the peer share processor to write to it. The policy grants write permissions
+# to any role or user in the peer data share processor's AWS account because
+# Amazon S3 won't let you define policies in terms of roles that don't exist. In
+# any case, since we have no control over or insight into the role assumption
+# policies in the other account, we gain nothing by specifying anything beyond
+# the AWS account.
+resource "aws_s3_bucket" "peer_validation_bucket" {
+  bucket = local.peer_validation_bucket_name
+  # Force deletion of bucket contents on bucket destroy.
+  force_destroy = true
+  policy        = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${var.peer_share_processor_aws_account_id}"
+      },
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:PutObject",
+        "s3:ListMultipartUploadParts",
+        "s3:ListBucketMultipartUploads"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${local.peer_validation_bucket_name}/*",
+        "arn:aws:s3:::${local.peer_validation_bucket_name}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_iam_role.bucket_owner_role.arn}"
+      },
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${local.peer_validation_bucket_name}/*",
+        "arn:aws:s3:::${local.peer_validation_bucket_name}"
       ]
     }
   ]
@@ -95,9 +204,32 @@ POLICY
 
 module "kubernetes" {
   source                    = "../../modules/kubernetes/"
-  peer_share_processor_name = var.peer_share_processor_name
+  data_share_processor_name = var.data_share_processor_name
   gcp_project               = var.gcp_project
   environment               = var.environment
-  ingestion_bucket          = "${aws_s3_bucket.buckets[local.ingestion_bucket_name].region}/${aws_s3_bucket.buckets[local.ingestion_bucket_name].bucket}"
-  ingestion_bucket_role     = aws_iam_role.bucket_role.arn
+  ingestion_bucket          = "${aws_s3_bucket.ingestion_bucket.region}/${aws_s3_bucket.ingestion_bucket.bucket}"
+  ingestion_bucket_role     = aws_iam_role.bucket_owner_role.arn
+}
+
+output "data_share_processor_name" {
+  value = var.data_share_processor_name
+}
+
+output "specific_manifest" {
+  value = {
+    format                 = 0
+    ingestion-bucket       = "${aws_s3_bucket.ingestion_bucket.region}/${aws_s3_bucket.ingestion_bucket.bucket}",
+    peer-validation-bucket = "${aws_s3_bucket.peer_validation_bucket.region}/${aws_s3_bucket.peer_validation_bucket.bucket}",
+    batch-signing-public-keys = {
+      (module.kubernetes.batch_signing_key) = {
+        public-key = ""
+        expiration = ""
+      }
+    }
+    packet-encryption-certificates = {
+      (module.kubernetes.ingestion_packet_decryption_key) = {
+        certificate = ""
+      }
+    }
+  }
 }

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -22,6 +22,14 @@ variable "peer_share_processor_aws_account_id" {
   type = string
 }
 
+variable "kubernetes_namespace" {
+  type = string
+}
+
+variable "packet_decryption_key_kubernetes_secret" {
+  type = string
+}
+
 locals {
   resource_prefix                  = "${var.environment}-${var.data_share_processor_name}"
   ingestion_bucket_writer_role_arn = var.ingestor_google_service_account_id != "" ? aws_iam_role.ingestor_bucket_writer_role[0].arn : var.ingestor_aws_role_arn
@@ -132,7 +140,7 @@ resource "aws_s3_bucket" "ingestion_bucket" {
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "${aws_iam_role.bucket_owner_role.arn}"
+        "AWS": "${aws_iam_role.bucket_role.arn}"
       },
       "Action": [
         "s3:GetObject"
@@ -184,7 +192,7 @@ resource "aws_s3_bucket" "peer_validation_bucket" {
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "${aws_iam_role.bucket_owner_role.arn}"
+        "AWS": "${aws_iam_role.bucket_role.arn}"
       },
       "Action": [
         "s3:GetObject"
@@ -203,16 +211,22 @@ POLICY
 }
 
 module "kubernetes" {
-  source                    = "../../modules/kubernetes/"
-  data_share_processor_name = var.data_share_processor_name
-  gcp_project               = var.gcp_project
-  environment               = var.environment
-  ingestion_bucket          = "${aws_s3_bucket.ingestion_bucket.region}/${aws_s3_bucket.ingestion_bucket.bucket}"
-  ingestion_bucket_role     = aws_iam_role.bucket_owner_role.arn
+  source                                  = "../../modules/kubernetes/"
+  data_share_processor_name               = var.data_share_processor_name
+  gcp_project                             = var.gcp_project
+  environment                             = var.environment
+  ingestion_bucket                        = "${aws_s3_bucket.ingestion_bucket.region}/${aws_s3_bucket.ingestion_bucket.bucket}"
+  ingestion_bucket_role                   = aws_iam_role.bucket_role.arn
+  kubernetes_namespace                    = var.kubernetes_namespace
+  packet_decryption_key_kubernetes_secret = var.packet_decryption_key_kubernetes_secret
 }
 
 output "data_share_processor_name" {
   value = var.data_share_processor_name
+}
+
+output "kubernetes_namespace" {
+  value = var.kubernetes_namespace
 }
 
 output "specific_manifest" {
@@ -227,7 +241,7 @@ output "specific_manifest" {
       }
     }
     packet-encryption-certificates = {
-      (module.kubernetes.ingestion_packet_decryption_key) = {
+      (var.packet_decryption_key_kubernetes_secret) = {
         certificate = ""
       }
     }

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -13,8 +13,8 @@ variable "gcp_project" {
 data "aws_caller_identity" "current" {}
 
 # This is the role in AWS we use to construct policy on the S3 buckets. It is
-# configured to allow access to the GCP service account for this facilitator via
-# Web Identity Federation
+# configured to allow access to the GCP service account for this data share
+# processor via Web Identity Federation
 # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
 resource "aws_iam_role" "bucket_role" {
   name = "prio-${var.environment}-${var.peer_share_processor_name}-bucket-role"

--- a/terraform/modules/gke/gke.tf
+++ b/terraform/modules/gke/gke.tf
@@ -48,6 +48,14 @@ resource "google_container_cluster" "cluster" {
   workload_identity_config {
     identity_namespace = "${var.gcp_project}.svc.id.goog"
   }
+  # This enables KMS encryption of the constents of the Kubernetes cluster etcd
+  # instance which among other things, stores Kubernetes secrets, like the keys
+  # used by data share processors to sign batches or decrypt ingestion shares.
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets
+  database_encryption {
+    state    = "ENCRYPTED"
+    key_name = google_kms_crypto_key.etcd_encryption_key.id
+  }
 }
 
 resource "google_container_node_pool" "worker_nodes" {
@@ -75,6 +83,45 @@ resource "google_container_node_pool" "worker_nodes" {
       node_metadata = "GKE_METADATA_SERVER"
     }
   }
+}
+
+# KMS keyring to store etcd encryption key
+resource "google_kms_key_ring" "keyring" {
+  provider = google-beta
+  name     = "${var.resource_prefix}-kms-keyring"
+  # Keyrings can also be zonal, but ours must be regional to match the GKE
+  # cluster.
+  location = var.gcp_region
+}
+
+# KMS key used by GKE cluster to encrypt contents of cluster etcd, crucially to
+# protect Kubernetes secrets.
+resource "google_kms_crypto_key" "etcd_encryption_key" {
+  provider = google-beta
+  name     = "${var.resource_prefix}-etcd-encryption-key"
+  key_ring = google_kms_key_ring.keyring.id
+  purpose  = "ENCRYPT_DECRYPT"
+  # Rotate database encryption key every 90 days. This doesn't reencrypt
+  # existing secrets unless we go touch them.
+  # https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets#key_rotation
+  rotation_period = "7776000s"
+}
+
+# We need the project _number_ to construct the GKE service account, below.
+data "google_project" "project" {
+  provider = google-beta
+}
+
+# Permit the GKE service account to use the KMS key. We construct the service
+# account name per the specification in:
+# https://cloud.google.com/kubernetes-engine/docs/how-to/encrypting-secrets#grant_permission_to_use_the_key
+resource "google_kms_crypto_key_iam_binding" "etcd-encryption-key-iam-binding" {
+  provider      = google-beta
+  crypto_key_id = google_kms_crypto_key.etcd_encryption_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  members = [
+    "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
+  ]
 }
 
 output "cluster_name" {

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -11,12 +11,12 @@ variable "container_registry" {
   default = "letsencrypt"
 }
 
-variable "execution_manager_image" {
+variable "workflow_manager_image" {
   type    = string
   default = "prio-facilitator"
 }
 
-variable "execution_manager_version" {
+variable "workflow_manager_version" {
   type    = string
   default = "0.1.0"
 }
@@ -56,14 +56,14 @@ resource "kubernetes_namespace" "namespace" {
 # [2] https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection
 
 # For each facilitator, we first create a GCP service account.
-resource "google_service_account" "execution_manager" {
+resource "google_service_account" "workflow_manager" {
   provider = google-beta
   # The Account ID must be unique across the whole GCP project, and not just the
   # namespace. It must also be fewer than 30 characters, so we can't concatenate
   # environment and PHA name to get something unique. Instead, we generate a
   # random string.
   account_id   = "prio-${random_string.account_id.result}"
-  display_name = "prio-${var.environment}-${var.peer_share_processor_name}-execution-manager"
+  display_name = "prio-${var.environment}-${var.peer_share_processor_name}-workflow-manager"
 }
 
 resource "random_string" "account_id" {
@@ -75,16 +75,16 @@ resource "random_string" "account_id" {
 
 # This is the Kubernetes-level service account which we associate with the GCP
 # service account above.
-resource "kubernetes_service_account" "execution_manager" {
+resource "kubernetes_service_account" "workflow_manager" {
   metadata {
-    name      = "execution-manager"
+    name      = "workflow-manager"
     namespace = var.peer_share_processor_name
     annotations = {
       environment = var.environment
       # This annotation is necessary for the Kubernetes-GCP service account
       # mapping. See step 6 in
       # https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to
-      "iam.gke.io/gcp-service-account" = google_service_account.execution_manager.email
+      "iam.gke.io/gcp-service-account" = google_service_account.workflow_manager.email
     }
   }
 }
@@ -93,13 +93,13 @@ resource "kubernetes_service_account" "execution_manager" {
 # account in GCP-level policies, below. See step 5 in
 # https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#authenticating_to
 locals {
-  service_account = "serviceAccount:${var.gcp_project}.svc.id.goog[${kubernetes_namespace.namespace.metadata[0].name}/${kubernetes_service_account.execution_manager.metadata[0].name}]"
+  service_account = "serviceAccount:${var.gcp_project}.svc.id.goog[${kubernetes_namespace.namespace.metadata[0].name}/${kubernetes_service_account.workflow_manager.metadata[0].name}]"
 }
 
 # Allows the Kubernetes service account to impersonate the GCP service account.
-resource "google_service_account_iam_binding" "execution-manager-workload" {
+resource "google_service_account_iam_binding" "workflow_manager_workload" {
   provider           = google-beta
-  service_account_id = google_service_account.execution_manager.name
+  service_account_id = google_service_account.workflow_manager.name
   role               = "roles/iam.workloadIdentityUser"
   members = [
     local.service_account
@@ -108,18 +108,18 @@ resource "google_service_account_iam_binding" "execution-manager-workload" {
 
 # Allows the Kubernetes service account to request auth tokens for the GCP
 # service account.
-resource "google_service_account_iam_binding" "execution-manager-token" {
+resource "google_service_account_iam_binding" "workflow_manager_token" {
   provider           = google-beta
-  service_account_id = google_service_account.execution_manager.name
+  service_account_id = google_service_account.workflow_manager.name
   role               = "roles/iam.serviceAccountTokenCreator"
   members = [
     local.service_account
   ]
 }
 
-resource "kubernetes_cron_job" "execution_manager" {
+resource "kubernetes_cron_job" "workflow_manager" {
   metadata {
-    name      = "${var.environment}-execution-manager"
+    name      = "${var.environment}-workflow-manager"
     namespace = var.peer_share_processor_name
 
     annotations = {
@@ -137,7 +137,7 @@ resource "kubernetes_cron_job" "execution_manager" {
           spec {
             container {
               name  = "facilitator"
-              image = "${var.container_registry}/${var.execution_manager_image}:${var.execution_manager_version}"
+              image = "${var.container_registry}/${var.workflow_manager_image}:${var.workflow_manager_version}"
               # Write sample data to exercise writing into S3.
               args = [
                 "generate-ingestion-sample",
@@ -166,7 +166,7 @@ resource "kubernetes_cron_job" "execution_manager" {
             # https://kubernetes.io/docs/concepts/workloads/controllers/job/#handling-pod-and-container-failures
             # https://github.com/kubernetes/kubernetes/issues/74848
             restart_policy       = "Never"
-            service_account_name = kubernetes_service_account.execution_manager.metadata[0].name
+            service_account_name = kubernetes_service_account.workflow_manager.metadata[0].name
           }
         }
       }
@@ -175,5 +175,5 @@ resource "kubernetes_cron_job" "execution_manager" {
 }
 
 output "service_account_unique_id" {
-  value = google_service_account.execution_manager.unique_id
+  value = google_service_account.workflow_manager.unique_id
 }

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -12,7 +12,9 @@ variable "container_registry" {
 }
 
 variable "workflow_manager_image" {
-  type    = string
+  type = string
+  # This should be "prio-data-share-processor" but we have not yet renamed the
+  # container image
   default = "prio-facilitator"
 }
 
@@ -35,7 +37,7 @@ variable "ingestion_bucket_role" {
 
 data "aws_caller_identity" "current" {}
 
-# Each facilitator is created in its own namespace
+# Each data share processor is created in its own namespace
 resource "kubernetes_namespace" "namespace" {
   metadata {
     name = var.peer_share_processor_name
@@ -55,7 +57,7 @@ resource "kubernetes_namespace" "namespace" {
 # [1] https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity
 # [2] https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection
 
-# For each facilitator, we first create a GCP service account.
+# For each data share processor, we first create a GCP service account.
 resource "google_service_account" "workflow_manager" {
   provider = google-beta
   # The Account ID must be unique across the whole GCP project, and not just the

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -117,6 +117,46 @@ resource "google_service_account_iam_binding" "workflow_manager_token" {
   ]
 }
 
+resource "kubernetes_secret" "batch_signing_key" {
+  metadata {
+    name      = "${var.environment}-${var.peer_share_processor_name}-batch-signing-key"
+    namespace = var.peer_share_processor_name
+  }
+
+  data = {
+    # We want this to be a Terraform resource that can be managed and destroyed
+    # by this module, but we do not want the cleartext private key to appear in
+    # the TF statefile. So we set a dummy value here, and will update the value
+    # later using kubectl. We use lifecycle.ignore_changes so that Terraform
+    # won't blow away the replaced value on subsequent applies.
+    signing_key = "not-a-real-key"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      data["signing_key"]
+    ]
+  }
+}
+
+resource "kubernetes_secret" "ingestion_packet_decryption_key" {
+  metadata {
+    name      = "${var.environment}-${var.peer_share_processor_name}-ingestion-packet-decryption-key"
+    namespace = var.peer_share_processor_name
+  }
+
+  data = {
+    # See comment on batch_signing_key, above, about the initial value here.
+    decryption_key = "not-a-real-key"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      data["decryption_key"]
+    ]
+  }
+}
+
 resource "kubernetes_cron_job" "workflow_manager" {
   metadata {
     name      = "${var.environment}-workflow-manager"
@@ -156,6 +196,24 @@ resource "kubernetes_cron_job" "workflow_manager" {
                 name  = "AWS_ACCOUNT_ID"
                 value = data.aws_caller_identity.current.account_id
               }
+              env {
+                name = "BATCH_SIGNING_KEY"
+                value_from {
+                  secret_key_ref {
+                    name = kubernetes_secret.batch_signing_key.metadata[0].name
+                    key  = "signing_key"
+                  }
+                }
+              }
+              env {
+                name = "INGESTION_PACKET_DECRYPTION_KEY"
+                value_from {
+                  secret_key_ref {
+                    name = kubernetes_secret.ingestion_packet_decryption_key.metadata[0].name
+                    key  = "decryption_key"
+                  }
+                }
+              }
             }
             # If we use any other restart policy, then when the job is finally
             # deemed to be a failure, Kubernetes will destroy the job, pod and
@@ -176,4 +234,12 @@ resource "kubernetes_cron_job" "workflow_manager" {
 
 output "service_account_unique_id" {
   value = google_service_account.workflow_manager.unique_id
+}
+
+output "batch_signing_key" {
+  value = kubernetes_secret.batch_signing_key.metadata[0].name
+}
+
+output "ingestion_packet_decryption_key" {
+  value = kubernetes_secret.ingestion_packet_decryption_key.metadata[0].name
 }

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -77,7 +77,7 @@ resource "random_string" "account_id" {
 # service account above.
 resource "kubernetes_service_account" "workflow_manager" {
   metadata {
-    name      = "workflow-manager"
+    name      = "${var.data_share_processor_name}-workflow-manager"
     namespace = var.kubernetes_namespace
     annotations = {
       environment = var.environment

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -1,4 +1,4 @@
-variable "peer_share_processor_name" {
+variable "data_share_processor_name" {
   type = string
 }
 
@@ -40,7 +40,7 @@ data "aws_caller_identity" "current" {}
 # Each data share processor is created in its own namespace
 resource "kubernetes_namespace" "namespace" {
   metadata {
-    name = var.peer_share_processor_name
+    name = var.data_share_processor_name
     annotations = {
       environment = var.environment
     }
@@ -65,7 +65,7 @@ resource "google_service_account" "workflow_manager" {
   # environment and PHA name to get something unique. Instead, we generate a
   # random string.
   account_id   = "prio-${random_string.account_id.result}"
-  display_name = "prio-${var.environment}-${var.peer_share_processor_name}-workflow-manager"
+  display_name = "prio-${var.environment}-${var.data_share_processor_name}-workflow-manager"
 }
 
 resource "random_string" "account_id" {
@@ -121,8 +121,8 @@ resource "google_service_account_iam_binding" "workflow_manager_token" {
 
 resource "kubernetes_secret" "batch_signing_key" {
   metadata {
-    name      = "${var.environment}-${var.peer_share_processor_name}-batch-signing-key"
-    namespace = var.peer_share_processor_name
+    name      = "${var.environment}-${var.data_share_processor_name}-batch-signing-key"
+    namespace = var.data_share_processor_name
   }
 
   data = {
@@ -143,8 +143,8 @@ resource "kubernetes_secret" "batch_signing_key" {
 
 resource "kubernetes_secret" "ingestion_packet_decryption_key" {
   metadata {
-    name      = "${var.environment}-${var.peer_share_processor_name}-ingestion-packet-decryption-key"
-    namespace = var.peer_share_processor_name
+    name      = "${var.environment}-${var.data_share_processor_name}-ingestion-packet-decryption-key"
+    namespace = var.data_share_processor_name
   }
 
   data = {
@@ -162,7 +162,7 @@ resource "kubernetes_secret" "ingestion_packet_decryption_key" {
 resource "kubernetes_cron_job" "workflow_manager" {
   metadata {
     name      = "${var.environment}-workflow-manager"
-    namespace = var.peer_share_processor_name
+    namespace = var.data_share_processor_name
 
     annotations = {
       environment = var.environment

--- a/terraform/modules/manifest/manifest.tf
+++ b/terraform/modules/manifest/manifest.tf
@@ -1,0 +1,110 @@
+variable "environment" {
+  type = string
+}
+
+variable "gcp_region" {
+  type = string
+}
+
+variable "domain" {
+  type = string
+}
+
+data "aws_caller_identity" "current" {}
+
+# Make a bucket where we will store global and specific manifests and from which
+# peers can fetch them.
+# https://cloud.google.com/cdn/docs/setting-up-cdn-with-bucket
+resource "google_storage_bucket" "manifests" {
+  provider = google-beta
+  name     = "prio-${var.environment}-manifests"
+  location = var.gcp_region
+  # Force deletion of bucket contents on bucket destroy. Bucket contents would
+  # be re-created by a subsequent deploy so no reason to keep them around.
+  force_destroy = true
+  # Disable per-object ACLs. Everything we put in here is meant to be world-
+  # readable and this is also in line with Google's recommendation:
+  # https://cloud.google.com/storage/docs/uniform-bucket-level-access
+  uniform_bucket_level_access = true
+}
+
+# With uniform bucket level access, we must use IAM permissions as ACLs are
+# ignored.
+# https://cloud.google.com/storage/docs/uniform-bucket-level-access
+resource "google_storage_bucket_iam_binding" "public_read" {
+  bucket = google_storage_bucket.manifests.name
+  # We want to allow unauthenticated reads of manifests. This also allows
+  # listing the bucket, which could allow an attacker to enumerate the PHAs
+  # that we have deployed support for. On the other hand, the attacker could
+  # also get that information by reading the tfvars files on GitHub.
+  # https://cloud.google.com/storage/docs/access-control/lists#predefined-acl
+  role = "roles/storage.objectViewer"
+  members = [
+    "allUsers"
+  ]
+}
+
+# Puts this data share processor's global manifest into the bucket.
+resource "google_storage_bucket_object" "global_manifest" {
+  provider     = google-beta
+  name         = "global-manifest.json"
+  bucket       = google_storage_bucket.manifests.name
+  content_type = "application/json"
+  content      = <<MANIFEST
+{
+  "format": 0,
+  "aws-account-id": "${data.aws_caller_identity.current.account_id}"
+}
+MANIFEST
+}
+
+# Now we configure an external HTTPS load balancer backed by the bucket.
+resource "google_compute_managed_ssl_certificate" "manifests" {
+  provider = google-beta
+  name     = "prio-${var.environment}-manifests"
+  managed {
+    domains = [var.domain]
+  }
+}
+
+# Reserve an external IP address for the load balancer.
+# https://cloud.google.com/cdn/docs/setting-up-cdn-with-bucket#ip-address
+# TODO(timg): we should have Terraform configure DNS for the manifest domain so
+# we can point it at this IP address, without which the managed certificate will
+# not work.
+resource "google_compute_global_address" "manifests" {
+  provider = google-beta
+  name     = "prio-${var.environment}-manifests"
+}
+
+resource "google_compute_backend_bucket" "manifests" {
+  provider    = google-beta
+  name        = "prio-${var.environment}-manifest-backend"
+  bucket_name = google_storage_bucket.manifests.name
+  enable_cdn  = true
+}
+
+resource "google_compute_url_map" "manifests" {
+  provider        = google-beta
+  name            = "prio-${var.environment}-manifests"
+  default_service = google_compute_backend_bucket.manifests.id
+}
+
+resource "google_compute_target_https_proxy" "manifests" {
+  provider         = google-beta
+  name             = "prio-${var.environment}-manifests"
+  url_map          = google_compute_url_map.manifests.id
+  ssl_certificates = [google_compute_managed_ssl_certificate.manifests.id]
+}
+
+resource "google_compute_global_forwarding_rule" "manifests" {
+  provider   = google-beta
+  name       = "prio-${var.environment}-manifests"
+  ip_address = google_compute_global_address.manifests.address
+  port_range = "443"
+  target     = google_compute_target_https_proxy.manifests.id
+}
+
+output "bucket" {
+  value = google_storage_bucket.manifests.name
+}

--- a/terraform/modules/manifest/manifest.tf
+++ b/terraform/modules/manifest/manifest.tf
@@ -50,12 +50,12 @@ resource "google_storage_bucket_object" "global_manifest" {
   name         = "global-manifest.json"
   bucket       = google_storage_bucket.manifests.name
   content_type = "application/json"
-  content      = <<MANIFEST
-{
-  "format": 0,
-  "aws-account-id": "${data.aws_caller_identity.current.account_id}"
-}
-MANIFEST
+  content      = jsonencode({
+    format = 0
+    server-identity = {
+      aws-account-id = data.aws_caller_identity.current.account_id
+    }
+  })
 }
 
 # Now we configure an external HTTPS load balancer backed by the bucket.

--- a/terraform/modules/manifest/manifest.tf
+++ b/terraform/modules/manifest/manifest.tf
@@ -50,7 +50,7 @@ resource "google_storage_bucket_object" "global_manifest" {
   name         = "global-manifest.json"
   bucket       = google_storage_bucket.manifests.name
   content_type = "application/json"
-  content      = jsonencode({
+  content = jsonencode({
     format = 0
     server-identity = {
       aws-account-id = data.aws_caller_identity.current.account_id

--- a/terraform/variables/demo-gcp.tfvars
+++ b/terraform/variables/demo-gcp.tfvars
@@ -6,3 +6,8 @@ peer_share_processor_names = ["test-pha-1", "test-pha-2"]
 aws_region                 = "us-west-1"
 # Graciously donated by jrenken
 manifest_domain = "portcull.is"
+ingestors = {
+  ingestor-1 = "portcull.is/ingestor-1"
+  ingestor-2 = "portcull.is/ingestor-2"
+}
+peer_share_processor_manifest_domain = "portcull.is/pha-servers"

--- a/terraform/variables/demo-gcp.tfvars
+++ b/terraform/variables/demo-gcp.tfvars
@@ -4,3 +4,5 @@ gcp_project                = "prio-bringup-290620"
 machine_type               = "e2-small"
 peer_share_processor_names = ["test-pha-1", "test-pha-2"]
 aws_region                 = "us-west-1"
+# Graciously donated by jrenken
+manifest_domain = "portcull.is"


### PR DESCRIPTION
This PR contains a series of commits that enables us to deploy data share processors in support of arbitrarily many ingestor servers and PHAs. The specific features are discussed in each commit message. There are several missing pieces here (tests on deploy-tool, support in deploy-tool for certifying packet decryption keys, Terraform management of manifest domain and its DNS, inclusion of key-identifier in batch signatures, hooking up peer manifest discovery to arguments on facilitator) but I wanted to get all these changes visible to our team because they might inform how the workflow manager will be built, and also so that the remaining tasks could be tackled in parallel.

Partially addresses: #20 #15