### PR TITLE
Apply Cache-Control: no-cache header on manifests

### DIFF
--- a/deploy-tool/main.go
+++ b/deploy-tool/main.go
@@ -278,8 +278,10 @@ func main() {
 		destination := fmt.Sprintf("gs://%s/%s-manifest.json",
 			terraformOutput.ManifestBucket.Value, dataShareProcessorName)
 		log.Printf("uploading specific manifest %s", destination)
-		gsutil := exec.Command("gsutil", "-h",
-			"Content-Type:application/json", "cp", "-", destination)
+		gsutil := exec.Command("gsutil",
+			"-h", "Content-Type:application/json",
+			"-h", "Cache-Control:no-cache",
+			"cp", "-", destination)
 		stdin, err := gsutil.StdinPipe()
 		if err != nil {
 			log.Fatalf("could not get pipe to gsutil stdin: %v", err)

--- a/terraform/modules/manifest/manifest.tf
+++ b/terraform/modules/manifest/manifest.tf
@@ -50,10 +50,11 @@ resource "google_storage_bucket_iam_binding" "public_read" {
 
 # Puts this data share processor's global manifest into the bucket.
 resource "google_storage_bucket_object" "global_manifest" {
-  provider     = google-beta
-  name         = "global-manifest.json"
-  bucket       = google_storage_bucket.manifests.name
-  content_type = "application/json"
+  provider      = google-beta
+  name          = "global-manifest.json"
+  bucket        = google_storage_bucket.manifests.name
+  content_type  = "application/json"
+  cache_control = "no-cache"
   content = jsonencode({
     format = 0
     server-identity = {


### PR DESCRIPTION
It looks like the load balancer observes the cache-control header on the
origin, and Google Storage sets cache-control on a per-object basis,
with a default of 1 hour for public objects.

This prevents getting confusing results during debugging if you've edited
a manifest.