### PR TITLE
terraform: Google Cloud DNS for manifest domain

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -38,6 +38,10 @@ variable "manifest_domain" {
   description = "Domain (plus optional relative path) to which this environment's global and specific manifests should be uploaded."
 }
 
+variable "managed_dns_zone" {
+  type = map(string)
+}
+
 variable "peer_share_processor_manifest_domain" {
   type = string
 }
@@ -92,7 +96,7 @@ module "manifest" {
   source                                = "./modules/manifest"
   environment                           = var.environment
   gcp_region                            = var.gcp_region
-  domain                                = var.manifest_domain
+  managed_dns_zone                      = var.managed_dns_zone
   sum_part_bucket_service_account_email = google_service_account.sum_part_bucket_writer.email
 }
 

--- a/terraform/variables/demo-gcp.tfvars
+++ b/terraform/variables/demo-gcp.tfvars
@@ -4,10 +4,13 @@ gcp_project                = "prio-bringup-290620"
 machine_type               = "e2-small"
 peer_share_processor_names = ["test-pha-1", "test-pha-2"]
 aws_region                 = "us-west-1"
-# Graciously donated by jrenken
-manifest_domain = "portcull.is"
-ingestors = {
-  ingestor-1 = "portcull.is/ingestor-1"
-  ingestor-2 = "portcull.is/ingestor-2"
+manifest_domain            = "isrg-prio.org"
+managed_dns_zone = {
+  name        = "manifests"
+  gcp_project = "prio-bringup-290620"
 }
-peer_share_processor_manifest_domain = "portcull.is/pha-servers"
+ingestors = {
+  ingestor-1 = "storage.googleapis.com/prio-demo-gcp-manifests/ingestor-1"
+  ingestor-2 = "storage.googleapis.com/prio-demo-gcp-manifests/ingestor-2"
+}
+peer_share_processor_manifest_domain = "storage.googleapis.com/prio-demo-gcp-manifests/pha-servers"


### PR DESCRIPTION
Up until now, we had been using jrenken's donated domain portcull.is to
serve manifests. Amir bought us isrg-prio.org the other day, so we can
use the <env>.manifests.isrg-prio.org namespace now. Additionally, we
can now use a GCP managed DNS zone for manifests.isrg-prio.org. and
use Terraform to create A records in there for specific envs.