### PR TITLE
facilitator: enable snappy feature on avro_rs

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -150,12 +150,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df4679042d549ad2dec299b84d64d4c3d2cd727e1a772dd6372bd9f7d71d723"
 dependencies = [
  "byteorder",
+ "crc",
  "digest",
  "libflate",
  "num-bigint",
  "rand 0.4.6",
  "serde",
  "serde_json",
+ "snap",
  "strum",
  "strum_macros",
  "thiserror",
@@ -216,6 +218,12 @@ checksum = "fa136449e765dc7faa244561ccae839c394048667929af599b5d931ebe7b7f10"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "build_const"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 
 [[package]]
 name = "bumpalo"
@@ -307,6 +315,15 @@ name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "crc"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+dependencies = [
+ "build_const",
+]
 
 [[package]]
 name = "crc32fast"
@@ -1538,6 +1555,16 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+
+[[package]]
+name = "snap"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95d697d63d44ad8b78b8d235bf85b34022a78af292c8918527c5f0cffdde7f43"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+]
 
 [[package]]
 name = "socket2"

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 
 [dependencies]
 anyhow = "1.0"
-avro-rs = "0.11.0"
+avro-rs = { version = "0.11.0", features = ["snappy"] }
 base64 = "0.12.3"
 chrono = "0.4"
 clap = "2.33.3"


### PR DESCRIPTION
We need to turn this feature on so that we can decompress Avro messages
that were compressed using the snappy codec. Happily this requires no
code changes; avro_rs automatically detects if it receives snappy
messages and decompresses appropriately.