### PR TITLE
terraform: create sum part writer service account

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -89,10 +89,11 @@ provider "kubernetes" {
 }
 
 module "manifest" {
-  source      = "./modules/manifest"
-  environment = var.environment
-  gcp_region  = var.gcp_region
-  domain      = var.manifest_domain
+  source                                = "./modules/manifest"
+  environment                           = var.environment
+  gcp_region                            = var.gcp_region
+  domain                                = var.manifest_domain
+  sum_part_bucket_service_account_email = google_service_account.sum_part_bucket_writer.email
 }
 
 module "gke" {
@@ -182,6 +183,25 @@ module "data_share_processors" {
   packet_decryption_key_kubernetes_secret = each.value.packet_decryption_key_kubernetes_secret
 
   depends_on = [module.gke]
+}
+
+# The portal owns two sum part buckets (one for each data share processor) and
+# the one for this data share processor gets configured by the portal operator
+# to permit writes from this GCP service account, whose email the portal
+# operator discovers in our global manifest.
+resource "google_service_account" "sum_part_bucket_writer" {
+  provider     = google-beta
+  account_id   = "prio-${var.environment}-sum-writer"
+  display_name = "prio-${var.environment}-sum-part-bucket-writer"
+}
+
+# Permit the service accounts for all the data share processors to impersonate
+# the sum part bucket writer.
+resource "google_service_account_iam_binding" "data_share_processors_to_sum_part_bucket_writer" {
+  provider           = google-beta
+  service_account_id = google_service_account.sum_part_bucket_writer.name
+  role               = "roles/iam.serviceAccountUser"
+  members            = [for v in module.data_share_processors : v.service_account_email]
 }
 
 output "manifest_bucket" {

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -237,6 +237,10 @@ output "kubernetes_namespace" {
   value = var.kubernetes_namespace
 }
 
+output "service_account_email" {
+  value = module.kubernetes.service_account_email
+}
+
 output "specific_manifest" {
   value = {
     format                 = 0

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -218,6 +218,10 @@ output "service_account_unique_id" {
   value = google_service_account.workflow_manager.unique_id
 }
 
+output "service_account_email" {
+  value = "serviceAccount:${google_service_account.workflow_manager.email}"
+}
+
 output "batch_signing_key" {
   value = kubernetes_secret.batch_signing_key.metadata[0].name
 }

--- a/terraform/modules/manifest/manifest.tf
+++ b/terraform/modules/manifest/manifest.tf
@@ -10,6 +10,10 @@ variable "domain" {
   type = string
 }
 
+variable "sum_part_bucket_service_account_email" {
+  type = string
+}
+
 data "aws_caller_identity" "current" {}
 
 # Make a bucket where we will store global and specific manifests and from which
@@ -53,7 +57,8 @@ resource "google_storage_bucket_object" "global_manifest" {
   content = jsonencode({
     format = 0
     server-identity = {
-      aws-account-id = data.aws_caller_identity.current.account_id
+      aws-account-id            = tonumber(data.aws_caller_identity.current.account_id)
+      gcp-service-account-email = var.sum_part_bucket_service_account_email
     }
   })
 }


### PR DESCRIPTION
As of just recently, MITRE/the portal server has assumed responsibility
for ownership of the buckets to which data share processors shall write
sum part batches. To enable them to grant write permissions to our
servers, we create a GCP service account, and advertise it from our
global manifest. We then allow all the service accounts we create for
individual data share processor instances to impersonate that account.