### PR TITLE
Speed up Docker build for facilitator

### DIFF
--- a/facilitator/Dockerfile
+++ b/facilitator/Dockerfile
@@ -1,6 +1,11 @@
 FROM rust:1.46-alpine as builder
 
 RUN apk add libc-dev && apk update
+# Attempt to install a nonexistent package. This triggers
+# updating the crates.io index separately from building the
+# dependencies, so if dependencies change we don't have to
+# re-download the whole index.
+RUN cargo install _update_crates_io_failure_is_expected_ ; true
 
 WORKDIR /usr/src/prio-server
 
@@ -11,19 +16,24 @@ COPY facilitator/Cargo.toml facilitator/Cargo.toml
 RUN sed -i /build.rs/d facilitator/Cargo.toml
 RUN mkdir -p facilitator/src
 RUN echo "fn main() {println!(\"if you see this, the build broke\")}" > facilitator/src/main.rs
-RUN cargo build --release --manifest-path ./facilitator/Cargo.toml
+# This cargo build command must match the one below, or the build cache will not be reused.
+RUN cargo build --manifest-path ./facilitator/Cargo.toml
 
 # Clean up and copy the real source.
-#RUN rm -f facilitator/target/*/release/deps/facilitator* facilitator/src/main.rs
-RUN rm -f facilitator/src/main.rs
+# After this we have a layer that should be cacheable so long as the dependencies don't change.
+RUN rm -f facilitator/target/*/release/deps/facilitator* facilitator/src/main.rs
 
 # We enumerate these paths so that `docker build` fails in an obvious way if run
 # from the wrong place.
 COPY ./avro-schema ./avro-schema
 COPY ./facilitator ./facilitator
-RUN cargo build --release --manifest-path ./facilitator/Cargo.toml
+# This cargo build command must match the one above, or the build cache will not be reused.
+RUN cargo build --manifest-path ./facilitator/Cargo.toml
+# We build in debug mode so the build runs quickly, then strip the binary for size.
+RUN strip facilitator/target/debug/facilitator
 
-FROM rust:1.46-alpine
-RUN apk update
-COPY --from=builder /usr/src/prio-server/facilitator/target/release/facilitator /usr/local/bin/facilitator
-ENTRYPOINT ["/usr/local/bin/facilitator"]
+# Build a minimal container containing only the binary and the one .so it needs.
+FROM scratch
+COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
+COPY --from=builder /usr/src/prio-server/facilitator/target/debug/facilitator /facilitator
+ENTRYPOINT ["/facilitator"]

--- a/facilitator/Dockerfile
+++ b/facilitator/Dockerfile
@@ -11,7 +11,6 @@ COPY facilitator/Cargo.toml facilitator/Cargo.toml
 RUN sed -i /build.rs/d facilitator/Cargo.toml
 RUN mkdir -p facilitator/src
 RUN echo "fn main() {println!(\"if you see this, the build broke\")}" > facilitator/src/main.rs
-WORKDIR facilitator
 RUN cargo build --release --manifest-path ./facilitator/Cargo.toml
 
 # Clean up and copy the real source.
@@ -22,9 +21,9 @@ RUN rm -f facilitator/src/main.rs
 # from the wrong place.
 COPY ./avro-schema ./avro-schema
 COPY ./facilitator ./facilitator
-RUN cargo install --path ./facilitator
+RUN cargo build --release --manifest-path ./facilitator/Cargo.toml
 
 FROM rust:1.46-alpine
 RUN apk update
-COPY --from=builder /usr/local/cargo/bin/facilitator /usr/local/bin/facilitator
+COPY --from=builder /usr/src/prio-server/facilitator/target/release/facilitator /usr/local/bin/facilitator
 ENTRYPOINT ["/usr/local/bin/facilitator"]

--- a/facilitator/Dockerfile
+++ b/facilitator/Dockerfile
@@ -3,11 +3,25 @@ FROM rust:1.46-alpine as builder
 RUN apk add libc-dev && apk update
 
 WORKDIR /usr/src/prio-server
+
+# First, copy just the Cargo.toml and a dummy main, then build them.
+# This primes a layer that contains the built dependencies.
+COPY facilitator/Cargo.lock facilitator/Cargo.lock
+COPY facilitator/Cargo.toml facilitator/Cargo.toml
+RUN sed -i /build.rs/d facilitator/Cargo.toml
+RUN mkdir -p facilitator/src
+RUN echo "fn main() {println!(\"if you see this, the build broke\")}" > facilitator/src/main.rs
+WORKDIR facilitator
+RUN cargo build --release --manifest-path ./facilitator/Cargo.toml
+
+# Clean up and copy the real source.
+#RUN rm -f facilitator/target/*/release/deps/facilitator* facilitator/src/main.rs
+RUN rm -f facilitator/src/main.rs
+
 # We enumerate these paths so that `docker build` fails in an obvious way if run
 # from the wrong place.
 COPY ./avro-schema ./avro-schema
 COPY ./facilitator ./facilitator
-
 RUN cargo install --path ./facilitator
 
 FROM rust:1.46-alpine


### PR DESCRIPTION
Previously, the Docker build was not caching anything, meaning we would download and build all dependencies each time we build the container. This uses some tricks from https://shaneutt.com/blog/rust-fast-small-docker-image-builds/ to break the build process across cacheable Docker layers so rebuilds are much faster. I also switched to stripped debug builds, which are faster than release builds and suitable for our current use cases. Later on we should make debug / release an env variable, so the automatic publish in GH Actions can take its time and do a release build. And I moved from shipping Alpine to a bare binary in the container.

Size went from
580MB (full OS) to
18MB (release binary only) to
26 MB (debug binary only, stripped)

Time went from

4m52 (release, full build) to
2m22 (debug, full build) to
1m8s (release, incremental) to
33s (debug, incremental)

Tested on a 32 vCPU instance in the cloud. Weirdly, the last stat (debug, incremental) was faster on my laptop - 19s.