### PR TITLE
Parameterize the facilitator image.

### DIFF
--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -280,6 +280,7 @@ resource "kubernetes_cron_job" "workflow_manager" {
                 "--pdks-secret-name", var.packet_decryption_key_kubernetes_secret,
                 "--intake-batch-config-map", kubernetes_config_map.intake_batch_job_config_map.metadata[0].name,
                 "--aggregate-config-map", kubernetes_config_map.aggregate_job_config_map.metadata[0].name,
+                "--facilitator-image", "${var.container_registry}/${var.facilitator_image}:${var.facilitator_version}",
               ]
             }
             # If we use any other restart policy, then when the job is finally

--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -121,9 +121,8 @@ func validationBasename(s string, isFirst bool) string {
 func index(isFirst bool) string {
 	if isFirst {
 		return "0"
-	} else {
-		return "1"
 	}
+	return "1"
 }
 
 // contains returns true if the string str exists in the slice s
@@ -167,6 +166,7 @@ var ownValidationInput = flag.String("own-validation-input", "", "Bucket for inp
 var ownValidationIdentity = flag.String("own-validation-identity", "", "Identity to use with own validation bucket (Required for S3)")
 var peerValidationInput = flag.String("peer-validation-input", "", "Bucket for input of validation batches from peer (s3:// or gs://) (required)")
 var peerValidationIdentity = flag.String("peer-validation-identity", "", "Identity to use with peer validation bucket (Required for S3)")
+var facilitatorImage = flag.String("facilitator-image", "", "Name (optionally including repository) of facilitator image")
 
 func main() {
 	log.Printf("starting %s version %s - %s. Args: %s", os.Args[0], BuildID, BuildTime, os.Args[1:])
@@ -178,6 +178,9 @@ func main() {
 
 	if *intakeConfigMap == "" || *aggregateConfigMap == "" {
 		log.Fatal("--intake-batch-config-map and --aggregate-config-map are required")
+	}
+	if *facilitatorImage == "" {
+		log.Fatal("--facilitator-image is required")
 	}
 
 	ageLimit, err := time.ParseDuration(*maxAge)
@@ -587,7 +590,7 @@ func launchAggregationJob(ctx context.Context, readyBatches []string) error {
 						{
 							Args:            args,
 							Name:            "facile-container",
-							Image:           "us.gcr.io/prio-bringup-290620/prio-facilitator:latest",
+							Image:           *facilitatorImage,
 							ImagePullPolicy: "Always",
 							EnvFrom: []corev1.EnvFromSource{
 								{
@@ -703,7 +706,7 @@ func startIntakeJob(
 						{
 							Args:            args,
 							Name:            "facile-container",
-							Image:           "us.gcr.io/jsha-prio-bringup/letsencrypt/prio-facilitator:1.2.3",
+							Image:           *facilitatorImage,
 							ImagePullPolicy: "Always",
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{


### PR DESCRIPTION
This allows setting the facilitator image in Terraform rather than hardcoding it in the workflow-manager binary. Note that this allows anyone who can provide arguments to workflow-manager to cause workflow-manager to run an arbitrary image with access to the facilitator's secrets and service account.