### PR TITLE
protocol: make encryption_key_id optional

### DIFF
--- a/avro-schema/ingestion-data-share-packet.avsc
+++ b/avro-schema/ingestion-data-share-packet.avsc
@@ -16,7 +16,10 @@
         },
         {
             "name": "encryption_key_id",
-            "type": "string",
+            "type": [
+                "null",
+                "string"
+            ],
             "doc": "Encryption key identifier (e.g., to support key rotations)"
         },
         {

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -303,7 +303,7 @@ mod tests {
             IngestionDataSharePacket {
                 uuid: Uuid::new_v4(),
                 encrypted_payload: vec![0u8, 1u8, 2u8, 3u8],
-                encryption_key_id: "fake-key-1".to_owned(),
+                encryption_key_id: Some("fake-key-1".to_owned()),
                 r_pit: 1,
                 version_configuration: Some("config-1".to_owned()),
                 device_nonce: None,
@@ -311,7 +311,7 @@ mod tests {
             IngestionDataSharePacket {
                 uuid: Uuid::new_v4(),
                 encrypted_payload: vec![4u8, 5u8, 6u8, 7u8],
-                encryption_key_id: "fake-key-2".to_owned(),
+                encryption_key_id: None,
                 r_pit: 2,
                 version_configuration: None,
                 device_nonce: Some(vec![8u8, 9u8, 10u8, 11u8]),
@@ -319,7 +319,7 @@ mod tests {
             IngestionDataSharePacket {
                 uuid: Uuid::new_v4(),
                 encrypted_payload: vec![8u8, 9u8, 10u8, 11u8],
-                encryption_key_id: "fake-key-3".to_owned(),
+                encryption_key_id: Some("fake-key-3".to_owned()),
                 r_pit: 3,
                 version_configuration: None,
                 device_nonce: None,

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -91,7 +91,7 @@ pub fn generate_ingestion_sample(
                         let pha_packet = IngestionDataSharePacket {
                             uuid: packet_uuid,
                             encrypted_payload: pha_share,
-                            encryption_key_id: "pha-fake-key-1".to_owned(),
+                            encryption_key_id: Some("pha-fake-key-1".to_owned()),
                             r_pit: u32::from(r_pit) as i64,
                             version_configuration: Some("config-1".to_owned()),
                             device_nonce: None,
@@ -102,7 +102,7 @@ pub fn generate_ingestion_sample(
                         let facilitator_packet = IngestionDataSharePacket {
                             uuid: packet_uuid,
                             encrypted_payload: facilitator_share,
-                            encryption_key_id: "facilitator-fake-key-1".to_owned(),
+                            encryption_key_id: None,
                             r_pit: u32::from(r_pit) as i64,
                             version_configuration: Some("config-1".to_owned()),
                             device_nonce: None,


### PR DESCRIPTION
Ingestion servers will not all be populating the encryption_key_id field
in PrioDataSharePacket, so we need to make that an optional field in the
Avro message.

Addresses #73 