### PR TITLE
Switch to env_logger for facilitator.

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -509,6 +509,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
+name = "env_logger"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54532e3223c5af90a6a757c90b5c5521564b07e5e7a958681bcd2afad421cdcd"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "error-chain"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +553,7 @@ dependencies = [
  "chrono",
  "clap",
  "derivative",
+ "env_logger",
  "hyper",
  "hyper-rustls 0.21.0",
  "log",
@@ -557,7 +571,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
- "simple_logger",
  "structopt",
  "tempfile",
  "thiserror",
@@ -812,6 +825,12 @@ name = "httpdate"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
+name = "humantime"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
@@ -1793,19 +1812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simple_logger"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd57f17c093ead1d4a1499dc9acaafdd71240908d64775465543b8d9a9f1d198"
-dependencies = [
- "atty",
- "chrono",
- "colored",
- "log",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1996,6 +2002,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2467,6 +2482,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -26,7 +26,7 @@ rusoto_s3 = { version = "0.45.0", default_features = false, features = ["rustls"
 rusoto_sts = { version = "0.45.0", default_features = false, features = ["rustls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-simple_logger = "1.11.0"
+env_logger = "0.8.1"
 structopt = "0.3"
 tempfile = "3.1.0"
 thiserror = "1.0"

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -290,8 +290,7 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
 
 fn main() -> Result<(), anyhow::Error> {
     use log::info;
-    use simple_logger::SimpleLogger;
-    SimpleLogger::new().init().unwrap();
+    env_logger::init();
 
     info!(
         "{} {} {}",

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Result};
 use chrono::{prelude::Utc, DateTime, Duration};
-use log::debug;
+use log::info;
 use serde::Deserialize;
 use std::{
     io,
@@ -216,7 +216,7 @@ impl GCSTransport {
 
 impl Transport for GCSTransport {
     fn get(&mut self, key: &str) -> Result<Box<dyn Read>> {
-        debug!("get {} as {:?}", self.path, self.oauth_token_provider);
+        info!("get {} as {:?}", self.path, self.oauth_token_provider);
         // Per API reference, the object key must be URL encoded.
         // API reference: https://cloud.google.com/storage/docs/json_api/v1/objects/get
         let encoded_key = urlencoding::encode(&[&self.path.key, key].concat());
@@ -252,7 +252,7 @@ impl Transport for GCSTransport {
     }
 
     fn put(&mut self, key: &str) -> Result<Box<dyn TransportWriter>> {
-        debug!("get {} as {:?}", self.path, self.oauth_token_provider);
+        info!("get {} as {:?}", self.path, self.oauth_token_provider);
         // The Oauth token will only be used once, during the call to
         // StreamingTransferWriter::new, so we don't have to worry about it
         // expiring during the lifetime of that object, and so obtain a token

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -6,7 +6,7 @@ use crate::{
 use anyhow::{Context, Result};
 use derivative::Derivative;
 use hyper_rustls::HttpsConnector;
-use log::debug;
+use log::info;
 use rusoto_core::{
     credential::{
         AutoRefreshingProvider, CredentialsError, DefaultCredentialsProvider, Secret, Variable,
@@ -183,7 +183,7 @@ type ClientProvider = Box<dyn Fn(&Region, Option<String>) -> Result<S3Client>>;
 
 impl Transport for S3Transport {
     fn get(&mut self, key: &str) -> Result<Box<dyn Read>> {
-        debug!("get {} as {:?}", self.path, self.iam_role);
+        info!("get {} as {:?}", self.path, self.iam_role);
         let mut runtime = basic_runtime()?;
         let client = (self.client_provider)(&self.path.region, self.iam_role.clone())?;
         let get_output = runtime
@@ -200,7 +200,7 @@ impl Transport for S3Transport {
     }
 
     fn put(&mut self, key: &str) -> Result<Box<dyn TransportWriter>> {
-        debug!("put {} as {:?}", self.path, self.iam_role);
+        info!("put {} as {:?}", self.path, self.iam_role);
         let writer = MultipartUploadWriter::new(
             self.path.bucket.to_owned(),
             format!("{}{}", &self.path.key, key),

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -202,6 +202,7 @@ resource "kubernetes_config_map" "intake_batch_job_config_map" {
     PEER_IDENTITY                        = var.peer_validation_bucket_role
     PEER_MANIFEST_BASE_URL               = "https://${var.peer_manifest_base_url}"
     OWN_OUTPUT                           = "gs://${var.own_validation_bucket}"
+    RUST_LOG                             = "info"
   }
 }
 
@@ -229,6 +230,7 @@ resource "kubernetes_config_map" "aggregate_job_config_map" {
     PEER_MANIFEST_BASE_URL               = "https://${var.peer_manifest_base_url}"
     PORTAL_IDENTITY                      = var.sum_part_bucket_service_account_email
     PORTAL_MANIFEST_BASE_URL             = "https://${var.portal_server_manifest_base_url}"
+    RUST_LOG                             = "info"
   }
 }
 


### PR DESCRIPTION
The full log output including TRACE was way too noisy. This configures
our default log level as "info," which we can change with env vars
later. We can also specialize per-module, turning up logs from some
components without turning them on for everything.