### PR TITLE
More fixes to get batch intake working

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -150,6 +150,7 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
         self.arg(
             Arg::with_name("instance-name")
                 .long("instance-name")
+                .env("INSTANCE_NAME")
                 .value_name("NAME")
                 .default_value("fake-pha-fake-ingestor")
                 .help("Name of this data share processor")
@@ -656,7 +657,7 @@ fn main() -> Result<(), anyhow::Error> {
             // We created the bucket to which we write copies of our validation
             // shares, so it is simply provided by argument.
             let own_validation_bucket =
-                StoragePath::from_str(matches.value_of("own-output").unwrap())?;
+                StoragePath::from_str(sub_matches.value_of("own-output").unwrap())?;
             let own_identity = sub_matches.value_of("own-identity");
             let mut own_validation_transport = SignableTransport {
                 transport: transport_for_path(own_validation_bucket, own_identity)?,

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -196,12 +196,12 @@ resource "kubernetes_config_map" "intake_batch_job_config_map" {
     AWS_ACCOUNT_ID                       = data.aws_caller_identity.current.account_id
     BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER = kubernetes_secret.batch_signing_key.metadata[0].name
     INGESTOR_IDENTITY                    = var.ingestion_bucket_role
-    INGESTOR_INPUT                       = var.ingestion_bucket
+    INGESTOR_INPUT                       = "s3://${var.ingestion_bucket}"
     INGESTOR_MANIFEST_BASE_URL           = "https://${var.ingestor_manifest_base_url}"
     INSTANCE_NAME                        = var.data_share_processor_name
     PEER_IDENTITY                        = var.peer_validation_bucket_role
     PEER_MANIFEST_BASE_URL               = "https://${var.peer_manifest_base_url}"
-    OWN_OUTPUT                           = var.own_validation_bucket
+    OWN_OUTPUT                           = "gs://${var.own_validation_bucket}"
   }
 }
 
@@ -257,6 +257,7 @@ resource "kubernetes_cron_job" "workflow_manager" {
               image = "${var.container_registry}/${var.workflow_manager_image}:${var.workflow_manager_version}"
               args = [
                 "--k8s-namespace", var.kubernetes_namespace,
+                "--k8s-service-account", kubernetes_service_account.workflow_manager.metadata[0].name,
                 "--input-bucket", var.ingestion_bucket,
                 "--bsk-secret-name", kubernetes_secret.batch_signing_key.metadata[0].name,
                 "--pdks-secret-name", var.packet_decryption_key_kubernetes_secret,

--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -62,6 +62,7 @@ func basename(s string) string {
 
 var k8sNS = flag.String("k8s-namespace", "", "Kubernetes namespace")
 var maxAge = flag.String("max-age", "1h", "Max age (in Go duration format) for batches to be worth processing.")
+var k8sServiceAccount = flag.String("k8s-service-account", "", "Kubernetes service account for intake and aggregate jobs")
 var bskSecretName = flag.String("bsk-secret-name", "", "Name of k8s secret for batch signing key")
 var pdksSecretName = flag.String("pdks-secret-name", "", "Name of k8s secret for packet decrypt keys")
 var intakeConfigMap = flag.String("intake-batch-config-map", "", "Name of config map for intake jobs")
@@ -307,7 +308,8 @@ func startJob(
 		Spec: batchv1.JobSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy: "Never",
+					ServiceAccountName: *k8sServiceAccount,
+					RestartPolicy:      "Never",
 					Containers: []corev1.Container{
 						{
 							Args:            args,


### PR DESCRIPTION
 - have facilitator check "INSTANCE_NAME" environment variable
 - include cloud storage service schema in bucket URLs when constructing
   intake config map
 - have workflow-manager spawn jobs as appropriate service account

With this commit, plus some hacks not worth documenting, I was able to
get batch intake working, emitting validation batches to both a
simulated peer bucket in S3 and an internal bucket in GCS.