### PR TITLE
Fix facilitator image push.

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -20,13 +20,11 @@ jobs:
         username: isrgautomaton
         password: ${{ secrets.ISRG_AUTOMATON_DOCKERHUB_AUTH_TOKEN }}
     - name: build
-      uses: docker/build-push-action@v2
-      with:
-        file: ./facilitator/Dockerfile
-        push: true
-        tags: letsencrypt/prio-facilitator:${{ steps.get_version.outputs.VERSION }}
+      run: docker build -f facilitator/Dockerfile -t letsencrypt/prio-facilitator:{{ steps.get_version.outputs.VERSION }}
     - name: tag-latest
       run: docker tag letsencrypt/prio-facilitator:${{ steps.get_version.outputs.VERSION }} letsencrypt/prio-facilitator:latest
+    - name: push
+      run: docker push letsencrypt/prio-facilitator:${{steps.get_version.outputs.VERSION }}
     - name: push-latest
       run: docker push letsencrypt/prio-facilitator:latest
 


### PR DESCRIPTION
It looks like the tag created by the built-in docker build step isn't
visible to subsequent steps. I saw this when tagging a release:

docker tag letsencrypt/prio-facilitator:0.3.0 letsencrypt/prio-facilitator:latest
shell: /bin/bash -e {0}
Error response from daemon: No such image: letsencrypt/prio-facilitator:0.3.0
Error: Process completed with exit code 1.

This reverts to just running the docker build command as a step and then
consuming the tag.