### PR TITLE
Reintroduce signature message and adopt it

### DIFF
--- a/avro-schema/batch-signature.avsc
+++ b/avro-schema/batch-signature.avsc
@@ -1,0 +1,17 @@
+{
+    "namespace": "org.abetterinternet.prio.v1",
+    "type": "record",
+    "name": "PrioBatchSignature",
+    "fields": [
+        {
+            "name": "batch_header_signature",
+            "type": "bytes",
+            "doc": "The signature of the Avro encoded header object in this batch, in ASN.1 DER encoded Ecdsa-Sig-Value format (as described in RFC 3279 section 2.2.3)."
+        },
+        {
+            "name": "key_identifier",
+            "type": "string",
+            "doc": "identifier of the key used to sign this batch. Can be used to look up trusted public key in a peer's global or specific manifest file."
+        }
+    ]
+}

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use ring::digest;
+use ring::{digest, signature::EcdsaKeyPair};
 use std::io::Write;
 
 pub mod aggregation;
@@ -90,4 +90,15 @@ impl<T: Write, W: Write> Write for SidecarWriter<T, W> {
         self.writer.flush()?;
         self.sidecar.flush()
     }
+}
+
+/// This struct represents a key used by this data share processor to sign
+/// batches (ingestion, validation or sum part).
+pub struct BatchSigningKey {
+    /// The ECDSA P256 key pair to use when signing batches.
+    pub key: EcdsaKeyPair,
+    /// The key identifier to be inserted into signature structures, which
+    /// must correspond to a batch-signing-key in the data share processor's
+    /// specific manifest.
+    pub identifier: String,
 }

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context, Result};
-use ring::signature::{UnparsedPublicKey, ECDSA_P256_SHA256_FIXED};
+use ring::signature::{UnparsedPublicKey, ECDSA_P256_SHA256_ASN1};
 use serde::Deserialize;
 use serde_json::from_reader;
 use std::{collections::HashMap, io::Read};
@@ -120,7 +120,7 @@ impl SpecificManifest {
         }
 
         Ok(UnparsedPublicKey::new(
-            &ECDSA_P256_SHA256_FIXED,
+            &ECDSA_P256_SHA256_ASN1,
             Vec::from(key),
         ))
     }
@@ -189,6 +189,7 @@ mod tests {
         let batch_signing_key = manifest.batch_signing_public_key("fake-key-2").unwrap();
         let content = b"some content";
         let signature = default_ingestor_private_key()
+            .key
             .sign(&SystemRandom::new(), content)
             .unwrap();
         batch_signing_key

--- a/facilitator/src/test_utils.rs
+++ b/facilitator/src/test_utils.rs
@@ -1,6 +1,7 @@
+use crate::BatchSigningKey;
 use ring::signature::{
-    EcdsaKeyPair, KeyPair, UnparsedPublicKey, ECDSA_P256_SHA256_FIXED,
-    ECDSA_P256_SHA256_FIXED_SIGNING,
+    EcdsaKeyPair, KeyPair, UnparsedPublicKey, ECDSA_P256_SHA256_ASN1,
+    ECDSA_P256_SHA256_ASN1_SIGNING,
 };
 
 /// Default keys used in testing and for sample data generation. These are
@@ -44,52 +45,70 @@ pub const DEFAULT_PHA_SUBJECT_PUBLIC_KEY_INFO: &str =
     QzOl2aiaJ6D9ZudqDdGiyA9YSUq3yia56nYJh5mk+HlzTX+AufoNR2bfrg==";
 
 /// Constructs an EcdsaKeyPair from the default ingestor server.
-pub fn default_ingestor_private_key() -> EcdsaKeyPair {
-    EcdsaKeyPair::from_pkcs8(
-        &ECDSA_P256_SHA256_FIXED_SIGNING,
-        &default_ingestor_private_key_raw(),
-    )
-    // Since we know DEFAULT_INGESTOR_PRIVATE_KEY is valid, it
-    // is ok to unwrap() here.
-    .unwrap()
-}
-
-pub fn default_ingestor_private_key_raw() -> Vec<u8> {
-    base64::decode(DEFAULT_INGESTOR_PRIVATE_KEY).unwrap()
+pub fn default_ingestor_private_key() -> BatchSigningKey {
+    BatchSigningKey {
+        key: EcdsaKeyPair::from_pkcs8(
+            &ECDSA_P256_SHA256_ASN1_SIGNING,
+            &base64::decode(DEFAULT_INGESTOR_PRIVATE_KEY).unwrap(),
+        )
+        // Since we know DEFAULT_INGESTOR_PRIVATE_KEY is valid, it
+        // is ok to unwrap() here.
+        .unwrap(),
+        identifier: "default-ingestor-signing-key".to_owned(),
+    }
 }
 
 pub fn default_ingestor_public_key() -> UnparsedPublicKey<Vec<u8>> {
     UnparsedPublicKey::new(
-        &ECDSA_P256_SHA256_FIXED,
+        &ECDSA_P256_SHA256_ASN1,
         default_ingestor_private_key()
+            .key
             .public_key()
             .as_ref()
             .to_vec(),
     )
 }
 
-pub fn default_facilitator_signing_private_key() -> EcdsaKeyPair {
-    EcdsaKeyPair::from_pkcs8(
-        &ECDSA_P256_SHA256_FIXED_SIGNING,
-        &default_facilitator_signing_private_key_raw(),
-    )
-    .unwrap()
-}
-
-pub fn default_facilitator_signing_private_key_raw() -> Vec<u8> {
-    base64::decode(DEFAULT_FACILITATOR_SIGNING_PRIVATE_KEY).unwrap()
+pub fn default_facilitator_signing_private_key() -> BatchSigningKey {
+    BatchSigningKey {
+        key: EcdsaKeyPair::from_pkcs8(
+            &ECDSA_P256_SHA256_ASN1_SIGNING,
+            &base64::decode(DEFAULT_FACILITATOR_SIGNING_PRIVATE_KEY).unwrap(),
+        )
+        .unwrap(),
+        identifier: "default-facilitator-signing-key".to_owned(),
+    }
 }
 
 pub fn default_facilitator_signing_public_key() -> UnparsedPublicKey<Vec<u8>> {
     UnparsedPublicKey::new(
-        &ECDSA_P256_SHA256_FIXED,
+        &ECDSA_P256_SHA256_ASN1,
         default_facilitator_signing_private_key()
+            .key
             .public_key()
             .as_ref()
             .to_vec(),
     )
 }
 
-pub fn default_pha_signing_private_key() -> Vec<u8> {
-    base64::decode(DEFAULT_PHA_SIGNING_PRIVATE_KEY).unwrap()
+pub fn default_pha_signing_private_key() -> BatchSigningKey {
+    BatchSigningKey {
+        key: EcdsaKeyPair::from_pkcs8(
+            &ECDSA_P256_SHA256_ASN1_SIGNING,
+            &base64::decode(DEFAULT_PHA_SIGNING_PRIVATE_KEY).unwrap(),
+        )
+        .unwrap(),
+        identifier: "default-pha-signing-key".to_owned(),
+    }
+}
+
+pub fn default_pha_signing_public_key() -> UnparsedPublicKey<Vec<u8>> {
+    UnparsedPublicKey::new(
+        &ECDSA_P256_SHA256_ASN1,
+        default_pha_signing_private_key()
+            .key
+            .public_key()
+            .as_ref()
+            .to_vec(),
+    )
 }

--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -6,17 +6,14 @@ use facilitator::{
     intake::BatchIntaker,
     sample::generate_ingestion_sample,
     test_utils::{
-        default_facilitator_signing_private_key, default_ingestor_private_key,
-        default_ingestor_private_key_raw, default_pha_signing_private_key,
-        DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY, DEFAULT_PHA_ECIES_PRIVATE_KEY,
+        default_facilitator_signing_private_key, default_facilitator_signing_public_key,
+        default_ingestor_private_key, default_ingestor_public_key, default_pha_signing_private_key,
+        default_pha_signing_public_key, DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY,
+        DEFAULT_PHA_ECIES_PRIVATE_KEY,
     },
     transport::LocalFileTransport,
 };
 use prio::{encrypt::PrivateKey, util::reconstruct_shares};
-use ring::signature::{
-    EcdsaKeyPair, KeyPair, UnparsedPublicKey, ECDSA_P256_SHA256_FIXED,
-    ECDSA_P256_SHA256_FIXED_SIGNING,
-};
 use uuid::Uuid;
 
 #[test]
@@ -43,27 +40,9 @@ fn end_to_end() {
     let pha_ecies_key = PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap();
     let facilitator_ecies_key =
         PrivateKey::from_base64(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY).unwrap();
-    let ingestor_pub_key = UnparsedPublicKey::new(
-        &ECDSA_P256_SHA256_FIXED,
-        default_ingestor_private_key()
-            .public_key()
-            .as_ref()
-            .to_vec(),
-    );
-    let pha_signing_key = EcdsaKeyPair::from_pkcs8(
-        &ECDSA_P256_SHA256_FIXED_SIGNING,
-        &default_pha_signing_private_key(),
-    )
-    .unwrap();
-    let pha_pub_signing_key = UnparsedPublicKey::new(
-        &ECDSA_P256_SHA256_FIXED,
-        pha_signing_key.public_key().as_ref().to_vec(),
-    );
-    let facilitator_signing_key = default_facilitator_signing_private_key();
-    let facilitator_pub_signing_key = UnparsedPublicKey::new(
-        &ECDSA_P256_SHA256_FIXED,
-        facilitator_signing_key.public_key().as_ref().to_vec(),
-    );
+    let ingestor_pub_key = default_ingestor_public_key();
+    let pha_pub_signing_key = default_pha_signing_public_key();
+    let facilitator_pub_signing_key = default_facilitator_signing_public_key();
 
     let batch_1_reference_sum = generate_ingestion_sample(
         &mut pha_ingest_transport,
@@ -73,7 +52,7 @@ fn end_to_end() {
         &date,
         &pha_ecies_key,
         &facilitator_ecies_key,
-        &default_ingestor_private_key_raw(),
+        &default_ingestor_private_key(),
         10,
         10,
         0.11,
@@ -94,7 +73,7 @@ fn end_to_end() {
         &date,
         &pha_ecies_key,
         &facilitator_ecies_key,
-        &default_ingestor_private_key_raw(),
+        &default_ingestor_private_key(),
         10,
         10,
         0.11,
@@ -107,6 +86,7 @@ fn end_to_end() {
         batch_2_reference_sum.err()
     );
 
+    let pha_signing_key = default_pha_signing_private_key();
     let res = BatchIntaker::new(
         &aggregation_name,
         &batch_1_uuid,
@@ -145,6 +125,7 @@ fn end_to_end() {
         res.err()
     );
 
+    let facilitator_signing_key = default_facilitator_signing_private_key();
     let res = BatchIntaker::new(
         &aggregation_name,
         &batch_1_uuid,


### PR DESCRIPTION
When evaluating a batch, a data share processor needs the identifier of the key it was signed with so it can look up the right public key in the peer's manifest. These commits reintroduce that Avro structure and teaches facilitator to use it when reading and writing batches.

Addresses #25