### PR TITLE
Add passthrough of args to workflow manager.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -184,6 +184,7 @@ module "data_share_processors" {
   ingestor_aws_role_arn                   = each.value.ingestor_aws_role_arn
   ingestor_google_service_account_id      = each.value.ingestor_gcp_service_account_id
   peer_share_processor_aws_account_id     = jsondecode(data.http.peer_share_processor_global_manifest.body).server-identity.aws-account-id
+  peer_share_processor_manifest_domain    = var.peer_share_processor_manifest_domain
   kubernetes_namespace                    = each.value.kubernetes_namespace
   packet_decryption_key_kubernetes_secret = each.value.packet_decryption_key_kubernetes_secret
   certificate_domain                      = "${var.environment}.certificates.${var.manifest_domain}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,7 +42,11 @@ variable "managed_dns_zone" {
   type = map(string)
 }
 
-variable "peer_share_processor_manifest_domain" {
+variable "peer_share_processor_manifest_base_url" {
+  type = string
+}
+
+variable "portal_server_manifest_base_url" {
   type = string
 }
 
@@ -121,7 +125,7 @@ data "http" "ingestor_global_manifests" {
 
 # Then we fetch the single global manifest for all the peer share processors.
 data "http" "peer_share_processor_global_manifest" {
-  url = "https://${var.peer_share_processor_manifest_domain}/global-manifest.json"
+  url = "https://${var.peer_share_processor_manifest_base_url}/global-manifest.json"
 }
 
 # While we create a distinct data share processor for each (ingestor, peer data
@@ -170,6 +174,7 @@ locals {
       packet_decryption_key_kubernetes_secret = kubernetes_secret.ingestion_packet_decryption_keys[pair[0]].metadata[0].name
       ingestor_aws_role_arn                   = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body).server-identity, "aws-iam-entity", "")
       ingestor_gcp_service_account_id         = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body).server-identity, "google-service-account", "")
+      ingestor_manifest_base_url              = var.ingestors[pair[1]]
     }
   }
 }
@@ -181,14 +186,17 @@ module "data_share_processors" {
   data_share_processor_name               = each.key
   gcp_region                              = var.gcp_region
   gcp_project                             = var.gcp_project
-  ingestor_aws_role_arn                   = each.value.ingestor_aws_role_arn
-  ingestor_google_service_account_id      = each.value.ingestor_gcp_service_account_id
-  peer_share_processor_aws_account_id     = jsondecode(data.http.peer_share_processor_global_manifest.body).server-identity.aws-account-id
-  peer_share_processor_manifest_domain    = var.peer_share_processor_manifest_domain
   kubernetes_namespace                    = each.value.kubernetes_namespace
-  packet_decryption_key_kubernetes_secret = each.value.packet_decryption_key_kubernetes_secret
   certificate_domain                      = "${var.environment}.certificates.${var.manifest_domain}"
+  ingestor_aws_role_arn                   = each.value.ingestor_aws_role_arn
+  ingestor_gcp_service_account_id         = each.value.ingestor_gcp_service_account_id
+  ingestor_manifest_base_url              = each.value.ingestor_manifest_base_url
+  packet_decryption_key_kubernetes_secret = each.value.packet_decryption_key_kubernetes_secret
+  peer_share_processor_aws_account_id     = jsondecode(data.http.peer_share_processor_global_manifest.body).server-identity.aws-account-id
+  peer_share_processor_manifest_base_url  = var.peer_share_processor_manifest_base_url
   sum_part_bucket_service_account_email   = google_service_account.sum_part_bucket_writer.email
+  portal_server_manifest_base_url         = var.portal_server_manifest_base_url
+  own_manifest_base_url                   = module.manifest.base_url
 
   depends_on = [module.gke]
 }

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -26,6 +26,10 @@ variable "peer_share_processor_aws_account_id" {
   type = string
 }
 
+variable "peer_share_processor_manifest_domain" {
+  type = string
+}
+
 variable "kubernetes_namespace" {
   type = string
 }
@@ -265,6 +269,9 @@ module "kubernetes" {
   kubernetes_namespace                    = var.kubernetes_namespace
   packet_decryption_key_kubernetes_secret = var.packet_decryption_key_kubernetes_secret
   sum_part_bucket_service_account_email   = var.sum_part_bucket_service_account_email
+  peer_share_processor_aws_account_id     = var.peer_share_processor_aws_account_id
+  peer_share_processor_manifest_domain    = var.peer_share_processor_manifest_domain
+  peer_validation_bucket_name             = local.peer_validation_bucket_name
 }
 
 output "data_share_processor_name" {

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -2,6 +2,18 @@ variable "data_share_processor_name" {
   type = string
 }
 
+variable "peer_share_processor_aws_account_id" {
+  type = string
+}
+
+variable "peer_share_processor_manifest_domain" {
+  type = string
+}
+
+variable "peer_validation_bucket_name" {
+  type = string
+}
+
 variable "environment" {
   type = string
 }

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -167,6 +167,22 @@ resource "kubernetes_cron_job" "workflow_manager" {
               args = [
                 "--k8s-namespace", var.kubernetes_namespace,
                 "--input-bucket", var.ingestion_bucket,
+                "--bsk-secret-name", kubernetes_secret.batch_signing_key.metadata[0].name,
+                "--pdks-secret-name", var.packet_decryption_key_kubernetes_secret,
+                "passthrough",
+                # These args are passed to facilitator in addition to the per-batch
+                # args that workflow-manager builds to pass in.
+                "intake-batch",
+                "--aggregation-id", "fake-1",
+                "--instance-name", "foo",
+
+                "--ingestor-input", var.ingestion_bucket,
+                "--ingestor-identity", var.ingestion_bucket_role,
+                "--ingestor-manifest-base-url", "I dunno",
+
+                "--peer-output", var.peer_validation_bucket_name,
+                "--peer-identity", var.peer_share_processor_aws_account_id,
+                "--peer-manifest-base-url", "https://${var.peer_share_processor_manifest_domain}/",
               ]
               env {
                 name  = "AWS_ROLE_ARN"
@@ -175,24 +191,6 @@ resource "kubernetes_cron_job" "workflow_manager" {
               env {
                 name  = "AWS_ACCOUNT_ID"
                 value = data.aws_caller_identity.current.account_id
-              }
-              env {
-                name = "BATCH_SIGNING_KEY"
-                value_from {
-                  secret_key_ref {
-                    name = kubernetes_secret.batch_signing_key.metadata[0].name
-                    key  = "signing_key"
-                  }
-                }
-              }
-              env {
-                name = "INGESTION_PACKET_DECRYPTION_KEY"
-                value_from {
-                  secret_key_ref {
-                    name = var.packet_decryption_key_kubernetes_secret
-                    key  = "decryption_key"
-                  }
-                }
               }
             }
             # If we use any other restart policy, then when the job is finally

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -2,18 +2,6 @@ variable "data_share_processor_name" {
   type = string
 }
 
-variable "peer_share_processor_aws_account_id" {
-  type = string
-}
-
-variable "peer_share_processor_manifest_domain" {
-  type = string
-}
-
-variable "peer_validation_bucket_name" {
-  type = string
-}
-
 variable "environment" {
   type = string
 }
@@ -45,11 +33,39 @@ variable "ingestion_bucket_role" {
   type = string
 }
 
+variable "ingestor_manifest_base_url" {
+  type = string
+}
+
+variable "peer_validation_bucket_name" {
+  type = string
+}
+
+variable "peer_validation_bucket_role" {
+  type = string
+}
+
+variable "peer_manifest_base_url" {
+  type = string
+}
+
+variable "own_validation_bucket" {
+  type = string
+}
+
+variable "own_manifest_base_url" {
+  type = string
+}
+
 variable "kubernetes_namespace" {
   type = string
 }
 
 variable "packet_decryption_key_kubernetes_secret" {
+  type = string
+}
+
+variable "portal_server_manifest_base_url" {
   type = string
 }
 
@@ -153,6 +169,59 @@ resource "kubernetes_secret" "batch_signing_key" {
   }
 }
 
+# ConfigMap containing the parameters that are common to every intake-batch job
+# that will be spawned in this data share processor, except for secrets.
+resource "kubernetes_config_map" "intake_batch_job_config_map" {
+  metadata {
+    name      = "${var.data_share_processor_name}-intake-batch-config"
+    namespace = var.kubernetes_namespace
+  }
+
+  # These key-value pairs will be plopped directly into the container
+  # environment, so they MUST match the environment variables set in various
+  # Arg::env calls in src/bin/facilitator.rs.
+  data = {
+    # PACKET_DECRYPTION_KEYS is a Kubernetes secret
+    # BATCH_SIGNING_PRIVATE_KEY is a Kubernetes secret
+    AWS_ACCOUNT_ID                       = data.aws_caller_identity.current.account_id
+    BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER = kubernetes_secret.batch_signing_key.metadata[0].name
+    INGESTOR_IDENTITY                    = var.ingestion_bucket_role
+    INGESTOR_INPUT                       = var.ingestion_bucket
+    INGESTOR_MANIFEST_BASE_URL           = var.ingestor_manifest_base_url
+    INSTANCE_NAME                        = var.data_share_processor_name
+    PEER_IDENTITY                        = var.peer_validation_bucket_role
+    PEER_MANIFEST_BASE_URL               = var.peer_manifest_base_url
+    OWN_OUTPUT                           = var.own_validation_bucket
+  }
+}
+
+# ConfigMap containing the parameters that are common to every aggregation job
+# that will be spawned in this data share processor, except for secrets.
+resource "kubernetes_config_map" "aggregate_job_config_map" {
+  metadata {
+    name      = "${var.data_share_processor_name}-aggregate-config"
+    namespace = var.kubernetes_namespace
+  }
+
+  data = {
+    # PACKET_DECRYPTION_KEYS is a Kubernetes secret
+    # BATCH_SIGNING_PRIVATE_KEY is a Kubernetes secret
+    AWS_ACCOUNT_ID                       = data.aws_caller_identity.current.account_id
+    BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER = kubernetes_secret.batch_signing_key.metadata[0].name
+    INGESTOR_IDENTITY                    = var.ingestion_bucket_role
+    INGESTOR_INPUT                       = var.ingestion_bucket
+    INGESTOR_MANIFEST_BASE_URL           = var.ingestor_manifest_base_url
+    INSTANCE_NAME                        = var.data_share_processor_name
+    OWN_INPUT                            = var.own_validation_bucket
+    OWN_MANIFEST_BASE_URL                = var.own_manifest_base_url
+    PEER_INPUT                           = var.peer_validation_bucket_name
+    PEER_IDENTITY                        = var.peer_validation_bucket_role
+    PEER_MANIFEST_BASE_URL               = var.peer_manifest_base_url
+    PORTAL_IDENTITY                      = var.sum_part_bucket_service_account_email
+    PORTAL_MANIFEST_BASE_URL             = var.portal_server_manifest_base_url
+  }
+}
+
 resource "kubernetes_cron_job" "workflow_manager" {
   metadata {
     name      = "${var.environment}-${var.data_share_processor_name}-workflow-manager"
@@ -181,20 +250,8 @@ resource "kubernetes_cron_job" "workflow_manager" {
                 "--input-bucket", var.ingestion_bucket,
                 "--bsk-secret-name", kubernetes_secret.batch_signing_key.metadata[0].name,
                 "--pdks-secret-name", var.packet_decryption_key_kubernetes_secret,
-                "passthrough",
-                # These args are passed to facilitator in addition to the per-batch
-                # args that workflow-manager builds to pass in.
-                "intake-batch",
-                "--aggregation-id", "fake-1",
-                "--instance-name", "foo",
-
-                "--ingestor-input", var.ingestion_bucket,
-                "--ingestor-identity", var.ingestion_bucket_role,
-                "--ingestor-manifest-base-url", "I dunno",
-
-                "--peer-output", var.peer_validation_bucket_name,
-                "--peer-identity", var.peer_share_processor_aws_account_id,
-                "--peer-manifest-base-url", "https://${var.peer_share_processor_manifest_domain}/",
+                "--intake-batch-job-config-map-name", kubernetes_config_map.intake_batch_job_config_map.metadata[0].name,
+                "--aggregate-job-config-map-name", kubernetes_config_map.aggregate_job_config_map.metadata[0].name,
               ]
               env {
                 name  = "AWS_ROLE_ARN"

--- a/terraform/modules/manifest/manifest.tf
+++ b/terraform/modules/manifest/manifest.tf
@@ -135,3 +135,7 @@ resource "google_compute_global_forwarding_rule" "manifests" {
 output "bucket" {
   value = google_storage_bucket.manifests.name
 }
+
+output "base_url" {
+  value = local.domain_name
+}

--- a/terraform/variables/demo-gcp.tfvars
+++ b/terraform/variables/demo-gcp.tfvars
@@ -13,4 +13,5 @@ ingestors = {
   ingestor-1 = "storage.googleapis.com/prio-demo-gcp-manifests/ingestor-1"
   ingestor-2 = "storage.googleapis.com/prio-demo-gcp-manifests/ingestor-2"
 }
-peer_share_processor_manifest_domain = "storage.googleapis.com/prio-demo-gcp-manifests/pha-servers"
+peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-demo-gcp-manifests/pha-servers"
+portal_server_manifest_base_url        = "storage.googleapis.com/prio-demo-gcp-manifests/portal-server"

--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -280,7 +280,7 @@ func startJob(
 						{
 							Args:            args,
 							Name:            "facile-container",
-							Image:           "us.gcr.io/jsha-prio-bringup/letsencrypt/prio-facilitator:7.7.7",
+							Image:           "us.gcr.io/jsha-prio-bringup/letsencrypt/prio-facilitator:1.2.3",
 							ImagePullPolicy: "Always",
 							Env: []corev1.EnvVar{
 								{

--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -56,6 +56,8 @@ func basename(s string) string {
 }
 
 var k8sNS = flag.String("k8s-namespace", "", "Kubernetes namespace")
+var bskSecretName = flag.String("bsk-secret-name", "", "Name of k8s secret for batch signing key")
+var pdksSecretName = flag.String("pdks-secret-name", "", "Nmae of k8s secret for packet decrypt keys")
 
 func main() {
 	inputBucket := flag.String("input-bucket", "", "Name of input bucket (required)")
@@ -65,6 +67,11 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
+
+	if len(flag.Args()) == 0 || flag.Args()[0] != "passthrough" {
+		log.Fatal("Must provide 'passthrough' arg, followed by args to pass through to facilitator")
+	}
+	passthroughArgs := flag.Args()[1:]
 
 	log.Printf("starting %s version %s - %s. Args: %s", os.Args[0], BuildID, BuildTime, os.Args[1:])
 	var readyBatches []string
@@ -84,7 +91,7 @@ func main() {
 		log.Fatalf("unknown service %s", *service)
 	}
 
-	if err := launch(context.Background(), readyBatches); err != nil {
+	if err := launch(context.Background(), readyBatches, passthroughArgs); err != nil {
 		log.Fatal(err)
 	}
 	log.Print("done")
@@ -220,7 +227,7 @@ func getReadyBatchesGS(ctx context.Context, inputBucket string) ([]string, error
 	return readyBatches, nil
 }
 
-func launch(ctx context.Context, readyBatches []string) error {
+func launch(ctx context.Context, readyBatches []string, passthroughArgs []string) error {
 	// This uses the credentials that an instance running in the k8s cluster
 	// gets automatically, via automount_service_account_token in the Terraform config.
 	config, err := rest.InClusterConfig()
@@ -234,20 +241,32 @@ func launch(ctx context.Context, readyBatches []string) error {
 
 	log.Printf("starting %d jobs", len(readyBatches))
 	for _, batchName := range readyBatches {
-		if err := startJob(ctx, clientset, batchName); err != nil {
+		if err := startJob(ctx, clientset, batchName, passthroughArgs); err != nil {
 			return fmt.Errorf("starting job for batch %q: %w", batchName, err)
 		}
 	}
 	return nil
 }
 
-func startJob(ctx context.Context, clientset *kubernetes.Clientset, batchName string) error {
-	log.Printf("starting job for batch %q...", batchName)
+func startJob(
+	ctx context.Context,
+	clientset *kubernetes.Clientset,
+	batchName string,
+	passthroughArgs []string,
+) error {
 	jobName := fmt.Sprintf("i-batch-%s", strings.ReplaceAll(batchName, "/", "-"))
 
 	pathComponents := strings.Split(batchName, "/")
 	batchID := pathComponents[len(pathComponents)-1]
 	batchDate := strings.Join(pathComponents[0:len(pathComponents)-1], "/")
+
+	var args []string
+	args = append(args, passthroughArgs...)
+	args = append(args,
+		"--batch-id", batchID,
+		"--date", batchDate,
+	)
+	log.Printf("starting job for batch %q with args %s", batchName, passthroughArgs)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
@@ -259,21 +278,24 @@ func startJob(ctx context.Context, clientset *kubernetes.Clientset, batchName st
 					RestartPolicy: "Never",
 					Containers: []corev1.Container{
 						{
-							Args: []string{
-								"batch-intake",
-								"--s3-use-credentials-from-gke-metadata",
-								"--aggregation-id", "fake-1",
-								"--batch-id", batchID,
-								"--date", batchDate,
-								"--ingestion-bucket", "gs://tbd",
-								"--validation-bucket", "gs://tbd",
-								"--ingestor-public-key", "what_is_my_pubkey",
-								"--ecies-private-key", "what_is_my_privkey",
-								"--share-processor-private-key", "what_is_my_other_privkey",
-							},
+							Args:            args,
 							Name:            "facile-container",
 							Image:           "us.gcr.io/jsha-prio-bringup/letsencrypt/prio-facilitator:7.7.7",
 							ImagePullPolicy: "Always",
+							Env: []corev1.EnvVar{
+								{
+									Name: "BATCH_SIGNING_KEY",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{Key: *bskSecretName},
+									},
+								},
+								{
+									Name: "PACKET_DECRYPTION_KEYS",
+									ValueFrom: &corev1.EnvVarSource{
+										SecretKeyRef: &corev1.SecretKeySelector{Key: *pdksSecretName},
+									},
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Common args are stored in a ConfigMap, which is used by workflow-manager.

Remove the secret keys from the workflow container, and have the workflow container configure the facilitator container to receive them. This introduces two new flags to the workflow container to pass the names of those secrets.