### PR TITLE
Various fixes to get intake-batch going

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -371,6 +371,7 @@ fn main() -> Result<(), anyhow::Error> {
                 .arg(
                     Arg::with_name("pha-ecies-private-key")
                         .long("pha-ecies-private-key")
+                        .env("PHA_ECIES_PRIVATE_KEY")
                         .value_name("B64")
                         .help(
                             "Base64 encoded ECIES private key for the PHA \
@@ -388,6 +389,7 @@ fn main() -> Result<(), anyhow::Error> {
                 .arg(
                     Arg::with_name("facilitator-ecies-private-key")
                         .long("facilitator-ecies-private-key")
+                        .env("FACILITATOR_ECIES_PRIVATE_KEY")
                         .value_name("B64")
                         .help(
                             "Base64 encoded ECIES private key for the \
@@ -624,7 +626,7 @@ fn main() -> Result<(), anyhow::Error> {
             )?;
             Ok(())
         }
-        ("batch-intake", Some(sub_matches)) => {
+        ("intake-batch", Some(sub_matches)) => {
             let mut intake_transport = intake_transport_from_args(sub_matches)?;
 
             // We need the bucket to which we will write validations for the

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -61,10 +61,12 @@ pub struct SpecificManifest {
 
 /// Obtains a manifest file from the provided URL
 fn fetch_manifest(manifest_url: &str) -> Result<Response> {
-    if !manifest_url.starts_with("https://") {
-        return Err(anyhow!("Manifest must be fetched over HTTPS"));
-    }
-    let response = ureq::get(manifest_url)
+    let url_with_scheme = if !manifest_url.starts_with("https://") {
+        format!("https://{}", manifest_url)
+    } else {
+        manifest_url.to_owned()
+    };
+    let response = ureq::get(&url_with_scheme)
         // By default, ureq will wait forever to connect or
         // read.
         .timeout_connect(10_000) // ten seconds

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -61,12 +61,10 @@ pub struct SpecificManifest {
 
 /// Obtains a manifest file from the provided URL
 fn fetch_manifest(manifest_url: &str) -> Result<Response> {
-    let url_with_scheme = if !manifest_url.starts_with("https://") {
-        format!("https://{}", manifest_url)
-    } else {
-        manifest_url.to_owned()
-    };
-    let response = ureq::get(&url_with_scheme)
+    if !manifest_url.starts_with("https://") {
+        return Err(anyhow!("Manifest must be fetched over HTTPS"));
+    }
+    let response = ureq::get(manifest_url)
         // By default, ureq will wait forever to connect or
         // read.
         .timeout_connect(10_000) // ten seconds

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -154,12 +154,12 @@ resource "kubernetes_secret" "ingestion_packet_decryption_keys" {
   data = {
     # See comment on batch_signing_key, in modules/kubernetes/kubernetes.tf,
     # about the initial value and the lifecycle block here.
-    decryption_key = "not-a-real-key"
+    secret_key = "not-a-real-key"
   }
 
   lifecycle {
     ignore_changes = [
-      data
+      data["secret_key"]
     ]
   }
 }

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -197,10 +197,10 @@ resource "kubernetes_config_map" "intake_batch_job_config_map" {
     BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER = kubernetes_secret.batch_signing_key.metadata[0].name
     INGESTOR_IDENTITY                    = var.ingestion_bucket_role
     INGESTOR_INPUT                       = var.ingestion_bucket
-    INGESTOR_MANIFEST_BASE_URL           = var.ingestor_manifest_base_url
+    INGESTOR_MANIFEST_BASE_URL           = "https://${var.ingestor_manifest_base_url}"
     INSTANCE_NAME                        = var.data_share_processor_name
     PEER_IDENTITY                        = var.peer_validation_bucket_role
-    PEER_MANIFEST_BASE_URL               = var.peer_manifest_base_url
+    PEER_MANIFEST_BASE_URL               = "https://${var.peer_manifest_base_url}"
     OWN_OUTPUT                           = var.own_validation_bucket
   }
 }
@@ -220,15 +220,15 @@ resource "kubernetes_config_map" "aggregate_job_config_map" {
     BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER = kubernetes_secret.batch_signing_key.metadata[0].name
     INGESTOR_INPUT                       = "s3://${var.ingestion_bucket}"
     INGESTOR_IDENTITY                    = var.ingestion_bucket_role
-    INGESTOR_MANIFEST_BASE_URL           = var.ingestor_manifest_base_url
+    INGESTOR_MANIFEST_BASE_URL           = "https://${var.ingestor_manifest_base_url}"
     INSTANCE_NAME                        = var.data_share_processor_name
     OWN_INPUT                            = "gs://${var.own_validation_bucket}"
     OWN_MANIFEST_BASE_URL                = var.own_manifest_base_url
     PEER_INPUT                           = "s3://${var.peer_validation_bucket}"
     PEER_IDENTITY                        = var.peer_validation_bucket_role
-    PEER_MANIFEST_BASE_URL               = var.peer_manifest_base_url
+    PEER_MANIFEST_BASE_URL               = "https://${var.peer_manifest_base_url}"
     PORTAL_IDENTITY                      = var.sum_part_bucket_service_account_email
-    PORTAL_MANIFEST_BASE_URL             = var.portal_server_manifest_base_url
+    PORTAL_MANIFEST_BASE_URL             = "https://${var.portal_server_manifest_base_url}"
   }
 }
 

--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -255,13 +255,16 @@ func startJob(
 	clientset *kubernetes.Clientset,
 	batchName string,
 ) error {
-	jobName := fmt.Sprintf("i-batch-%s", strings.ReplaceAll(batchName, "/", "-"))
-
+	// batchName is like "kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771"
 	pathComponents := strings.Split(batchName, "/")
 	batchID := pathComponents[len(pathComponents)-1]
-	batchDate := strings.Join(pathComponents[0:len(pathComponents)-1], "/")
+	batchDate := strings.Join(pathComponents[1:len(pathComponents)-1], "/")
+	aggregationID := pathComponents[0]
+	jobName := fmt.Sprintf("i-batch-%s", batchID)
 
 	args := []string{
+		"intake-batch",
+		"--aggregation-id", aggregationID,
 		"--batch-id", batchID,
 		"--date", batchDate,
 	}
@@ -294,13 +297,23 @@ func startJob(
 								{
 									Name: "BATCH_SIGNING_KEY",
 									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{Key: *bskSecretName},
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: *bskSecretName,
+											},
+											Key: "secret_key",
+										},
 									},
 								},
 								{
 									Name: "PACKET_DECRYPTION_KEYS",
 									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{Key: *pdksSecretName},
+										SecretKeyRef: &corev1.SecretKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: *pdksSecretName,
+											},
+											Key: "secret_key",
+										},
 									},
 								},
 							},


### PR DESCRIPTION
deploy-tool:
libprio-rs expects to receive packet decryption keys as the X9.62
uncompressed public key, concatenated with the secret scalar, and not
the PKCS#8 documents that we were plugging into Kubernetes secrets.
deploy-tool now has logic to serialize the ECDSA keys it generates into
the desired format.

facilitator:
 - generate-ingestion-sample now consults environment variables for the
   ECIES encryption keys to use when generating data.
 - argument handling was incorrectly looking for "batch-intake" instead
   of "intake-batch"
 - manifest::fetch_manifest now makes sure to construct https:// URLs
   when fetching manifests.

terraform:
 - Use the same key name within all Kubernetes secrets for simplicity
 - Fix parameters to sample_maker cronjob

workflow-manager:
 - parse aggregation ID from batch filename
 - fix arguments to `facilitator intake-batch`
 - fix `SecretKeyRefs` set on intake-batch jobs to correctly reference
   key inside secrets