### PR TITLE
Store copy of validation batches in internal bucket

### DIFF
--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -23,7 +23,9 @@ use uuid::Uuid;
 #[test]
 fn end_to_end() {
     let pha_tempdir = tempfile::TempDir::new().unwrap();
+    let pha_copy_tempdir = tempfile::TempDir::new().unwrap();
     let facilitator_tempdir = tempfile::TempDir::new().unwrap();
+    let facilitator_copy_tempdir = tempfile::TempDir::new().unwrap();
 
     let aggregation_name = "fake-aggregation-1".to_owned();
     let date = NaiveDateTime::from_timestamp(2234567890, 654321);
@@ -102,14 +104,28 @@ fn end_to_end() {
         ],
     };
 
-    let mut pha_validate_signable_transport = SignableTransport {
+    let mut pha_peer_validate_signable_transport = SignableTransport {
         transport: Box::new(LocalFileTransport::new(pha_tempdir.path().to_path_buf())),
         batch_signing_key: default_pha_signing_private_key(),
     };
 
-    let mut facilitator_validate_signable_transport = SignableTransport {
+    let mut facilitator_peer_validate_signable_transport = SignableTransport {
         transport: Box::new(LocalFileTransport::new(
             facilitator_tempdir.path().to_path_buf(),
+        )),
+        batch_signing_key: default_facilitator_signing_private_key(),
+    };
+
+    let mut pha_own_validate_signable_transport = SignableTransport {
+        transport: Box::new(LocalFileTransport::new(
+            pha_copy_tempdir.path().to_path_buf(),
+        )),
+        batch_signing_key: default_pha_signing_private_key(),
+    };
+
+    let mut facilitator_own_validate_signable_transport = SignableTransport {
+        transport: Box::new(LocalFileTransport::new(
+            facilitator_copy_tempdir.path().to_path_buf(),
         )),
         batch_signing_key: default_facilitator_signing_private_key(),
     };
@@ -119,7 +135,8 @@ fn end_to_end() {
         &batch_1_uuid,
         &date,
         &mut pha_ingest_transport,
-        &mut pha_validate_signable_transport,
+        &mut pha_peer_validate_signable_transport,
+        &mut pha_own_validate_signable_transport,
         true,
     )
     .unwrap()
@@ -131,7 +148,8 @@ fn end_to_end() {
         &batch_2_uuid,
         &date,
         &mut pha_ingest_transport,
-        &mut pha_validate_signable_transport,
+        &mut pha_peer_validate_signable_transport,
+        &mut pha_own_validate_signable_transport,
         true,
     )
     .unwrap()
@@ -143,7 +161,8 @@ fn end_to_end() {
         &batch_1_uuid,
         &date,
         &mut facilitator_ingest_transport,
-        &mut facilitator_validate_signable_transport,
+        &mut facilitator_peer_validate_signable_transport,
+        &mut facilitator_own_validate_signable_transport,
         false,
     )
     .unwrap()
@@ -155,7 +174,8 @@ fn end_to_end() {
         &batch_2_uuid,
         &date,
         &mut facilitator_ingest_transport,
-        &mut facilitator_validate_signable_transport,
+        &mut facilitator_peer_validate_signable_transport,
+        &mut facilitator_own_validate_signable_transport,
         false,
     )
     .unwrap()

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -179,6 +179,7 @@ module "data_share_processors" {
   source                                  = "./modules/data_share_processor"
   environment                             = var.environment
   data_share_processor_name               = each.key
+  gcp_region                              = var.gcp_region
   gcp_project                             = var.gcp_project
   ingestor_aws_role_arn                   = each.value.ingestor_aws_role_arn
   ingestor_google_service_account_id      = each.value.ingestor_gcp_service_account_id

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -249,7 +249,7 @@ resource "google_storage_bucket" "own_validation_bucket" {
 # bucket
 resource "google_storage_bucket_iam_binding" "own_validation_bucket_admin" {
   bucket = google_storage_bucket.own_validation_bucket.name
-  role   = "roles/storage.objectAdmin"
+  role   = "roles/storage.legacyBucketWriter"
   members = [
     module.kubernetes.service_account_email
   ]


### PR DESCRIPTION
This PR amends the Terraform to create an additional GCS bucket into which we shall write a copy of validation batches, to ensure we have our own validations available at aggregation time. It also extends the intake map step implementation in facilitator so that it can take two `SignableTransports`, which required teaching `BatchWriter` and `SidecarWriter` to deal with many potential writers under the covers.