### PR TITLE
Add S3 input bucket support to workflow-manager

### DIFF
--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -157,7 +157,8 @@ resource "aws_s3_bucket" "ingestion_bucket" {
         "AWS": "${aws_iam_role.bucket_role.arn}"
       },
       "Action": [
-        "s3:GetObject"
+        "s3:GetObject",
+        "s3:ListBucket"
       ],
       "Resource": [
         "arn:aws:s3:::${local.ingestion_bucket_name}/*",
@@ -210,7 +211,8 @@ resource "aws_s3_bucket" "peer_validation_bucket" {
         "AWS": "${aws_iam_role.bucket_role.arn}"
       },
       "Action": [
-        "s3:GetObject"
+        "s3:GetObject",
+        "s3:ListBucket"
       ],
       "Resource": [
         "arn:aws:s3:::${local.peer_validation_bucket_name}/*",

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -12,10 +12,8 @@ variable "container_registry" {
 }
 
 variable "workflow_manager_image" {
-  type = string
-  # This should be "prio-data-share-processor" but we have not yet renamed the
-  # container image
-  default = "prio-workflow-manager"
+  type    = string
+  default = "letsencrypt"
 }
 
 variable "workflow_manager_version" {

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -13,7 +13,7 @@ variable "container_registry" {
 
 variable "workflow_manager_image" {
   type    = string
-  default = "letsencrypt"
+  default = "prio-workflow-manager"
 }
 
 variable "workflow_manager_version" {

--- a/workflow-manager/go.mod
+++ b/workflow-manager/go.mod
@@ -4,7 +4,11 @@ go 1.15
 
 require (
 	cloud.google.com/go/storage v1.12.0
+	github.com/aws/aws-sdk-go v1.35.16
+	golang.org/x/net v0.0.0-20201027133719-8eef5233e2a1 // indirect
+	golang.org/x/text v0.3.4 // indirect
 	google.golang.org/api v0.33.0
+	k8s.io/api v0.19.3
 	k8s.io/apimachinery v0.19.3
 	k8s.io/client-go v0.19.3
 	k8s.io/klog v1.0.0 // indirect

--- a/workflow-manager/go.sum
+++ b/workflow-manager/go.sum
@@ -53,6 +53,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/aws/aws-sdk-go v1.35.16 h1:kaYAh0lYwMUTmb/t6whBkj2nZzi3yAeQuwv0QB6dQcg=
+github.com/aws/aws-sdk-go v1.35.16/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -151,6 +153,9 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -178,6 +183,7 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -266,6 +272,8 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73 h1:MXfv8rhZWmFeqX3GNZRsd6vOLoaCHjYEX3qkRo3YBUA=
 golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201027133719-8eef5233e2a1 h1:IEhJ99VWSYpHIxjlbu3DQyHegGPnQYAv0IaCX9KHyG0=
+golang.org/x/net v0.0.0-20201027133719-8eef5233e2a1/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -312,12 +320,16 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200828194041-157a740278f4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f h1:Fqb3ao1hUmOR3GkUOg/Y+BadLwykBIzs5q8Ez2SbHyc=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
+golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=

--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -9,19 +9,27 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	aws_session "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/sts"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
-
-	"cloud.google.com/go/storage"
-	"google.golang.org/api/iterator"
 )
 
 var BuildID string
@@ -51,38 +59,128 @@ var k8sNS = flag.String("k8s-namespace", "", "Kubernetes namespace")
 
 func main() {
 	inputBucket := flag.String("input-bucket", "", "Name of input bucket (required)")
+	service := flag.String("service", "s3", "Where to find buckets (s3 or gs)")
 	flag.Parse()
 	if *inputBucket == "" {
 		flag.Usage()
+		os.Exit(1)
 	}
 
-	log.Printf("starting %s", os.Args[0])
-	if err := work(context.Background(), *inputBucket); err != nil {
+	log.Printf("starting %s version %s - %s. Args: %s", os.Args[0], BuildID, BuildTime, os.Args[1:])
+	var readyBatches []string
+	var err error
+	switch *service {
+	case "s3":
+		readyBatches, err = getReadyBatchesS3(context.Background(), *inputBucket)
+		if err != nil {
+			log.Fatal(err)
+		}
+	case "gs":
+		readyBatches, err = getReadyBatchesGS(context.Background(), *inputBucket)
+		if err != nil {
+			log.Fatal(err)
+		}
+	default:
+		log.Fatalf("unknown service %s", *service)
+	}
+
+	if err := launch(context.Background(), readyBatches); err != nil {
 		log.Fatal(err)
 	}
 	log.Print("done")
 }
 
-func work(ctx context.Context, inputBucket string) error {
-	config, err := rest.InClusterConfig()
+type tokenFetcher struct{}
+
+func (tf tokenFetcher) FetchToken(credentials.Context) ([]byte, error) {
+	audience := fmt.Sprintf("sts.amazonaws.com/%s", os.Getenv("AWS_ACCOUNT_ID"))
+	url := fmt.Sprintf("http://metadata.google.internal:80/computeMetadata/v1/instance/service-accounts/default/identity?audience=%s", audience)
+	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return fmt.Errorf("cluster config: %w", err)
+		return nil, fmt.Errorf("building request: %w", err)
 	}
-	// creates the clientset
-	clientset, err := kubernetes.NewForConfig(config)
+	req.Header.Add("Metadata-Flavor", "Google")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("clientset: %w", err)
+		return nil, fmt.Errorf("fetching %s: %w", url, err)
+	}
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading body of %s: %w", url, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code %d from metadata service at %s: %s",
+			resp.StatusCode, url, string(bytes))
+	}
+	log.Printf("fetched token from %s", url)
+	return bytes, nil
+}
+
+func getReadyBatchesS3(ctx context.Context, inputBucket string) ([]string, error) {
+	parts := strings.SplitN(inputBucket, "/", 2)
+	region := parts[0]
+	bucket := parts[1]
+	sess, err := aws_session.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("making AWS session: %w", err)
 	}
 
+	stsSTS := sts.New(sess)
+	roleARN := os.Getenv("AWS_ROLE_ARN")
+	roleSessionName := ""
+	roleProvider := stscreds.NewWebIdentityRoleProviderWithToken(
+		stsSTS, roleARN, roleSessionName, tokenFetcher{})
+
+	credentials := credentials.NewCredentials(roleProvider)
+
+	config := aws.NewConfig().
+		WithRegion(region).
+		WithCredentials(credentials)
+	svc := s3.New(sess, config)
+	resp, err := svc.ListObjectsV2(&s3.ListObjectsV2Input{Bucket: aws.String(bucket)})
+	if err != nil {
+		return nil, fmt.Errorf("Unable to list items in bucket %q, %w", inputBucket, err)
+	}
+	batches := make(map[string]*batch)
+	for _, item := range resp.Contents {
+		name := *item.Key
+		basename := basename(name)
+		if batches[basename] == nil {
+			batches[basename] = new(batch)
+		}
+		b := batches[basename]
+		if strings.HasSuffix(name, ".batch") {
+			b.metadata = true
+		}
+		if strings.HasSuffix(name, ".batch.avro") {
+			b.avro = true
+		}
+		if strings.HasSuffix(name, ".batch.sig") {
+			b.sig = true
+		}
+	}
+
+	var readyBatches []string
+	for k, v := range batches {
+		if v.metadata && v.avro && v.sig {
+			log.Printf("ready: %s", k)
+			readyBatches = append(readyBatches, k)
+		} else {
+			log.Printf("unready: %s", k)
+		}
+	}
+	return readyBatches, nil
+}
+
+func getReadyBatchesGS(ctx context.Context, inputBucket string) ([]string, error) {
 	client, err := storage.NewClient(ctx)
 	if err != nil {
-		return fmt.Errorf("storage.newClient: %w", err)
+		return nil, fmt.Errorf("storage.newClient: %w", err)
 	}
 
-	batches := make(batchMap)
+	batches := make(map[string]*batch)
 	bkt := client.Bucket(inputBucket)
 	query := &storage.Query{Prefix: ""}
-	var names []string
 	it := bkt.Objects(ctx, query)
 	for {
 		attrs, err := it.Next()
@@ -90,7 +188,7 @@ func work(ctx context.Context, inputBucket string) error {
 			break
 		}
 		if err != nil {
-			return fmt.Errorf("iterating on inputBucket objects from %q: %w", inputBucket, err)
+			return nil, fmt.Errorf("iterating on inputBucket objects from %q: %w", inputBucket, err)
 		}
 		name := attrs.Name
 		basename := basename(name)
@@ -107,7 +205,6 @@ func work(ctx context.Context, inputBucket string) error {
 		if strings.HasSuffix(name, ".batch.sig") {
 			b.sig = true
 		}
-		names = append(names, attrs.Name)
 	}
 
 	var readyBatches []string
@@ -120,10 +217,24 @@ func work(ctx context.Context, inputBucket string) error {
 		}
 	}
 
+	return readyBatches, nil
+}
+
+func launch(ctx context.Context, readyBatches []string) error {
+	// This uses the credentials that an instance running in the k8s cluster
+	// gets automatically, via automount_service_account_token in the Terraform config.
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return fmt.Errorf("cluster config: %w", err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("clientset: %w", err)
+	}
+
 	log.Printf("starting %d jobs", len(readyBatches))
 	for _, batchName := range readyBatches {
-		err = startJob(ctx, clientset, batchName)
-		if err != nil {
+		if err := startJob(ctx, clientset, batchName); err != nil {
 			return fmt.Errorf("starting job for batch %q: %w", batchName, err)
 		}
 	}


### PR DESCRIPTION
Add the necessary terraform to grant permission on ingestion buckets.

Add a flag to control which service is in use (GCS vs S3).

Pull a token from the GKE metadata endpoint and use it to authenticate to the S3 API.