### PR TITLE
Create the terraform parser utility

### DIFF
--- a/terraform-parser/.gitignore
+++ b/terraform-parser/.gitignore
@@ -1,0 +1,4 @@
+deploy-tool
+config.toml
+vendor/
+coverage.coverprofile

--- a/terraform-parser/go.mod
+++ b/terraform-parser/go.mod
@@ -1,0 +1,3 @@
+module github.com/abetterinternet/prio-server/terraform-parser
+
+go 1.15

--- a/terraform-parser/kubernetes/kubernetes.go
+++ b/terraform-parser/kubernetes/kubernetes.go
@@ -1,5 +1,6 @@
 package kubernetes
 
+// TerraformData is the representation of the CRD defined by the Operator
 type TerraformData struct {
 	ApiVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`
@@ -7,11 +8,13 @@ type TerraformData struct {
 	Spec       `json:"spec"`
 }
 
+// Metadata is the representation of the metadata of the CRD
 type Metadata struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
 }
 
+// Spec is the representation of the spec of the CRD
 type Spec struct {
 	CertificateFQDN     string `json:"certificateFQDN"`
 	HealthAuthorityName string `json:"healthAuthorityName"`

--- a/terraform-parser/kubernetes/kubernetes.go
+++ b/terraform-parser/kubernetes/kubernetes.go
@@ -1,0 +1,19 @@
+package kubernetes
+
+type TerraformData struct {
+	ApiVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Metadata   `json:"metadata"`
+	Spec       `json:"spec"`
+}
+
+type Metadata struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+type Spec struct {
+	CertificateFQDN     string `json:"certificateFQDN"`
+	HealthAuthorityName string `json:"healthAuthorityName"`
+	ManifestBucket      string `json:"manifestBucket"`
+}

--- a/terraform-parser/main.go
+++ b/terraform-parser/main.go
@@ -52,7 +52,11 @@ func main() {
 
 	for name, data := range configuration {
 		if err := encoder.Encode(data); err != nil {
-			log.Fatalf("Failed to encode the output for %s", name)
+			log.Fatalf("Failed to encode the output for %s:%v", name, err)
+		}
+		// Print out the three newlines to make it easier to separate into multiple files if the admin needs that.
+		if _, err := os.Stdout.WriteString("\n\n\n"); err != nil {
+			log.Fatalf("Failed to write newlines to the output for %s:%v", name, err)
 		}
 	}
 }

--- a/terraform-parser/main.go
+++ b/terraform-parser/main.go
@@ -12,8 +12,7 @@ import (
 func main() {
 	var output terraform.Output
 
-	f, _ := os.Open("output.json")
-	if err := json.NewDecoder(f).Decode(&output); err != nil {
+	if err := json.NewDecoder(os.Stdin).Decode(&output); err != nil {
 		log.Fatalf("failed to parse the terraform output: %v", err)
 	}
 

--- a/terraform-parser/main.go
+++ b/terraform-parser/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/abetterinternet/prio-server/terraform-parser/kubernetes"
+	"github.com/abetterinternet/prio-server/terraform-parser/terraform"
+	"log"
+	"os"
+)
+
+func main() {
+	var output terraform.Output
+
+	f, _ := os.Open("output.json")
+	if err := json.NewDecoder(f).Decode(&output); err != nil {
+		log.Fatalf("failed to parse the terraform output: %v", err)
+	}
+
+	configuration := make(map[string]kubernetes.TerraformData)
+
+	for dataShareProcessorName, manifestWrapper := range output.SpecificManifests.Value {
+		namespace := manifestWrapper.KubernetesNamespace
+
+		_, exists := configuration[namespace]
+		if exists {
+			continue
+		}
+
+		metadata := kubernetes.Metadata{
+			Name:      fmt.Sprintf("%s-data", namespace),
+			Namespace: namespace,
+		}
+
+		spec := kubernetes.Spec{
+			CertificateFQDN:     manifestWrapper.CertificateFQDN,
+			HealthAuthorityName: dataShareProcessorName,
+			ManifestBucket:      output.ManifestBucket.Value,
+		}
+
+		data := kubernetes.TerraformData{
+			ApiVersion: "terraform.isrg-prio.com/v1",
+			Kind:       "TerraformData",
+			Metadata:   metadata,
+			Spec:       spec,
+		}
+
+		configuration[namespace] = data
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "    ")
+
+	for name, data := range configuration {
+		if err := encoder.Encode(data); err != nil {
+			log.Fatalf("Failed to encode the output for %s", name)
+		}
+	}
+}

--- a/terraform-parser/terraform/terraform.go
+++ b/terraform-parser/terraform/terraform.go
@@ -1,0 +1,29 @@
+package terraform
+
+// Output represents the JSON output from `terraform apply` or
+// `terraform output --json`. This struct must match the output variables
+// defined in terraform/main.tf, though it only need describe the output
+// variables this program is interested in.
+type Output struct {
+	ManifestBucket    ManifestBucket    `json:"manifest_bucket"`
+	SpecificManifests SpecificManifests `json:"specific_manifests"`
+}
+
+// ManifestBucket represents the ManifestBucket section of the Output
+type ManifestBucket struct {
+	Value string
+}
+
+// SpecificManifests is a K-V representation between the name of the
+// ingestor and the SpecificManifestContainer
+type SpecificManifests struct {
+	Value map[string]SpecificManifestContainer `json:"value"`
+}
+
+// SpecificManifestContainer is the representation of the container that contains
+// the SpecificManifest structure.
+// We don't need the SpecificManifest so it is not included in this structure
+type SpecificManifestContainer struct {
+	KubernetesNamespace string `json:"kubernetes-namespace"`
+	CertificateFQDN     string `json:"certificate-fqdn"`
+}


### PR DESCRIPTION
Expected to be used like:

```
terraform output -json | ../terraform-parser/terraform-parser | kubectl apply -f -
```


Creates the following JSON:

```json
{
    "apiVersion": "terraform.isrg-prio.com/v1",
    "kind": "TerraformData",
    "metadata": {
        "name": "test-pha-1-data",
        "namespace": "test-pha-1"
    },
    "spec": {
        "certificateFQDN": "test-pha-1.amir-demo.certificates.isrg-prio.org",
        "healthAuthorityName": "test-pha-1-ingestor-2",
        "manifestBucket": "prio-amir-demo-manifests"
    }
}
{
    "apiVersion": "terraform.isrg-prio.com/v1",
    "kind": "TerraformData",
    "metadata": {
        "name": "test-pha-2-data",
        "namespace": "test-pha-2"
    },
    "spec": {
        "certificateFQDN": "test-pha-2.amir-demo.certificates.isrg-prio.org",
        "healthAuthorityName": "test-pha-2-ingestor-1",
        "manifestBucket": "prio-amir-demo-manifests"
    }
}
```