### PR TITLE
Set up two envs that can exchange validation shares

### DIFF
--- a/deploy-tool/main.go
+++ b/deploy-tool/main.go
@@ -20,11 +20,11 @@ import (
 	"github.com/abetterinternet/prio-server/deploy-tool/config"
 )
 
-// DEFAULT_PHA_ECIES_PRIVATE_KEY is a libprio-rs encoded ECIES private key. It
+// DefaultPHAECIESPrivateKey is a libprio-rs encoded ECIES private key. It
 // MUST match the constant of the same name in facilitator/src/test_utils.rs.
 // It is present here so that a test environment can be configured to use
 // predictable keys for packet decryption.
-const DEFAULT_PHA_ECIES_PRIVATE_KEY = "BIl6j+J6dYttxALdjISDv6ZI4/VWVEhUzaS05Lg" +
+const DefaultPHAECIESPrivateKey = "BIl6j+J6dYttxALdjISDv6ZI4/VWVEhUzaS05Lg" +
 	"rsfswmbLOgNt9HUC2E0w+9RqZx3XMkdEHBHfNuCSMpOwofVSq3TfyKwn0NrftKisKKVSaTOt5" +
 	"seJ67P5QL4hxgPWvxw=="
 
@@ -118,7 +118,7 @@ func marshalPKCS8PrivateKey(ecdsaKey *ecdsa.PrivateKey) ([]byte, error) {
 // default PHA ECIES private key compiled into the facilitator. This is intended
 // for test environments so they can use predictable keys.
 func marshalDefaultPHAECIESPrivateKey(ecdsaKey *ecdsa.PrivateKey) ([]byte, error) {
-	return base64.StdEncoding.DecodeString(DEFAULT_PHA_ECIES_PRIVATE_KEY)
+	return base64.StdEncoding.DecodeString(DefaultPHAECIESPrivateKey)
 }
 
 // generateAndDeployKeyPair generates a P-256 key pair and stores the base64

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -466,7 +466,7 @@ fn main() -> Result<(), anyhow::Error> {
                         )
                         .validator(date_validator),
                 )
-                .arg(Arg::with_name("is-first").long("is-first").help(
+                .arg(Arg::with_name("is-first").env("IS_FIRST").long("is-first").help(
                     "Whether this is the \"first\" server receiving a share, \
                     i.e., the PHA.",
                 ))
@@ -555,7 +555,7 @@ fn main() -> Result<(), anyhow::Error> {
                 .add_storage_arguments(Entity::Portal, InOut::Output)
                 .add_packet_decryption_key_argument()
                 .add_batch_signing_key_arguments()
-                .arg(Arg::with_name("is-first").long("is-first").help(
+                .arg(Arg::with_name("is-first").env("IS_FIRST").long("is-first").help(
                     "Whether this is the \"first\" server receiving a share, i.e., the PHA.",
                 )),
         )

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -50,6 +50,24 @@ variable "portal_server_manifest_base_url" {
   type = string
 }
 
+variable "test_peer_environment" {
+  type        = string
+  default     = ""
+  description = "Name of peer environment set up to test against this one (not to be used in production deployments)"
+}
+
+variable "test_peer_environment_with_fake_ingestors" {
+  type        = string
+  default     = ""
+  description = "Name of peer environment which contains fake ingestion servers set up to test against this one (not to be used in production deployments)"
+}
+
+variable "is_pha" {
+  type        = bool
+  default     = false
+  description = "Whether the data share processors created by this environment are \"first\" or \"PHA servers\""
+}
+
 terraform {
   backend "gcs" {}
 
@@ -180,23 +198,26 @@ locals {
 }
 
 module "data_share_processors" {
-  for_each                                = local.peer_ingestor_pairs
-  source                                  = "./modules/data_share_processor"
-  environment                             = var.environment
-  data_share_processor_name               = each.key
-  gcp_region                              = var.gcp_region
-  gcp_project                             = var.gcp_project
-  kubernetes_namespace                    = each.value.kubernetes_namespace
-  certificate_domain                      = "${var.environment}.certificates.${var.manifest_domain}"
-  ingestor_aws_role_arn                   = each.value.ingestor_aws_role_arn
-  ingestor_gcp_service_account_id         = each.value.ingestor_gcp_service_account_id
-  ingestor_manifest_base_url              = each.value.ingestor_manifest_base_url
-  packet_decryption_key_kubernetes_secret = each.value.packet_decryption_key_kubernetes_secret
-  peer_share_processor_aws_account_id     = jsondecode(data.http.peer_share_processor_global_manifest.body).server-identity.aws-account-id
-  peer_share_processor_manifest_base_url  = var.peer_share_processor_manifest_base_url
-  sum_part_bucket_service_account_email   = google_service_account.sum_part_bucket_writer.email
-  portal_server_manifest_base_url         = var.portal_server_manifest_base_url
-  own_manifest_base_url                   = module.manifest.base_url
+  for_each                                  = local.peer_ingestor_pairs
+  source                                    = "./modules/data_share_processor"
+  environment                               = var.environment
+  data_share_processor_name                 = each.key
+  gcp_region                                = var.gcp_region
+  gcp_project                               = var.gcp_project
+  kubernetes_namespace                      = each.value.kubernetes_namespace
+  certificate_domain                        = "${var.environment}.certificates.${var.manifest_domain}"
+  ingestor_aws_role_arn                     = each.value.ingestor_aws_role_arn
+  ingestor_gcp_service_account_id           = each.value.ingestor_gcp_service_account_id
+  ingestor_manifest_base_url                = each.value.ingestor_manifest_base_url
+  packet_decryption_key_kubernetes_secret   = each.value.packet_decryption_key_kubernetes_secret
+  peer_share_processor_aws_account_id       = jsondecode(data.http.peer_share_processor_global_manifest.body).server-identity.aws-account-id
+  peer_share_processor_manifest_base_url    = var.peer_share_processor_manifest_base_url
+  sum_part_bucket_service_account_email     = google_service_account.sum_part_bucket_writer.email
+  portal_server_manifest_base_url           = var.portal_server_manifest_base_url
+  own_manifest_base_url                     = module.manifest.base_url
+  test_peer_environment                     = var.test_peer_environment
+  test_peer_environment_with_fake_ingestors = var.test_peer_environment_with_fake_ingestors
+  is_pha                                    = var.is_pha
 
   depends_on = [module.gke]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,16 +53,16 @@ variable "portal_server_manifest_base_url" {
 variable "test_peer_environment" {
   type        = string
   default     = ""
-  description = "Name of peer environment set up to test against this one (not to be used in production deployments)"
+  description = "Name of peer environment set up to test against this one (not to be used in production deployments). Should not be set alongside test_peer_environment_with_fake_ingestors."
 }
 
 variable "test_peer_environment_with_fake_ingestors" {
   type        = string
   default     = ""
-  description = "Name of peer environment which contains fake ingestion servers set up to test against this one (not to be used in production deployments)"
+  description = "Name of peer environment which contains fake ingestion servers set up to test against this one (not to be used in production deployments). Should not be set alongside test_peer_environment."
 }
 
-variable "is_pha" {
+variable "is_first" {
   type        = bool
   default     = false
   description = "Whether the data share processors created by this environment are \"first\" or \"PHA servers\""
@@ -217,7 +217,7 @@ module "data_share_processors" {
   own_manifest_base_url                     = module.manifest.base_url
   test_peer_environment                     = var.test_peer_environment
   test_peer_environment_with_fake_ingestors = var.test_peer_environment_with_fake_ingestors
-  is_pha                                    = var.is_pha
+  is_first                                  = var.is_first
 
   depends_on = [module.gke]
 }
@@ -258,6 +258,6 @@ output "specific_manifests" {
   }
 }
 
-output "use_default_pha_ecies_key" {
+output "use_test_pha_decryption_key" {
   value = var.test_peer_environment_with_fake_ingestors != ""
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -257,3 +257,7 @@ output "specific_manifests" {
     }
   }
 }
+
+output "use_default_pha_ecies_key" {
+  value = var.test_peer_environment_with_fake_ingestors != ""
+}

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -66,7 +66,7 @@ variable "test_peer_environment_with_fake_ingestors" {
   type = string
 }
 
-variable "is_pha" {
+variable "is_first" {
   type = bool
 }
 
@@ -75,18 +75,19 @@ locals {
   # There are four cases for who is writing to this data share processor's
   # ingestion bucket, listed in the order we check for them:
   #
-  # 1 - This is a test peer environment that creates fake ingestors. The fake
+  # 1 - This is a test environment that creates fake ingestors. The fake
   #     ingestors assume this data share processor's aws_iam_role.bucket_role,
-  #     so, grant that role write permissions on the ingestion bucket.
-  # 2 - This is a test peer environment that does _not_ create fake ingestors.
-  #     We assume the test peer env uses the same AWS account ID and that it
-  #     follows the same naming conventions we do, and grant what should be the
-  #     corresponding data share processor's aws_iam_role.bucket_role access.
+  #     so grant that role write permissions on the ingestion bucket.
+  # 2 - This is a test environment that does _not_ create fake ingestors.
+  #     We assume the other test env (our peer) uses the same AWS account ID and
+  #     that it follows the same naming conventions we do, and grant what should
+  #     be the corresponding data share processor's aws_iam_role.bucket_role
+  #     access.
   # 3 - This is a non-test environment for an ingestor that advertises a GCP
   #     service account. We will have created
   #     aws_iam_role.ingestor_bucket_writer_role and grant it write access.
   # 4 - This is a non-test environment for an ingestor that advertises an AWS
-  #     role. We grant that arole write access.
+  #     role. We grant that role write access.
   ingestion_bucket_writer_role_arn = var.test_peer_environment != "" ? (
     aws_iam_role.bucket_role.arn
     ) : var.test_peer_environment_with_fake_ingestors != "" ? (
@@ -98,11 +99,11 @@ locals {
   )
   ingestion_bucket_name       = "${local.resource_prefix}-ingestion"
   peer_validation_bucket_name = "${local.resource_prefix}-peer-validation"
-  # If this is a test peer environment that creates fake ingestors, we make an
-  # educated guess about the name of the test peer's ingestion bucket so our
-  # fake ingestors can write ingestion batches to them. This assumes that the
-  # test peer follows our naming convention and that they are in the same AWS
-  # region as we are.
+  # If this environment creates fake ingestors, we make an educated guess about
+  # the name of the other test environment's ingestion bucket so our fake
+  # ingestors can write ingestion batches to them. This assumes that the
+  # other test environment follows our naming convention and that they are in
+  # the same AWS region as we are.
   test_peer_ingestion_bucket = var.test_peer_environment != "" ? (
     "${aws_s3_bucket.ingestion_bucket.region}/prio-${var.test_peer_environment}-${var.data_share_processor_name}-ingestion"
   ) : ""
@@ -334,7 +335,7 @@ module "kubernetes" {
   sum_part_bucket_service_account_email   = var.sum_part_bucket_service_account_email
   portal_server_manifest_base_url         = var.portal_server_manifest_base_url
   test_peer_ingestion_bucket              = local.test_peer_ingestion_bucket
-  is_pha                                  = var.is_pha
+  is_first                                = var.is_first
 }
 
 output "data_share_processor_name" {

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -58,15 +58,54 @@ variable "portal_server_manifest_base_url" {
   type = string
 }
 
+variable "test_peer_environment" {
+  type = string
+}
+
+variable "test_peer_environment_with_fake_ingestors" {
+  type = string
+}
+
+variable "is_pha" {
+  type = bool
+}
+
 locals {
   resource_prefix = "prio-${var.environment}-${var.data_share_processor_name}"
-  ingestion_bucket_writer_role_arn = var.ingestor_gcp_service_account_id != "" ? (
+  # There are four cases for who is writing to this data share processor's
+  # ingestion bucket, listed in the order we check for them:
+  #
+  # 1 - This is a test peer environment that creates fake ingestors. The fake
+  #     ingestors assume this data share processor's aws_iam_role.bucket_role,
+  #     so, grant that role write permissions on the ingestion bucket.
+  # 2 - This is a test peer environment that does _not_ create fake ingestors.
+  #     We assume the test peer env uses the same AWS account ID and that it
+  #     follows the same naming conventions we do, and grant what should be the
+  #     corresponding data share processor's aws_iam_role.bucket_role access.
+  # 3 - This is a non-test environment for an ingestor that advertises a GCP
+  #     service account. We will have created
+  #     aws_iam_role.ingestor_bucket_writer_role and grant it write access.
+  # 4 - This is a non-test environment for an ingestor that advertises an AWS
+  #     role. We grant that arole write access.
+  ingestion_bucket_writer_role_arn = var.test_peer_environment != "" ? (
+    aws_iam_role.bucket_role.arn
+    ) : var.test_peer_environment_with_fake_ingestors != "" ? (
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/prio-${var.test_peer_environment_with_fake_ingestors}-${var.data_share_processor_name}-bucket-role"
+    ) : var.ingestor_gcp_service_account_id != "" ? (
     aws_iam_role.ingestor_bucket_writer_role[0].arn
     ) : (
     var.ingestor_aws_role_arn
   )
   ingestion_bucket_name       = "${local.resource_prefix}-ingestion"
   peer_validation_bucket_name = "${local.resource_prefix}-peer-validation"
+  # If this is a test peer environment that creates fake ingestors, we make an
+  # educated guess about the name of the test peer's ingestion bucket so our
+  # fake ingestors can write ingestion batches to them. This assumes that the
+  # test peer follows our naming convention and that they are in the same AWS
+  # region as we are.
+  test_peer_ingestion_bucket = var.test_peer_environment != "" ? (
+    "${aws_s3_bucket.ingestion_bucket.region}/prio-${var.test_peer_environment}-${var.data_share_processor_name}-ingestion"
+  ) : ""
 }
 
 data "aws_caller_identity" "current" {}
@@ -214,7 +253,7 @@ resource "aws_s3_bucket" "peer_validation_bucket" {
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "${var.peer_share_processor_aws_account_id}"
+        "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/prio-${coalesce(var.test_peer_environment, var.test_peer_environment_with_fake_ingestors)}-${var.data_share_processor_name}-bucket-role"
       },
       "Action": [
         "s3:AbortMultipartUpload",
@@ -294,6 +333,8 @@ module "kubernetes" {
   own_manifest_base_url                   = var.own_manifest_base_url
   sum_part_bucket_service_account_email   = var.sum_part_bucket_service_account_email
   portal_server_manifest_base_url         = var.portal_server_manifest_base_url
+  test_peer_ingestion_bucket              = local.test_peer_ingestion_bucket
+  is_pha                                  = var.is_pha
 }
 
 output "data_share_processor_name" {

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -201,7 +201,7 @@ resource "kubernetes_config_map" "intake_batch_job_config_map" {
   data = {
     # PACKET_DECRYPTION_KEYS is a Kubernetes secret
     # BATCH_SIGNING_PRIVATE_KEY is a Kubernetes secret
-    #IS_FIRST = var.is_pha ? "TRUE" : "FALSE"
+    IS_FIRST                             = var.is_pha ? "true" : "false"
     AWS_ACCOUNT_ID                       = data.aws_caller_identity.current.account_id
     BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER = kubernetes_secret.batch_signing_key.metadata[0].name
     INGESTOR_IDENTITY                    = var.ingestion_bucket_role
@@ -225,7 +225,7 @@ resource "kubernetes_config_map" "aggregate_job_config_map" {
   data = {
     # PACKET_DECRYPTION_KEYS is a Kubernetes secret
     # BATCH_SIGNING_PRIVATE_KEY is a Kubernetes secret
-    #IS_FIRST = var.is_pha ? "TRUE" : "FALSE"
+    IS_FIRST                             = var.is_pha ? "true" : "false"
     AWS_ACCOUNT_ID                       = data.aws_caller_identity.current.account_id
     BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER = kubernetes_secret.batch_signing_key.metadata[0].name
     INGESTOR_INPUT                       = "s3://${var.ingestion_bucket}"
@@ -340,15 +340,9 @@ resource "kubernetes_cron_job" "sample_maker" {
                 name  = "AWS_ACCOUNT_ID"
                 value = data.aws_caller_identity.current.account_id
               }
-              env {
-                name = "PHA_ECIES_PRIVATE_KEY"
-                value_from {
-                  secret_key_ref {
-                    name = var.packet_decryption_key_kubernetes_secret
-                    key  = "secret_key"
-                  }
-                }
-              }
+              # We intentionally do not specify PHA_ECIES_PRIVATE_KEY, so that
+              # facilitator will use the DEFAULT_PHA_ECIES_PRIVATE_KEY, which
+              # the facilitators in the peer test env have access to.
               env {
                 name = "FACILITATOR_ECIES_PRIVATE_KEY"
                 value_from {

--- a/terraform/variables/demo-gcp-peer.tfvars
+++ b/terraform/variables/demo-gcp-peer.tfvars
@@ -1,0 +1,19 @@
+environment                = "demo-gcp-peer"
+gcp_region                 = "us-west1"
+gcp_project                = "prio-bringup-290620"
+machine_type               = "e2-small"
+peer_share_processor_names = ["test-pha-1", "test-pha-2"]
+aws_region                 = "us-west-1"
+manifest_domain            = "isrg-prio.org"
+managed_dns_zone = {
+  name        = "manifests"
+  gcp_project = "prio-bringup-290620"
+}
+ingestors = {
+  ingestor-1 = "storage.googleapis.com/prio-demo-gcp-manifests/ingestor-1"
+  ingestor-2 = "storage.googleapis.com/prio-demo-gcp-manifests/ingestor-2"
+}
+peer_share_processor_manifest_base_url    = "demo-gcp.manifests.isrg-prio.org"
+portal_server_manifest_base_url           = "storage.googleapis.com/prio-demo-gcp-manifests/portal-server"
+test_peer_environment_with_fake_ingestors = "demo-gcp"
+is_pha                                    = true

--- a/terraform/variables/demo-gcp-peer.tfvars
+++ b/terraform/variables/demo-gcp-peer.tfvars
@@ -16,4 +16,4 @@ ingestors = {
 peer_share_processor_manifest_base_url    = "demo-gcp.manifests.isrg-prio.org"
 portal_server_manifest_base_url           = "storage.googleapis.com/prio-demo-gcp-manifests/portal-server"
 test_peer_environment_with_fake_ingestors = "demo-gcp"
-is_pha                                    = true
+is_first                                  = true

--- a/terraform/variables/demo-gcp.tfvars
+++ b/terraform/variables/demo-gcp.tfvars
@@ -13,5 +13,6 @@ ingestors = {
   ingestor-1 = "storage.googleapis.com/prio-demo-gcp-manifests/ingestor-1"
   ingestor-2 = "storage.googleapis.com/prio-demo-gcp-manifests/ingestor-2"
 }
-peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-demo-gcp-manifests/pha-servers"
+peer_share_processor_manifest_base_url = "demo-gcp-peer.manifests.isrg-prio.org"
 portal_server_manifest_base_url        = "storage.googleapis.com/prio-demo-gcp-manifests/portal-server"
+test_peer_environment                  = "demo-gcp-peer"


### PR DESCRIPTION
This series of commits creates a new env, `demo-gcp-peer`, and sets it and `demo-gcp` up to consume ingestion batches and then exchange validation batches. `demo-gcp` contains per-data-share-processor instances of a `sample-maker` job which is set up to emit ingestion batches to the data share processor in its own env as well as the corresponding one in `demo-gcp-peer`. We use the top-level variables `test_peer_environment` and `test_peer_environment_with_fake_ingestors` so that the envs can figure out if (1) they are being created in a test environment and (2) whether they are the test env that contains the sample-makers.

This also exposes a config value for whether this env's data share processors are "first", a.k.a. "PHA servers.

With these changes, I was able to encrypt and sign ingestion batches and upload them to both env's ingestion buckets. I was then able to have both env's workflow-managers discover the ingestion batches and schedule intake-batch jobs. Finally, the intake-batch jobs successfully did their intake (verifying batch signatures and decrypting packets) and then constructed and emitted validation batches to all expected buckets (peer and own validation bucket for both envs).

A remaining problem here is how data share processors grant each other access to peer validation buckets. The plan is to construct IAM bucket policies that grant access to a whole account, with an IAM principal like `"AWS": "arn:aws:iam::3XXX765XXX13:root"`. Empirically that doesn't work, though all the AWS S3 and IAM docs say it should. To enable this test setup, we put in a more specific AWS IAM role, but in a real deployment, we can't do that.