### PR TITLE
facilitator: Add GCSTransport

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -116,6 +116,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
+name = "assert-json-diff"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4259cbe96513d2f1073027a259fc2ca917feb3026a5a8d984e3628e490255cc0"
+dependencies = [
+ "extend",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +312,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +461,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +518,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "extend"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47da3a72ec598d9c8937a7ebca8962a5c7a1f28444e38c2b33c771ba3f55f05"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "facilitator"
 version = "0.1.0"
 dependencies = [
@@ -502,6 +542,7 @@ dependencies = [
  "derivative",
  "hyper",
  "hyper-rustls 0.21.0",
+ "mockito",
  "once_cell",
  "pem",
  "prio",
@@ -520,6 +561,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "ureq",
+ "urlencoding",
  "uuid",
  "vergen",
 ]
@@ -1003,6 +1045,24 @@ checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
 dependencies = [
  "socket2",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "mockito"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a634720d366bcbce30fb05871a35da229cef101ad0b2ea4e46cf5abf031a273"
+dependencies = [
+ "assert-json-diff",
+ "colored",
+ "difference",
+ "httparse",
+ "lazy_static",
+ "log",
+ "rand 0.7.3",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
 ]
 
 [[package]]
@@ -2204,6 +2264,8 @@ dependencies = [
  "once_cell",
  "qstring",
  "rustls 0.18.1",
+ "serde",
+ "serde_json",
  "url",
  "webpki",
  "webpki-roots",
@@ -2219,6 +2281,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9232eb53352b4442e40d7900465dfc534e8cb2dc8f18656fcb2ac16112b5593"
 
 [[package]]
 name = "uuid"

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -9,7 +9,7 @@ build = "build.rs"
 anyhow = "1.0"
 avro-rs = { version = "0.11.0", features = ["snappy"] }
 base64 = "0.12.3"
-chrono = "0.4"
+chrono = { version ="0.4", features = ["serde"] }
 clap = "2.33.3"
 derivative = "2.1.1"
 hyper = "0.13.8"
@@ -29,7 +29,8 @@ structopt = "0.3"
 tempfile = "3.1.0"
 thiserror = "1.0"
 tokio = { version = "0.2", features = ["rt-core", "io-util"] }
-ureq = "1.5.1"
+ureq = { version = "1.5.1", features = ["json"] }
+urlencoding = "1.1.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [build-dependencies]
@@ -37,5 +38,6 @@ vergen = "3"
 
 [dev-dependencies]
 assert_matches = "1.4.0"
+mockito = "0.27.0"
 rusoto_mock = { version = "0.45.0", default_features = false, features = ["rustls"] }
 serde_test = "1.0"

--- a/facilitator/src/aggregation.rs
+++ b/facilitator/src/aggregation.rs
@@ -143,7 +143,7 @@ impl<'a> BatchAggregator<'a> {
         batch_id: &Uuid,
         batch_date: &NaiveDateTime,
     ) -> Result<IngestionHeader> {
-        let ingestion_batch: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
+        let mut ingestion_batch: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchReader::new(
                 Batch::new_ingestion(self.aggregation_name, batch_id, batch_date),
                 self.ingestion_transport,
@@ -163,17 +163,17 @@ impl<'a> BatchAggregator<'a> {
         server: &mut prio::server::Server,
         invalid_uuids: &mut Vec<Uuid>,
     ) -> Result<()> {
-        let ingestion_batch: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
+        let mut ingestion_batch: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchReader::new(
                 Batch::new_ingestion(self.aggregation_name, batch_id, batch_date),
                 self.ingestion_transport,
             );
-        let own_validation_batch: BatchReader<'_, ValidationHeader, ValidationPacket> =
+        let mut own_validation_batch: BatchReader<'_, ValidationHeader, ValidationPacket> =
             BatchReader::new(
                 Batch::new_validation(self.aggregation_name, batch_id, batch_date, self.is_first),
                 self.own_validation_transport,
             );
-        let peer_validation_batch: BatchReader<'_, ValidationHeader, ValidationPacket> =
+        let mut peer_validation_batch: BatchReader<'_, ValidationHeader, ValidationPacket> =
             BatchReader::new(
                 Batch::new_validation(self.aggregation_name, batch_id, batch_date, !self.is_first),
                 self.peer_validation_transport,

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -123,7 +123,7 @@ impl<'a, H: Header, P: Packet> BatchReader<'a, H, P> {
 
     /// Return the parsed header from this batch, but only if its signature is
     /// valid.
-    pub fn header(&self, key: &UnparsedPublicKey<Vec<u8>>) -> Result<H> {
+    pub fn header(&mut self, key: &UnparsedPublicKey<Vec<u8>>) -> Result<H> {
         let signature = BatchSignature::read(self.transport.get(self.batch.signature_key())?)?;
 
         let mut header_buf = Vec::new();
@@ -141,7 +141,7 @@ impl<'a, H: Header, P: Packet> BatchReader<'a, H, P> {
     /// Return an avro_rs::Reader that yields the packets in the packet file,
     /// but only if the whole file's digest matches the packet_file_digest field
     /// in the provided header. The header is assumed to be trusted.
-    pub fn packet_file_reader(&self, header: &H) -> Result<Reader<Cursor<Vec<u8>>>> {
+    pub fn packet_file_reader(&mut self, header: &H) -> Result<Reader<Cursor<Vec<u8>>>> {
         // Fetch packet file to validate its digest. It could be quite large so
         // so our intuition would be to stream the packets from the transport
         // and into a hasher and into the validation step, so that we wouldn't
@@ -288,7 +288,7 @@ mod tests {
         base_path: String,
         filenames: &[String],
         batch_writer: &mut BatchWriter<'a, IngestionHeader, IngestionDataSharePacket>,
-        batch_reader: &BatchReader<'a, IngestionHeader, IngestionDataSharePacket>,
+        batch_reader: &mut BatchReader<'a, IngestionHeader, IngestionDataSharePacket>,
         transport: &mut LocalFileTransport,
         write_key: &EcdsaKeyPair,
         read_key: &UnparsedPublicKey<Vec<u8>>,
@@ -421,7 +421,7 @@ mod tests {
                 Batch::new_ingestion(&aggregation_name, &batch_id, &date),
                 &mut write_transport,
             );
-        let batch_reader: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
+        let mut batch_reader: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchReader::new(
                 Batch::new_ingestion(&aggregation_name, &batch_id, &date),
                 &mut read_transport,
@@ -447,7 +447,7 @@ mod tests {
                 "batch.sig".to_owned(),
             ],
             &mut batch_writer,
-            &batch_reader,
+            &mut batch_reader,
             &mut verify_transport,
             &default_ingestor_private_key().key,
             &read_key,
@@ -490,7 +490,7 @@ mod tests {
                 Batch::new_validation(&aggregation_name, &batch_id, &date, is_first),
                 &mut write_transport,
             );
-        let batch_reader: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
+        let mut batch_reader: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchReader::new(
                 Batch::new_validation(&aggregation_name, &batch_id, &date, is_first),
                 &mut read_transport,
@@ -526,7 +526,7 @@ mod tests {
                 second_filenames
             },
             &mut batch_writer,
-            &batch_reader,
+            &mut batch_reader,
             &mut verify_transport,
             &default_ingestor_private_key().key,
             &read_key,
@@ -570,7 +570,7 @@ mod tests {
                 Batch::new_sum(&aggregation_name, &start, &end, is_first),
                 &mut write_transport,
             );
-        let batch_reader: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
+        let mut batch_reader: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchReader::new(
                 Batch::new_sum(&aggregation_name, &start, &end, is_first),
                 &mut read_transport,
@@ -606,7 +606,7 @@ mod tests {
                 second_filenames
             },
             &mut batch_writer,
-            &batch_reader,
+            &mut batch_reader,
             &mut verify_transport,
             &default_ingestor_private_key().key,
             &read_key,

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -149,7 +149,7 @@ mod tests {
     "batch-signing-public-keys": {{
         "fake-key-2": {{
         "expiration": "",
-        "public-key": "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----"
+        "public-key": "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----\n"
       }}
     }},
     "ingestion-bucket": "us-west-1/ingestion",
@@ -166,7 +166,7 @@ mod tests {
             BatchSigningPublicKey {
                 expiration: "".to_string(),
                 public_key: format!(
-                    "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----",
+                    "-----BEGIN PUBLIC KEY-----\n{}\n-----END PUBLIC KEY-----\n",
                     DEFAULT_INGESTOR_SUBJECT_PUBLIC_KEY_INFO
                 ),
             },
@@ -319,7 +319,7 @@ mod tests {
     "batch-signing-public-keys": {
         "fake-key-2": {
         "expiration": "",
-        "public-key": "-----BEGIN PUBLIC KEY-----\ndG9vIHNob3J0Cg==\n-----END PUBLIC KEY-----"
+        "public-key": "-----BEGIN PUBLIC KEY-----\ndG9vIHNob3J0Cg==\n-----END PUBLIC KEY-----\n"
       }
     },
     "ingestion-bucket": "us-west-1/ingestion",

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -195,7 +195,7 @@ mod tests {
         assert!(res.is_ok(), "error writing sample data {:?}", res.err());
         let expected_path = format!("fake-aggregation/2009/02/13/23/31/{}.batch", batch_uuid);
 
-        let transports = &[pha_transport, facilitator_transport];
+        let transports = &mut [pha_transport, facilitator_transport];
         for transport in transports {
             let reader = transport.get(&expected_path);
             assert!(res.is_ok(), "error reading header back {:?}", res.err());

--- a/facilitator/src/transport.rs
+++ b/facilitator/src/transport.rs
@@ -1,3 +1,4 @@
+mod gcs;
 mod local;
 mod s3;
 
@@ -7,6 +8,7 @@ use std::{
     io::{Read, Write},
 };
 
+pub use gcs::GCSTransport;
 pub use local::LocalFileTransport;
 pub use s3::S3Transport;
 
@@ -39,7 +41,7 @@ impl<T: TransportWriter + ?Sized> TransportWriter for Box<T> {
 pub trait Transport {
     /// Returns an std::io::Read instance from which the contents of the value
     /// of the provided key may be read.
-    fn get(&self, key: &str) -> Result<Box<dyn Read>>;
+    fn get(&mut self, key: &str) -> Result<Box<dyn Read>>;
     /// Returns an std::io::Write instance into which the contents of the value
     /// may be written.
     fn put(&mut self, key: &str) -> Result<Box<dyn TransportWriter>>;

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -1,0 +1,601 @@
+use crate::{
+    config::GCSPath,
+    transport::{Transport, TransportWriter},
+    Error,
+};
+use anyhow::{anyhow, Context, Result};
+use chrono::{prelude::Utc, DateTime, Duration};
+use serde::Deserialize;
+use std::{
+    io::{Cursor, Read, Write},
+    mem,
+};
+
+const STORAGE_API_BASE_URL: &str = "https://storage.googleapis.com";
+const DEFAULT_OAUTH_TOKEN_URL: &str =
+    "http://metadata.google.internal:80/computeMetadata/v1/instance/service-accounts/default/token";
+
+// A wrapper around an Oauth token and its expiration date.
+#[derive(Debug)]
+struct OauthToken {
+    token: String,
+    expiration: DateTime<Utc>,
+}
+
+impl OauthToken {
+    // Returns true if the token is not yet expired.
+    fn expired(&self) -> bool {
+        Utc::now() < self.expiration
+    }
+}
+
+// Represents the response from a GET request to the GKE metadata service's
+// service account token endpoint. Structure is derived from empirical
+// observation of the JSON scraped from inside a GKE job.
+#[derive(Debug, Deserialize, PartialEq)]
+struct MetadataServiceTokenResponse {
+    access_token: String,
+    expires_in: i64,
+    token_type: String,
+}
+
+// Represents the response from a POST request to the GCP IAM service's
+// generateAccessToken endpoint.
+// https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct GenerateAccessTokenResponse {
+    access_token: String,
+    expire_time: DateTime<Utc>,
+}
+
+// OauthTokenProvider manages a default service account Oauth token (i.e. the
+// one for a GCP service account mapped to a Kubernetes service account) and an
+// Oauth token used to impersonate another service account.
+struct OauthTokenProvider {
+    service_account_to_impersonate: Option<String>,
+    default_service_account_oauth_token: Option<OauthToken>,
+    impersonated_service_account_oauth_token: Option<OauthToken>,
+}
+
+impl OauthTokenProvider {
+    // Creates a token provider which can impersonate the specified service
+    // account.
+    fn new(service_account_to_impersonate: Option<String>) -> OauthTokenProvider {
+        OauthTokenProvider {
+            service_account_to_impersonate,
+            default_service_account_oauth_token: None,
+            impersonated_service_account_oauth_token: None,
+        }
+    }
+
+    fn ensure_storage_access_oauth_token(&mut self) -> Result<String> {
+        match self.service_account_to_impersonate {
+            Some(_) => self.ensure_impersonated_service_account_oauth_token(),
+            None => self.ensure_default_service_account_oauth_token(),
+        }
+    }
+
+    // Obtains an Oauth token for the default service account, if one is not
+    // already held or if it has expired. Otherwise returns a copy of the token.
+    // The returned value is an owned reference because the token owned by this
+    // struct could change while the caller is still holding the returned token.
+    fn ensure_default_service_account_oauth_token(&mut self) -> Result<String> {
+        match &self.default_service_account_oauth_token {
+            Some(token) if !token.expired() => Ok(token.token.clone()),
+            _ => {
+                let http_response = ureq::get(DEFAULT_OAUTH_TOKEN_URL)
+                    .set("Metadata-Flavor", "Google")
+                    // By default, ureq will wait forever to connect or
+                    // read.
+                    .timeout_connect(10_000) // ten seconds
+                    .timeout_read(10_000) // ten seconds
+                    .call();
+                if http_response.error() {
+                    return Err(anyhow!(
+                        "failed to query GKE metadata service: {:?}",
+                        http_response
+                    ));
+                }
+
+                let response = http_response
+                    .into_json_deserialize::<MetadataServiceTokenResponse>()
+                    .context("failed to deserialize response from GKE metadata service")?;
+
+                if response.token_type != "Bearer" {
+                    return Err(anyhow!("unexpected token type {}", response.token_type));
+                }
+
+                self.default_service_account_oauth_token = Some(OauthToken {
+                    token: response.access_token.clone(),
+                    expiration: Utc::now() + Duration::seconds(response.expires_in),
+                });
+
+                Ok(response.access_token)
+            }
+        }
+    }
+
+    // Obtains an Oauth token to impersonate the service account this provider
+    // was set up with, if one is not already held or it has expired. Otherwise
+    // reutrns a copy of the valid token.
+    fn ensure_impersonated_service_account_oauth_token(&mut self) -> Result<String> {
+        if self.service_account_to_impersonate.is_none() {
+            return Err(anyhow!("no service account to impersonate was provided"));
+        }
+        let service_account_to_impersonate = self.service_account_to_impersonate.clone().unwrap();
+        // API reference:
+        // https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
+        let request_url = format!("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}:generateAccessToken",
+            service_account_to_impersonate);
+        let http_response = ureq::post(&request_url)
+            .set(
+                "Authorization",
+                &format!(
+                    "Bearer {}",
+                    self.ensure_default_service_account_oauth_token()?
+                ),
+            )
+            .set("Content-Type", "application/json")
+            // At the moment, these tokens are only used to read and write from
+            // GCS buckets, so we request an appropriate scope. We could further
+            // narrow this to a devstorage.read token if we knew what it was
+            // going to be used for, but that would require this object to
+            // manage two impersonation tokens which is more work than I want to
+            // do right now.
+            // https://cloud.google.com/storage/docs/authentication#oauth-scopes
+            .send_json(ureq::json!({
+                "scope": [
+                    "https://www.googleapis.com/auth/devstorage.read_write"
+                ]
+            }));
+        if http_response.error() {
+            return Err(anyhow!(
+                "failed to get Oauth token to impersonate service account {}: {:?}",
+                service_account_to_impersonate,
+                http_response
+            ));
+        }
+
+        let response = http_response
+            .into_json_deserialize::<GenerateAccessTokenResponse>()
+            .context("failed to deserialize response from IAM API")?;
+        self.impersonated_service_account_oauth_token = Some(OauthToken {
+            token: response.access_token.clone(),
+            expiration: response.expire_time,
+        });
+
+        Ok(response.access_token)
+    }
+}
+
+// GCSTransport manages reading and writing from GCS buckets. Currently, the
+// only authentication it supports is by means of impersonating a specified GCP
+// service account, which is assumed to have the necessary read or write
+// permissions on the bucket.
+pub struct GCSTransport {
+    path: GCSPath,
+    oauth_token_provider: OauthTokenProvider,
+}
+
+impl GCSTransport {
+    pub fn new(path: GCSPath, impersonate: Option<String>) -> GCSTransport {
+        GCSTransport {
+            path: path.ensure_directory_prefix(),
+            oauth_token_provider: OauthTokenProvider::new(impersonate),
+        }
+    }
+}
+
+impl Transport for GCSTransport {
+    fn get(&mut self, key: &str) -> Result<Box<dyn Read>> {
+        // Per API reference, the object key must be URL encoded.
+        // API reference: https://cloud.google.com/storage/docs/json_api/v1/objects/get
+        let encoded_key = urlencoding::encode(&[&self.path.key, key].concat());
+        let url = format!(
+            "{}/storage/v1/b/{}/o/{}",
+            STORAGE_API_BASE_URL, self.path.bucket, encoded_key
+        );
+
+        let response = ureq::get(&url)
+            // Ensures response body will be content and not JSON metadata.
+            // https://cloud.google.com/storage/docs/json_api/v1/objects/get#parameters
+            .query("alt", "media")
+            .set(
+                "Authorization",
+                &format!(
+                    "Bearer {}",
+                    self.oauth_token_provider
+                        .ensure_storage_access_oauth_token()?
+                ),
+            )
+            // By default, ureq will wait forever to connect or read
+            .timeout_connect(10_000) // ten seconds
+            .timeout_read(10_000) // ten seconds
+            .call();
+        if response.error() {
+            return Err(anyhow!(
+                "failed to fetch object {} from GCS: {:?}",
+                url,
+                response
+            ));
+        }
+        Ok(Box::new(response.into_reader()))
+    }
+
+    fn put(&mut self, key: &str) -> Result<Box<dyn TransportWriter>> {
+        // The Oauth token will only be used once, during the call to
+        // StreamingTransferWriter::new, so we don't have to worry about it
+        // expiring during the lifetime of that object, and so obtain a token
+        // here instead of passing the token provider into the
+        // StreamingTransferWriter.
+        let oauth_token = self
+            .oauth_token_provider
+            .ensure_storage_access_oauth_token()?;
+        Ok(Box::new(StreamingTransferWriter::new(
+            self.path.bucket.to_owned(),
+            [&self.path.key, key].concat(),
+            // GCP documentation recommends setting upload part size to 8 MiB.
+            // https://cloud.google.com/storage/docs/performing-resumable-uploads#chunked-upload
+            8_388_608,
+            oauth_token,
+        )?))
+    }
+}
+
+// StreamingTransferWriter implements GCS's resumable, streaming upload feature,
+// allowing us to stream data into the GCS buckets.
+//
+// The GCS resumable, streaming upload API is, frankly, diabolical. The idea is
+// that you initiate a transfer with a POST request to an upload endpoint, as in
+// StreamingTransferWriter::new_with_api_url, which gets you an upload session
+// URI. Then, you perform multiple PUTs to the session URI that each have a
+// Content-Range header indicating which chunk of the object they make up. As we
+// don't know the final length of the object, we set Content-Range: bytes x-y/*,
+// where x and y are the indices of the current slice. We indicate that an
+// object upload is finished by setting the final, total size of the object in
+// the last field of the Content-Range header in the last PUT request to the
+// upload session URI.
+// Now, Google mandates that upload chunks be at least 256 KiB, and recommend a
+// chunk size of 8 MiB. Where it gets hair raising is that there's no guarantee
+// a whole chunk will be uploaded at once: responses to the PUT requests include
+// a Range header telling you how much of the chunk Google got, so you can build
+// the next PUT request appropriately. So suppose you are trying to upload an 8
+// MiB chunk from the middle of the overall object, and you succeed, but Google
+// tells you they didn't get the last 100 KiB. You might right away want to
+// upload that last 100 KiB, but if you try, you will fail because it's not the
+// final chunk and it's less than 256 KiB. So we do two special things in
+// upload_chunk when we know it's the last chunk: (1) we construct the Content-
+// Range header without any asterisks (2) we drain self.buffer.
+struct StreamingTransferWriter {
+    upload_session_uri: String,
+    minimum_upload_chunk_size: usize,
+    object_upload_position: usize,
+    buffer: Vec<u8>,
+}
+
+impl StreamingTransferWriter {
+    fn new(
+        bucket: String,
+        object: String,
+        minimum_upload_chunk_size: usize,
+        oauth_token: String,
+    ) -> Result<StreamingTransferWriter> {
+        StreamingTransferWriter::new_with_api_url(
+            bucket,
+            object,
+            minimum_upload_chunk_size,
+            oauth_token,
+            STORAGE_API_BASE_URL,
+        )
+    }
+
+    fn new_with_api_url(
+        bucket: String,
+        object: String,
+        minimum_upload_chunk_size: usize,
+        oauth_token: String,
+        storage_api_base_url: &str,
+    ) -> Result<StreamingTransferWriter> {
+        // Initiate the resumable, streaming upload. Unlike the GET side, the
+        // key is provided as a query parameter here, and thus doesn't need to
+        // be URL encoded.
+        // https://cloud.google.com/storage/docs/performing-resumable-uploads#initiate-session
+        let upload_url = format!(
+            "{}/upload/storage/v1/b/{}/o/?uploadType=resumable&name={}",
+            storage_api_base_url, bucket, object
+        );
+        let http_response = ureq::post(&upload_url)
+            .set("Authorization", &format!("Bearer {}", oauth_token))
+            .set("Content-Length", "0")
+            // By default, ureq will wait forever to connect or read
+            .timeout_connect(10_000) // ten seconds
+            .timeout_read(10_000) // ten seconds
+            .call();
+        if http_response.error() {
+            return Err(anyhow!(
+                "failed to initiate streaming transfer: {:?}",
+                http_response
+            ));
+        }
+
+        // The upload session URI authenticates subsequent upload requests for
+        // this upload, so we no longer need the impersonated service account's
+        // Oauth token. Session URIs are valid for a week, which should be more
+        // than enough for any upload we perform.
+        // https://cloud.google.com/storage/docs/resumable-uploads#session-uris
+        let upload_session_uri = match http_response.header("Location") {
+            Some(location) => location,
+            None => {
+                return Err(anyhow!(
+                    "no Location header in response when initiating streaming transfer"
+                ))
+            }
+        };
+
+        Ok(StreamingTransferWriter {
+            minimum_upload_chunk_size,
+            buffer: Vec::with_capacity(minimum_upload_chunk_size * 2),
+            object_upload_position: 0,
+            upload_session_uri: upload_session_uri.to_owned(),
+        })
+    }
+
+    fn upload_chunk(&mut self, last_chunk: bool) -> Result<()> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+
+        let chunk = mem::replace(
+            &mut self.buffer,
+            Vec::with_capacity(self.minimum_upload_chunk_size * 2),
+        );
+        let chunk_len = chunk.len();
+        // We may not yet be at the last chunk, and hence may not know the total
+        // length of eventual complete object, but this variable the total
+        // length of all the bytes fed into write(), even if we haven't uploaded
+        // them all yet.
+        let object_length_thus_far = self.object_upload_position + chunk_len;
+
+        // When this is the last piece being uploaded, the Content-Range header
+        // should include the total object size, but otherwise should have * to
+        // indicate to GCS that there is an unknown further amount to come.
+        // https://cloud.google.com/storage/docs/streaming#streaming_uploads
+        let content_range_header_total_length_field = if last_chunk {
+            format!("{}", object_length_thus_far)
+        } else {
+            "*".to_owned()
+        };
+        let content_range = format!(
+            "bytes {}-{}/{}",
+            self.object_upload_position,
+            object_length_thus_far - 1,
+            content_range_header_total_length_field
+        );
+
+        // ureq::Request::send takes possession of the argument so we must clone
+        // here, in case the entire chunk doesn't get uploaded successfully.
+        let body = Cursor::new(chunk.clone());
+
+        let http_response = ureq::put(&self.upload_session_uri)
+            .set("Content-Length", &format!("{}", chunk_len))
+            .set("Content-Range", &content_range)
+            // By default, ureq will wait forever to connect or read
+            .timeout_connect(10_000) // ten seconds
+            .timeout_read(10_000) // ten seconds
+            .send(body);
+
+        // On success we expect HTTP 308 Resume Incomplete and a Range: header,
+        // unless this is the last part and the server accepts the entire
+        // provided Content-Range, in which case it's HTTP 200, or 201 (?).
+        // https://cloud.google.com/storage/docs/performing-resumable-uploads#chunked-upload
+        match http_response.status() {
+            200 | 201 => {
+                if !last_chunk {
+                    return Err(anyhow!(
+                        "received HTTP 200 or 201 response with chunks remaining"
+                    ));
+                }
+            }
+            308 => {
+                if !http_response.has("Range") {
+                    return Err(anyhow!(
+                        "No range header in response from GCS: {:?}",
+                        http_response.into_string()
+                    ));
+                }
+                let range_header = http_response.header("Range").unwrap();
+                // The range header is like "bytes=111-222", and represents a
+                // range in the overall object, not the current chunk.
+                let range = range_header
+                    .strip_prefix("bytes=")
+                    .context(format!("unexpected Range header {}", range_header))?;
+                let mut values = range.splitn(2, '-');
+                let start = values
+                    .next()
+                    .context(format!("unexpected Range header {}", range_header))?
+                    .parse::<usize>()
+                    .context(format!("unexpected Range header {}", range_header))?;
+                let end = values
+                    .next()
+                    .context(format!("unexpected Range header {}", range_header))?
+                    .parse::<usize>()
+                    .context(format!("unexpected Range header {}", range_header))?;
+
+                if start != self.object_upload_position {
+                    return Err(anyhow!("unexpected Range header {}", range_header));
+                }
+
+                self.object_upload_position = end + 1;
+
+                // If we have a little content left over, we can't just make
+                // another request, because if there's too little of it, Google
+                // will reject it. Instead, put the portion of the chunk that we
+                // didn't manage to upload back into self.buffer so it can be
+                // handled by a subsequent call to upload_chunk.
+                self.buffer
+                    .extend_from_slice(&chunk[self.object_upload_position - start..]);
+            }
+            _ => {
+                return Err(anyhow!(
+                    "failed to upload part to GCS: {} synthetic: {}\n{:?}",
+                    http_response.status(),
+                    http_response.synthetic(),
+                    http_response.into_string()
+                ))
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Write for StreamingTransferWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        // Write into memory buffer, and upload to GCS if we have accumulated
+        // enough content
+        self.buffer.extend_from_slice(buf);
+        if self.buffer.len() >= self.minimum_upload_chunk_size {
+            self.upload_chunk(false).map_err(|e| {
+                std::io::Error::new(std::io::ErrorKind::Other, Error::AnyhowError(e))
+            })?;
+        }
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl TransportWriter for StreamingTransferWriter {
+    fn complete_upload(&mut self) -> Result<()> {
+        while !self.buffer.is_empty() {
+            self.upload_chunk(true)?;
+        }
+        Ok(())
+    }
+
+    fn cancel_upload(&mut self) -> Result<()> {
+        // https://cloud.google.com/storage/docs/performing-resumable-uploads#cancel-upload
+        let http_response = ureq::delete(&self.upload_session_uri)
+            .set("Content-Length", "0")
+            // By default, ureq will wait forever to connect or read
+            .timeout_connect(10_000) // ten seconds
+            .timeout_read(10_000) // ten seconds
+            .call();
+        if http_response.status() != 499 {
+            return Err(anyhow!(
+                "failed to cancel streaming transfer to GCS: {:?}",
+                http_response
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::{mock, Matcher};
+
+    #[test]
+    fn simple_upload() {
+        let fake_upload_session_uri = format!("{}/fake-session-uri", mockito::server_url());
+        let mocked_post = mock("POST", "/upload/storage/v1/b/fake-bucket/o/")
+            .match_header("Authorization", "Bearer fake-token")
+            .match_header("Content-Length", "0")
+            .match_query(Matcher::UrlEncoded(
+                "uploadType".to_owned(),
+                "resumable".to_owned(),
+            ))
+            .match_query(Matcher::UrlEncoded(
+                "name".to_owned(),
+                "fake-object".to_owned(),
+            ))
+            .with_status(200)
+            .with_header("Location", &fake_upload_session_uri)
+            .expect_at_most(1)
+            .create();
+
+        let mut writer = StreamingTransferWriter::new_with_api_url(
+            "fake-bucket".to_string(),
+            "fake-object".to_string(),
+            10,
+            "fake-token".to_string(),
+            &mockito::server_url(),
+        )
+        .unwrap();
+
+        mocked_post.assert();
+
+        let mocked_put = mock("PUT", "/fake-session-uri")
+            .match_header("Content-Length", "7")
+            .match_header("Content-Range", "bytes 0-6/7")
+            .match_body("content")
+            .with_status(200)
+            .expect_at_most(1)
+            .create();
+
+        assert_eq!(writer.write(b"content").unwrap(), 7);
+        writer.complete_upload().unwrap();
+
+        mocked_put.assert();
+    }
+
+    #[test]
+    fn multi_chunk_upload() {
+        let fake_upload_session_uri = format!("{}/fake-session-uri", mockito::server_url());
+        let mocked_post = mock("POST", "/upload/storage/v1/b/fake-bucket/o/")
+            .match_header("Authorization", "Bearer fake-token")
+            .match_header("Content-Length", "0")
+            .match_query(Matcher::UrlEncoded(
+                "uploadType".to_owned(),
+                "resumable".to_owned(),
+            ))
+            .match_query(Matcher::UrlEncoded(
+                "name".to_owned(),
+                "fake-object".to_owned(),
+            ))
+            .with_status(200)
+            .with_header("Location", &fake_upload_session_uri)
+            .expect_at_most(1)
+            .create();
+
+        let mut writer = StreamingTransferWriter::new_with_api_url(
+            "fake-bucket".to_string(),
+            "fake-object".to_string(),
+            5,
+            "fake-token".to_string(),
+            &mockito::server_url(),
+        )
+        .unwrap();
+
+        mocked_post.assert();
+
+        let first_mocked_put = mock("PUT", "/fake-session-uri")
+            .match_header("Content-Length", "10")
+            .match_header("Content-Range", "bytes 0-9/*")
+            .match_body("0123456789")
+            .with_status(308)
+            .with_header("Range", "bytes=0-4")
+            .expect_at_most(1)
+            .create();
+
+        let final_mocked_put = mock("PUT", "/fake-session-uri")
+            .match_header("Content-Length", "5")
+            .match_header("Content-Range", "bytes 5-9/10")
+            .match_body("56789")
+            .with_status(200)
+            .expect_at_most(1)
+            .create();
+
+        assert_eq!(writer.write(b"0123456789").unwrap(), 10);
+        writer.complete_upload().unwrap();
+
+        first_mocked_put.assert();
+        final_mocked_put.assert();
+    }
+}

--- a/facilitator/src/transport/local.rs
+++ b/facilitator/src/transport/local.rs
@@ -29,7 +29,7 @@ impl LocalFileTransport {
 }
 
 impl Transport for LocalFileTransport {
-    fn get(&self, key: &str) -> Result<Box<dyn Read>> {
+    fn get(&mut self, key: &str) -> Result<Box<dyn Read>> {
         let path = self.directory.join(LocalFileTransport::relative_path(key));
         let f =
             File::open(path.as_path()).with_context(|| format!("opening {}", path.display()))?;
@@ -63,7 +63,6 @@ impl TransportWriter for File {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Read;
 
     #[test]
     fn roundtrip_file_transport() {

--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -210,7 +210,7 @@ fn end_to_end() {
         res.err()
     );
 
-    let pha_aggregation_batch_reader: BatchReader<'_, SumPart, IngestionDataSharePacket> =
+    let mut pha_aggregation_batch_reader: BatchReader<'_, SumPart, IngestionDataSharePacket> =
         BatchReader::new(
             Batch::new_sum(&aggregation_name, &start_date, &end_date, true),
             &mut aggregation_transport,
@@ -230,11 +230,14 @@ fn end_to_end() {
         "should get no invalid packet reader when all packets were OK"
     );
 
-    let facilitator_aggregation_batch_reader: BatchReader<'_, SumPart, IngestionDataSharePacket> =
-        BatchReader::new(
-            Batch::new_sum(&aggregation_name, &start_date, &end_date, false),
-            &mut aggregation_transport,
-        );
+    let mut facilitator_aggregation_batch_reader: BatchReader<
+        '_,
+        SumPart,
+        IngestionDataSharePacket,
+    > = BatchReader::new(
+        Batch::new_sum(&aggregation_name, &start_date, &end_date, false),
+        &mut aggregation_transport,
+    );
     let facilitator_sum_part =
         facilitator_aggregation_batch_reader.header(&facilitator_pub_signing_key);
     assert!(

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -186,6 +186,7 @@ module "data_share_processors" {
   kubernetes_namespace                    = each.value.kubernetes_namespace
   packet_decryption_key_kubernetes_secret = each.value.packet_decryption_key_kubernetes_secret
   certificate_domain                      = "${var.environment}.certificates.${var.manifest_domain}"
+  sum_part_bucket_service_account_email   = google_service_account.sum_part_bucket_writer.email
 
   depends_on = [module.gke]
 }
@@ -200,12 +201,12 @@ resource "google_service_account" "sum_part_bucket_writer" {
   display_name = "prio-${var.environment}-sum-part-bucket-writer"
 }
 
-# Permit the service accounts for all the data share processors to impersonate
-# the sum part bucket writer.
-resource "google_service_account_iam_binding" "data_share_processors_to_sum_part_bucket_writer" {
+# Permit the service accounts for all the data share processors to request Oauth
+# tokens allowing them to impersonate the sum part bucket writer.
+resource "google_service_account_iam_binding" "data_share_processors_to_sum_part_bucket_writer_token_creator" {
   provider           = google-beta
   service_account_id = google_service_account.sum_part_bucket_writer.name
-  role               = "roles/iam.serviceAccountUser"
+  role               = "roles/iam.serviceAccountTokenCreator"
   members            = [for v in module.data_share_processors : v.service_account_email]
 }
 

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -34,6 +34,10 @@ variable "certificate_domain" {
   type = string
 }
 
+variable "sum_part_bucket_service_account_email" {
+  type = string
+}
+
 locals {
   resource_prefix = "prio-${var.environment}-${var.data_share_processor_name}"
   ingestion_bucket_writer_role_arn = var.ingestor_google_service_account_id != "" ? (
@@ -231,6 +235,7 @@ module "kubernetes" {
   ingestion_bucket_role                   = aws_iam_role.bucket_role.arn
   kubernetes_namespace                    = var.kubernetes_namespace
   packet_decryption_key_kubernetes_secret = var.packet_decryption_key_kubernetes_secret
+  sum_part_bucket_service_account_email   = var.sum_part_bucket_service_account_email
 }
 
 output "data_share_processor_name" {

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -43,6 +43,10 @@ variable "packet_decryption_key_kubernetes_secret" {
   type = string
 }
 
+variable "sum_part_bucket_service_account_email" {
+  type = string
+}
+
 data "aws_caller_identity" "current" {}
 
 # Workload identity[1] lets us map GCP service accounts to Kubernetes service


### PR DESCRIPTION
Adds an implementation of the Transport trait which implements
authenticated reads and writes from Google Cloud Storage buckets. It
supports two auth scenarios:
 - Using the default Oauth token retrieved from the GKE metadata service
 - Obtaining an Oauth token to impersonate another service account
   specified in GCSTransport::new.

The former case will allow ISRG's GCP workload deployment to read and
write from its own GCS buckets. The latter will allow us to write to the
MITRE Corporation's sum part buckets.

This also refactors some argument handling at the facilitator.rs level to
make it possible to specify on a per-transport basis how to do S3
authentication (for "s3://" style transports) or whether to impersonate
a GCP service account (for "gs://" style transports). This would allow
us to e.g., do OIDC auth to read from an S3 ingestion bucket, then use
the default service account to read and write from a validation bucket,
and finally impersonate the sum part bucket writer SA to emit sum parts.