### PR TITLE
Remove deploy-tool invocation from Makefile.

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -88,7 +88,7 @@ apply: prep ## Have terraform do the things. This will cost money.
 		-input=false \
 		-refresh=true \
 		-var-file="$(VARS)"
-	@terraform output --json | go run ../deploy-tool/main.go
+	echo "If that succeeded, run 'terraform output --json | (cd ../deploy-tool/ ; go run main.go )'"
 
 .PHONY: apply-target
 apply-target: prep ## Have terraform do the things for a specific resource. This will cost money.


### PR DESCRIPTION
Since the Makefile currently proceeds on errors,
the deploy-tool invocation can obscure errors during make apply.