### PR TITLE
terraform: multi-project bug fixes

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -16,6 +16,10 @@ REGION="$(shell grep '^gcp_region' $(VARS) | awk -F'=' '{print $$2}' | sed 's/[[
 ifeq ($(REGION),)
 $(error $(BOLD)$(RED)REGION was not detected$(RESET))
 endif
+PROJECT="$(shell grep '^gcp_project' $(VARS) | awk -F'=' '{print $$2}' | sed 's/[[:space:]]//g')"
+ifeq ($(PROJECT),)
+$(error $(BOLD)$(RED)PROJECT was not detected$(RESET))
+endif
 
 STORAGE_BUCKET="$(ENV)-$(REGION)-prio-terraform"
 STORAGE_BUCKET_URL="gs://$(STORAGE_BUCKET)"
@@ -31,11 +35,11 @@ prep: ## Prepare a new workspace (environment) if needed, configure the tfstate 
 		echo "$(BOLD)$(RED)Could not find variables file: $(VARS)$(RESET)"; \
 		exit 1; \
 	 fi
-	@echo "$(BOLD)Verifying that the storage bucket $(STORAGE_BUCKET_URL) for remote state exists$(RESET)"
-	@if ! gsutil ls -b $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; then \
+	@echo "$(BOLD)Verifying that the storage bucket $(STORAGE_BUCKET_URL) in $(PROJECT) for remote state exists$(RESET)"
+	@if ! gsutil ls -p $(PROJECT) -b $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; then \
 		echo "$(BOLD)Storage bucket $(STORAGE_BUCKET_URL) was not found, creating new bucket with versioning enabled to store tfstate$(RESET)"; \
-		gsutil mb -l $(REGION) $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; \
-		gsutil versioning set on $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; \
+		gsutil mb -p $(PROJECT) -l $(REGION) $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; \
+		gsutil versioning set on -p $(PROJECT) $(STORAGE_BUCKET_URL) > /dev/null 2>&1 ; \
 		echo "$(BOLD)$(GREEN)Storage bucket $(STORAGE_BUCKET_URL) created$(RESET)"; \
 	 else
 		echo "$(BOLD)$(GREEN)Storage bucket $(STORAGE_BUCKET_URL) exists$(RESET)"; \

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -214,7 +214,7 @@ output "manifest_bucket" {
 }
 
 output "gke_kubeconfig" {
-  value = "Run this command to update your kubectl config: gcloud container clusters get-credentials ${module.gke.cluster_name} --region ${var.gcp_region}"
+  value = "Run this command to update your kubectl config: gcloud container clusters get-credentials ${module.gke.cluster_name} --region ${var.gcp_region} --project ${var.gcp_project}"
 }
 
 output "specific_manifests" {

--- a/terraform/modules/manifest/manifest.tf
+++ b/terraform/modules/manifest/manifest.tf
@@ -89,6 +89,7 @@ data "google_dns_managed_zone" "manifests" {
 # Create an A record from which this env's manifests will be served.
 resource "google_dns_record_set" "manifests" {
   provider     = google-beta
+  project      = var.managed_dns_zone.gcp_project
   name         = local.domain_name
   managed_zone = data.google_dns_managed_zone.manifests.name
   type         = "A"


### PR DESCRIPTION
This commit resolves some bugs around spinning up an env spanning
multiple GCP projects, or outside of one's gcloud default auth
credentials.

The `gsutil` invocations in the Makefile now get a -p (project)
parameter from the .tfvars file to ensure that Terraform backend buckets
are created in the correct project.

The google_dns_record_set resource in manifest.tf is now created in the
same project as the google_dns_managed_zone.