### PR TITLE
More robust paired test env

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -511,6 +511,7 @@ fn main() -> Result<(), anyhow::Error> {
                         .long("aggregation-start")
                         .value_name("DATE")
                         .help("Beginning of the timespan covered by the aggregation.")
+                        .required(true)
                         .validator(date_validator),
                 )
                 .arg(
@@ -518,6 +519,7 @@ fn main() -> Result<(), anyhow::Error> {
                         .long("aggregation-end")
                         .value_name("DATE")
                         .help("End of the timespan covered by the aggregation.")
+                        .required(true)
                         .validator(date_validator),
                 )
                 .add_manifest_base_url_argument(Entity::Ingestor)

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -15,10 +15,6 @@ use facilitator::{
     intake::BatchIntaker,
     manifest::{IngestionServerGlobalManifest, PortalServerGlobalManifest, SpecificManifest},
     sample::generate_ingestion_sample,
-    test_utils::{
-        DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY, DEFAULT_FACILITATOR_SIGNING_PRIVATE_KEY,
-        DEFAULT_PHA_ECIES_PRIVATE_KEY,
-    },
     transport::{
         GCSTransport, LocalFileTransport, S3Transport, SignableTransport, Transport,
         VerifiableAndDecryptableTransport, VerifiableTransport,
@@ -156,7 +152,7 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                 .value_name("BOOL")
                 .possible_value("true")
                 .possible_value("false")
-                .default_value("false")
+                .required(true)
                 .help(
                     "Whether this is the \"first\" server receiving a share, \
                     i.e., the PHA.",
@@ -169,7 +165,7 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                 .long("instance-name")
                 .env("INSTANCE_NAME")
                 .value_name("NAME")
-                .default_value("fake-pha-fake-ingestor")
+                .required(true)
                 .help("Name of this data share processor")
                 .long_help(
                     "Name of this data share processor instance, to be used to \
@@ -210,7 +206,6 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                 .env(name_env)
                 .value_name("PATH")
                 .validator(path_validator)
-                .default_value(".")
                 .help("Storage path (gs://, s3:// or local dir name)"),
         )
         .arg(
@@ -234,8 +229,6 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                     "Batch signing public key for the {}",
                     entity.str()
                 )))
-                .default_value(DEFAULT_FACILITATOR_SIGNING_PRIVATE_KEY)
-                .hide_default_value(true)
                 .validator(b64_validator),
         )
         .arg(
@@ -245,8 +238,7 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                 .help(leak_string(format!(
                     "Identifier for the {}'s batch keypair",
                     entity.str()
-                )))
-                .default_value("default-batch-signing-key-id"),
+                ))),
         )
     }
 
@@ -260,11 +252,9 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                 .long_help(
                     "Base64 encoded PKCS#8 document containing P-256 \
                     batch signing private key to be used by this server when \
-                    sending messages to other servers. If not specified, a \
-                    fixed private key is used.",
+                    sending messages to other servers.",
                 )
-                .default_value(DEFAULT_FACILITATOR_SIGNING_PRIVATE_KEY)
-                .hide_default_value(true)
+                .required(true)
                 .validator(b64_validator),
         )
         .arg(
@@ -279,8 +269,7 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                     or specific manifest. Used to construct \
                     PrioBatchSignature messages.",
                 )
-                .default_value("default-batch-signing-key-id")
-                .hide_default_value(true),
+                .required(true),
         )
     }
 
@@ -299,8 +288,7 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                 .min_values(1)
                 .use_delimiter(true)
                 .validator(b64_validator)
-                .default_value(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY)
-                .hide_default_value(true),
+                .required(true),
         )
     }
 }
@@ -339,7 +327,7 @@ fn main() -> Result<(), anyhow::Error> {
                     Arg::with_name("aggregation-id")
                         .long("aggregation-id")
                         .value_name("ID")
-                        .default_value("fake-aggregation")
+                        .required(true)
                         .help("Name of the aggregation"),
                 )
                 .arg(
@@ -368,7 +356,7 @@ fn main() -> Result<(), anyhow::Error> {
                         .long("dimension")
                         .short("d")
                         .value_name("INT")
-                        .default_value("123")
+                        .required(true)
                         .validator(num_validator::<i32>)
                         .help(
                             "Length in bits of the data packets to generate \
@@ -381,7 +369,7 @@ fn main() -> Result<(), anyhow::Error> {
                         .long("packet-count")
                         .short("p")
                         .value_name("INT")
-                        .default_value("10")
+                        .required(true)
                         .validator(num_validator::<usize>)
                         .help("Number of data packets to generate"),
                 )
@@ -394,13 +382,7 @@ fn main() -> Result<(), anyhow::Error> {
                             "Base64 encoded ECIES private key for the PHA \
                             server",
                         )
-                        .long_help(
-                            "Base64 encoded private key for the PHA \
-                            server. If not specified, a fixed private key will \
-                            be used.",
-                        )
-                        .default_value(DEFAULT_PHA_ECIES_PRIVATE_KEY)
-                        .hide_default_value(true)
+                        .required(true)
                         .validator(b64_validator),
                 )
                 .arg(
@@ -412,13 +394,7 @@ fn main() -> Result<(), anyhow::Error> {
                             "Base64 encoded ECIES private key for the \
                             facilitator server",
                         )
-                        .long_help(
-                            "Base64 encoded ECIES private key for the \
-                            facilitator server. If not specified, a fixed \
-                            private key will be used.",
-                        )
-                        .default_value(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY)
-                        .hide_default_value(true)
+                        .required(true)
                         .validator(b64_validator),
                 )
                 .add_batch_signing_key_arguments()
@@ -430,7 +406,7 @@ fn main() -> Result<(), anyhow::Error> {
                             "Differential privacy parameter for local \
                             randomization before aggregation",
                         )
-                        .default_value("0.23")
+                        .required(true)
                         .validator(num_validator::<f64>),
                 )
                 .arg(
@@ -438,7 +414,7 @@ fn main() -> Result<(), anyhow::Error> {
                         .long("batch-start-time")
                         .value_name("MILLIS")
                         .help("Start of timespan covered by the batch, in milliseconds since epoch")
-                        .default_value("1000000000")
+                        .required(true)
                         .validator(num_validator::<i64>),
                 )
                 .arg(
@@ -446,7 +422,7 @@ fn main() -> Result<(), anyhow::Error> {
                         .long("batch-end-time")
                         .value_name("MILLIS")
                         .help("End of timespan covered by the batch, in milliseconds since epoch")
-                        .default_value("1000000100")
+                        .required(true)
                         .validator(num_validator::<i64>),
                 ),
         )
@@ -459,17 +435,15 @@ fn main() -> Result<(), anyhow::Error> {
                     Arg::with_name("aggregation-id")
                         .long("aggregation-id")
                         .value_name("ID")
-                        .default_value("fake-aggregation")
+                        .required(true)
                         .help("Name of the aggregation"),
                 )
                 .arg(
                     Arg::with_name("batch-id")
                         .long("batch-id")
                         .value_name("UUID")
-                        .help(
-                            "UUID of the batch. If omitted, a UUID is \
-                            randomly generated.",
-                        )
+                        .help("UUID of the batch.")
+                        .required(true)
                         .validator(uuid_validator),
                 )
                 .arg(
@@ -477,11 +451,8 @@ fn main() -> Result<(), anyhow::Error> {
                         .long("date")
                         .value_name("DATE")
                         .help("Date for the batch in YYYY/mm/dd/HH/MM format")
-                        .long_help(
-                            "Date for the batch in YYYY/mm/dd/HH/MM format. If \
-                            omitted, the current date is used.",
-                        )
-                        .validator(date_validator),
+                        .validator(date_validator)
+                        .required(true),
                 )
                 .add_packet_decryption_key_argument()
                 .add_batch_public_key_arguments(Entity::Ingestor)
@@ -501,7 +472,7 @@ fn main() -> Result<(), anyhow::Error> {
                     Arg::with_name("aggregation-id")
                         .long("aggregation-id")
                         .value_name("ID")
-                        .default_value("fake-aggregation")
+                        .required(true)
                         .help("Name of the aggregation"),
                 )
                 .arg(
@@ -540,10 +511,6 @@ fn main() -> Result<(), anyhow::Error> {
                         .long("aggregation-start")
                         .value_name("DATE")
                         .help("Beginning of the timespan covered by the aggregation.")
-                        .long_help(
-                            "Beginning of the timespan covered by the \
-                            aggregation. If omitted, the current time is used.",
-                        )
                         .validator(date_validator),
                 )
                 .arg(
@@ -551,10 +518,6 @@ fn main() -> Result<(), anyhow::Error> {
                         .long("aggregation-end")
                         .value_name("DATE")
                         .help("End of the timespan covered by the aggregation.")
-                        .long_help(
-                            "End of the timespan covered by the aggregation \
-                            If omitted, the current time is used.",
-                        )
                         .validator(date_validator),
                 )
                 .add_manifest_base_url_argument(Entity::Ingestor)
@@ -677,13 +640,9 @@ fn main() -> Result<(), anyhow::Error> {
 
             let mut batch_intaker = BatchIntaker::new(
                 &sub_matches.value_of("aggregation-id").unwrap(),
-                &sub_matches
-                    .value_of("batch-id")
-                    .map_or_else(Uuid::new_v4, |v| Uuid::parse_str(v).unwrap()),
-                &sub_matches.value_of("date").map_or_else(
-                    || Utc::now().naive_utc(),
-                    |v| NaiveDateTime::parse_from_str(&v, DATE_FORMAT).unwrap(),
-                ),
+                &Uuid::parse_str(sub_matches.value_of("batch-id").unwrap()).unwrap(),
+                &NaiveDateTime::parse_from_str(&sub_matches.value_of("date").unwrap(), DATE_FORMAT)
+                    .unwrap(),
                 &mut intake_transport,
                 &mut peer_validation_transport,
                 &mut own_validation_transport,
@@ -806,14 +765,16 @@ fn main() -> Result<(), anyhow::Error> {
             let batch_info: Vec<_> = batch_ids.into_iter().zip(batch_dates).collect();
             BatchAggregator::new(
                 &sub_matches.value_of("aggregation-id").unwrap(),
-                &sub_matches.value_of("aggregation-start").map_or_else(
-                    || Utc::now().naive_utc(),
-                    |v| NaiveDateTime::parse_from_str(&v, DATE_FORMAT).unwrap(),
-                ),
-                &sub_matches.value_of("aggregation-end").map_or_else(
-                    || Utc::now().naive_utc(),
-                    |v| NaiveDateTime::parse_from_str(&v, DATE_FORMAT).unwrap(),
-                ),
+                &NaiveDateTime::parse_from_str(
+                    &sub_matches.value_of("aggregation-start").unwrap(),
+                    DATE_FORMAT,
+                )
+                .unwrap(),
+                &NaiveDateTime::parse_from_str(
+                    &sub_matches.value_of("aggregation-end").unwrap(),
+                    DATE_FORMAT,
+                )
+                .unwrap(),
                 is_first,
                 &mut intake_transport,
                 &mut VerifiableTransport {

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -104,6 +104,16 @@ apply-bootstrap: prep ## Have terraform bring up the minimal resources needed to
 		-target=module.manifest \
 		-target=module.fake_server_resources
 
+.PHONY: destroy-bootstrap
+destroy-bootstrap: prep ## Have terraform destroy the resources brought up by apply-bootstrap
+	@terraform destroy \
+		-lock=true \
+		-input=false \
+		-refresh=true \
+		-var-file="$(VARS)" \
+		-target=module.manifest \
+		-target=module.fake_server_resources
+
 .PHONY: apply-target
 apply-target: prep ## Have terraform do the things for a specific resource. This will cost money.
 	@echo "$(YELLOW)$(BOLD)[INFO]   $(RESET)"; echo "Example to type for the following question: module.gke.google_container_cluster.cluster"

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -101,7 +101,8 @@ apply-bootstrap: prep ## Have terraform bring up the minimal resources needed to
 		-input=false \
 		-refresh=true \
 		-var-file="$(VARS)" \
-		-target=module.manifest
+		-target=module.manifest \
+		-target=module.fake_server_resources
 
 .PHONY: apply-target
 apply-target: prep ## Have terraform do the things for a specific resource. This will cost money.

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -94,6 +94,15 @@ apply: prep ## Have terraform do the things. This will cost money.
 		-var-file="$(VARS)"
 	echo "If that succeeded, run 'terraform output --json | (cd ../deploy-tool/ ; go run main.go )'"
 
+.PHONY: apply-bootstrap
+apply-bootstrap: prep ## Have terraform bring up the minimal resources needed to bootstrap an env and permit peers to begin deploying
+	@terraform apply \
+		-lock=true \
+		-input=false \
+		-refresh=true \
+		-var-file="$(VARS)" \
+		-target=module.manifest
+
 .PHONY: apply-target
 apply-target: prep ## Have terraform do the things for a specific resource. This will cost money.
 	@echo "$(YELLOW)$(BOLD)[INFO]   $(RESET)"; echo "Example to type for the following question: module.gke.google_container_cluster.cluster"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -52,6 +52,9 @@ The values must correspond to the names of the environments you are using. Pick 
 
     ENV=with-ingestor make apply-bootstrap
     ENV=without-ingestor make apply-bootstrap
+
+After the successful `apply-bootstrap` you may need to wait several minutes for managed TLS certificates to finish provisioning. Once those are in place, move on to the full deployment:
+
     ENV=with-ingestor make apply
     ENV=without-ingestor make apply
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -27,7 +27,24 @@ If you're having problems, check `gcloud config list` and `kubectl config curren
 
 ## New clusters
 
-To add a data share processor to support a new PHA in an existing region, add their PHA name to the `peer_share_processor_names` variable in the relevant `variables/<environment>.tfvars` file. To bring up a whole new cluster, drop a `your-new-environment.tfvars` file in `variables`, fill in the required variables and use `ENV=your-new-environment make apply` to deploy it. Multiple environments may be deployed to the same GCP region.
+To add a data share processor to support a new PHA in an existing region, add their PHA name to the `peer_share_processor_names` variable in the relevant `variables/<environment>.tfvars` file.
+
+To bring up a whole new cluster, drop a `your-new-environment.tfvars` file in `variables`, fill in the required variables and then bootstrap it with:
+
+    ENV=your-new-environment make apply-bootstrap
+
+This will deploy just enough of an environment to permit peers to begin deploying resources. Once your environment is bootstrapped, and once all the other servers you intend to exchange data with have bootstrapped, finish the deploy with
+
+    ENV=your-new-environment make apply
+
+Once bootstrapped, subsequent deployments should use `ENV=your-new-environment make apply`. Multiple environments may be deployed to the same GCP region.
+
+For example, let's suppose you were setting up two environments, `test-1` and `test-2` and configuring them to exchange shares. Once you've set up their .tfvars to refer to each other (on which topic documentation will soon follow), you might do:
+
+    ENV=test-1 make apply-bootstrap
+    ENV=test-2 make apply-bootstrap
+    ENV=test-1 make apply
+    ENV=test-2 make apply
 
 ## kubectl configuration
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -39,12 +39,21 @@ This will deploy just enough of an environment to permit peers to begin deployin
 
 Once bootstrapped, subsequent deployments should use `ENV=your-new-environment make apply`. Multiple environments may be deployed to the same GCP region.
 
-For example, let's suppose you were setting up two environments, `test-1` and `test-2` and configuring them to exchange shares. Once you've set up their .tfvars to refer to each other (on which topic documentation will soon follow), you might do:
+## Paired test environments
 
-    ENV=test-1 make apply-bootstrap
-    ENV=test-2 make apply-bootstrap
-    ENV=test-1 make apply
-    ENV=test-2 make apply
+We have support for creating two paired test environments which can exchange validation shares, along with a convincing simulation of ingestion servers and a portal server. To do this, you will need to create two `.tfvars` files, and on top of the usual variables, each must contain a variable like:
+
+    test_peer_environment = {
+      env_with_ingestor    = "with-ingestor"
+      env_without_ingestor = "without-ingestor"
+    }
+
+The values must correspond to the names of the environments you are using. Pick one of them to be the environment with ingestors. From there, you should be able to bring up the two environments like so:
+
+    ENV=with-ingestor make apply-bootstrap
+    ENV=without-ingestor make apply-bootstrap
+    ENV=with-ingestor make apply
+    ENV=without-ingestor make apply
 
 ## kubectl configuration
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -51,15 +51,14 @@ variable "portal_server_manifest_base_url" {
 }
 
 variable "test_peer_environment" {
-  type        = string
-  default     = ""
-  description = "Name of peer environment set up to test against this one (not to be used in production deployments). Should not be set alongside test_peer_environment_with_fake_ingestors."
-}
-
-variable "test_peer_environment_with_fake_ingestors" {
-  type        = string
-  default     = ""
-  description = "Name of peer environment which contains fake ingestion servers set up to test against this one (not to be used in production deployments). Should not be set alongside test_peer_environment."
+  type        = map(string)
+  default     = {}
+  description = <<DESCRIPTION
+Describes a pair of data share processor environments set up to test against
+each other. One environment, named in "env_with_ingestor", hosts a fake
+ingestion server. The other, named in "env_without_ingestor", does not. This
+variable should not be specified in production deployments.
+DESCRIPTION
 }
 
 variable "is_first" {
@@ -215,8 +214,8 @@ module "data_share_processors" {
   sum_part_bucket_service_account_email     = google_service_account.sum_part_bucket_writer.email
   portal_server_manifest_base_url           = var.portal_server_manifest_base_url
   own_manifest_base_url                     = module.manifest.base_url
-  test_peer_environment                     = var.test_peer_environment
-  test_peer_environment_with_fake_ingestors = var.test_peer_environment_with_fake_ingestors
+  test_peer_environment                     = var.test_peer_environment.env_without_ingestor
+  test_peer_environment_with_fake_ingestors = var.test_peer_environment.env_with_ingestor
   is_first                                  = var.is_first
 
   depends_on = [module.gke]
@@ -241,6 +240,16 @@ resource "google_service_account_iam_binding" "data_share_processors_to_sum_part
   members            = [for v in module.data_share_processors : v.service_account_email]
 }
 
+module "fake_server_resources" {
+  count                        = lookup(var.test_peer_environment, "env_with_ingestor", "") == "" ? 0 : 1
+  source                       = "./modules/fake_server_resources"
+  manifest_bucket              = module.manifest.bucket
+  gcp_region                   = var.gcp_region
+  environment                  = var.environment
+  sum_part_bucket_writer_email = google_service_account.sum_part_bucket_writer.email
+  ingestors                    = var.ingestors
+}
+
 output "manifest_bucket" {
   value = module.manifest.bucket
 }
@@ -259,5 +268,5 @@ output "specific_manifests" {
 }
 
 output "use_test_pha_decryption_key" {
-  value = var.test_peer_environment_with_fake_ingestors != ""
+  value = lookup(var.test_peer_environment, "env_without_ingestor", "") == var.environment
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -197,26 +197,25 @@ locals {
 }
 
 module "data_share_processors" {
-  for_each                                  = local.peer_ingestor_pairs
-  source                                    = "./modules/data_share_processor"
-  environment                               = var.environment
-  data_share_processor_name                 = each.key
-  gcp_region                                = var.gcp_region
-  gcp_project                               = var.gcp_project
-  kubernetes_namespace                      = each.value.kubernetes_namespace
-  certificate_domain                        = "${var.environment}.certificates.${var.manifest_domain}"
-  ingestor_aws_role_arn                     = each.value.ingestor_aws_role_arn
-  ingestor_gcp_service_account_id           = each.value.ingestor_gcp_service_account_id
-  ingestor_manifest_base_url                = each.value.ingestor_manifest_base_url
-  packet_decryption_key_kubernetes_secret   = each.value.packet_decryption_key_kubernetes_secret
-  peer_share_processor_aws_account_id       = jsondecode(data.http.peer_share_processor_global_manifest.body).server-identity.aws-account-id
-  peer_share_processor_manifest_base_url    = var.peer_share_processor_manifest_base_url
-  sum_part_bucket_service_account_email     = google_service_account.sum_part_bucket_writer.email
-  portal_server_manifest_base_url           = var.portal_server_manifest_base_url
-  own_manifest_base_url                     = module.manifest.base_url
-  test_peer_environment                     = var.test_peer_environment.env_without_ingestor
-  test_peer_environment_with_fake_ingestors = var.test_peer_environment.env_with_ingestor
-  is_first                                  = var.is_first
+  for_each                                = local.peer_ingestor_pairs
+  source                                  = "./modules/data_share_processor"
+  environment                             = var.environment
+  data_share_processor_name               = each.key
+  gcp_region                              = var.gcp_region
+  gcp_project                             = var.gcp_project
+  kubernetes_namespace                    = each.value.kubernetes_namespace
+  certificate_domain                      = "${var.environment}.certificates.${var.manifest_domain}"
+  ingestor_aws_role_arn                   = each.value.ingestor_aws_role_arn
+  ingestor_gcp_service_account_id         = each.value.ingestor_gcp_service_account_id
+  ingestor_manifest_base_url              = each.value.ingestor_manifest_base_url
+  packet_decryption_key_kubernetes_secret = each.value.packet_decryption_key_kubernetes_secret
+  peer_share_processor_aws_account_id     = jsondecode(data.http.peer_share_processor_global_manifest.body).server-identity.aws-account-id
+  peer_share_processor_manifest_base_url  = var.peer_share_processor_manifest_base_url
+  sum_part_bucket_service_account_email   = google_service_account.sum_part_bucket_writer.email
+  portal_server_manifest_base_url         = var.portal_server_manifest_base_url
+  own_manifest_base_url                   = module.manifest.base_url
+  test_peer_environment                   = var.test_peer_environment
+  is_first                                = var.is_first
 
   depends_on = [module.gke]
 }

--- a/terraform/modules/fake_server_resources/fake_server_resources.tf
+++ b/terraform/modules/fake_server_resources/fake_server_resources.tf
@@ -1,0 +1,90 @@
+variable "environment" {
+  type = string
+}
+
+variable "gcp_region" {
+  type = string
+}
+
+variable "manifest_bucket" {
+  type = string
+}
+
+variable "sum_part_bucket_writer_email" {
+  type = string
+}
+
+variable "ingestors" {
+  type = map(string)
+}
+
+# For our purposes, a fake portal server is simply a bucket where we can write
+# sum parts, as well as a correctly formed global manifest advertising that
+# bucket's name.
+resource "google_storage_bucket" "sum_part_output" {
+  provider = google-beta
+  name     = "prio-${var.environment}-sum-part-output"
+  location = var.gcp_region
+  # Force deletion of bucket contents on bucket destroy. Bucket contents would
+  # be re-created by a subsequent deploy so no reason to keep them around.
+  force_destroy = true
+  # Disable per-object ACLs. Everything we put in here is meant to be world-
+  # readable and this is also in line with Google's recommendation:
+  # https://cloud.google.com/storage/docs/uniform-bucket-level-access
+  uniform_bucket_level_access = true
+}
+
+# Enable the sum part bucket writer GCP SA to write output
+resource "google_storage_bucket_iam_binding" "write_sum_parts" {
+  bucket = google_storage_bucket.sum_part_output.name
+  # Allow ourselves to write to sum part outputs
+  role = "roles/storage.objectAdmin"
+  members = [
+    "serviceAccount:${var.sum_part_bucket_writer_email}"
+  ]
+}
+
+# Create a portal server global manifest and advertise it from our manifest
+# bucket. Note that the manifest bucket name and the relative path in this
+# resource's name field must match the portal_server_manifest_base_url value in
+# this env's .tfvars!
+resource "google_storage_bucket_object" "portal_server_global_manifest" {
+  provider     = google-beta
+  name         = "portal-server/global-manifest.json"
+  bucket       = var.manifest_bucket
+  content_type = "application/json"
+  content = jsonencode({
+    format = 0
+    # We're cheating here by listing the same bucket twice, but the other env
+    # will consult a totally different portal server global manifest.
+    facilitator-sum-part-bucket = google_storage_bucket.sum_part_output.name
+    pha-sum-part-bucket         = google_storage_bucket.sum_part_output.name
+  })
+}
+
+# Constructs global manifests for this env's ingestion servers, populated with
+# public keys that match what the sample_maker will use.
+resource "google_storage_bucket_object" "ingestor_global_manifests" {
+  for_each     = var.ingestors
+  provider     = google-beta
+  name         = "${each.key}/global-manifest.json"
+  bucket       = var.manifest_bucket
+  content_type = "application/json"
+  content = jsonencode({
+    format = 0
+    server-identity = {
+      # this value is ignored in our test setup; see data_share_processor.tf
+      aws-iam-entity = "irrelevant in test environment"
+    }
+    batch-signing-public-keys = {
+      # This key identifier matches the one passed to sample_maker's
+      # --batch-signing-private-key-identifier parameter in kubernetes.tf
+      sample-maker-signing-key = {
+        # This public key matches the one passed to sample_maker's
+        # --batch-signing-private-key parameter in kubernetes.tf
+        public-key = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENpmX5uFAu9z5FrGM91Lm+lEyABUA\njxsaLj9TtT5Zp7TqXy2Hb8mQwrnpwM79aAn8k6KJTQKzY8KP/oWqzZ9X7A==\n-----END PUBLIC KEY-----"
+        expiration = "some date"
+      }
+    }
+  })
+}

--- a/terraform/variables/demo-gcp-peer.tfvars
+++ b/terraform/variables/demo-gcp-peer.tfvars
@@ -10,10 +10,13 @@ managed_dns_zone = {
   gcp_project = "prio-bringup-290620"
 }
 ingestors = {
-  ingestor-1 = "storage.googleapis.com/prio-demo-gcp-manifests/ingestor-1"
-  ingestor-2 = "storage.googleapis.com/prio-demo-gcp-manifests/ingestor-2"
+  ingestor-1 = "demo-gcp-peer.manifests.isrg-prio.org/ingestor-1"
+  ingestor-2 = "demo-gcp-peer.manifests.isrg-prio.org/ingestor-2"
 }
-peer_share_processor_manifest_base_url    = "demo-gcp.manifests.isrg-prio.org"
-portal_server_manifest_base_url           = "storage.googleapis.com/prio-demo-gcp-manifests/portal-server"
-test_peer_environment_with_fake_ingestors = "demo-gcp"
-is_first                                  = true
+peer_share_processor_manifest_base_url = "demo-gcp.manifests.isrg-prio.org"
+portal_server_manifest_base_url        = "demo-gcp-peer.manifests.isrg-prio.org/portal-server"
+test_peer_environment = {
+  env_with_ingestor    = "demo-gcp"
+  env_without_ingestor = "demo-gcp-peer"
+}
+is_first = true

--- a/terraform/variables/demo-gcp.tfvars
+++ b/terraform/variables/demo-gcp.tfvars
@@ -10,9 +10,13 @@ managed_dns_zone = {
   gcp_project = "prio-bringup-290620"
 }
 ingestors = {
-  ingestor-1 = "storage.googleapis.com/prio-demo-gcp-manifests/ingestor-1"
-  ingestor-2 = "storage.googleapis.com/prio-demo-gcp-manifests/ingestor-2"
+  ingestor-1 = "demo-gcp.manifests.isrg-prio.org/ingestor-1"
+  ingestor-2 = "demo-gcp.manifests.isrg-prio.org/ingestor-2"
 }
 peer_share_processor_manifest_base_url = "demo-gcp-peer.manifests.isrg-prio.org"
-portal_server_manifest_base_url        = "storage.googleapis.com/prio-demo-gcp-manifests/portal-server"
-test_peer_environment                  = "demo-gcp-peer"
+portal_server_manifest_base_url        = "demo-gcp.manifests.isrg-prio.org/portal-server"
+test_peer_environment = {
+  env_with_ingestor    = "demo-gcp"
+  env_without_ingestor = "demo-gcp-peer"
+}
+is_first = false


### PR DESCRIPTION
This PR makes it easier to set up paired test environments via Terraform, with fake ingestion servers and also buckets into which sum parts can be written. It also removes ALL default values from facilitator (except that generate-ingestion-sample will still generate batch UUIDs and use the current date when constructing object keys), to make misconfigurations more obvious.