### PR TITLE
Improve debuggability.

### DIFF
--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -87,7 +87,10 @@ fn public_key_from_pem(pem_key: &str) -> Result<UnparsedPublicKey<Vec<u8>>> {
     // blob inside the PEM has the expected prefix for this kind of key in
     // this kind of encoding, as suggested in this GitHub issue on ring:
     // https://github.com/briansmith/ring/issues/881
-    let pem = pem::parse(&pem_key).context("failed to parse key as PEM")?;
+    if pem_key == "" {
+        return Err(anyhow!("empty PEM input"));
+    }
+    let pem = pem::parse(&pem_key).context(format!("failed to parse key as PEM: {}", pem_key))?;
     if pem.tag != "PUBLIC KEY" {
         return Err(anyhow!(
             "key for identifier {} is not a PEM encoded public key"

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -220,6 +220,7 @@ resource "kubernetes_config_map" "intake_batch_job_config_map" {
     PEER_MANIFEST_BASE_URL               = "https://${var.peer_manifest_base_url}"
     OWN_OUTPUT                           = "gs://${var.own_validation_bucket}"
     RUST_LOG                             = "info"
+    RUST_BACKTRACE                       = "1"
   }
 }
 
@@ -249,6 +250,7 @@ resource "kubernetes_config_map" "aggregate_job_config_map" {
     PORTAL_IDENTITY                      = var.sum_part_bucket_service_account_email
     PORTAL_MANIFEST_BASE_URL             = "https://${var.portal_server_manifest_base_url}"
     RUST_LOG                             = "info"
+    RUST_BACKTRACE                       = "1"
   }
 }
 
@@ -362,6 +364,14 @@ resource "kubernetes_cron_job" "sample_maker" {
                 "--dimension", "123",
                 "--epsilon", "0.23",
               ]
+              env {
+                name  = "RUST_LOG"
+                value = "1"
+              }
+              env {
+                name  = "RUST_BACKTRACE"
+                value = "1"
+              }
               env {
                 name  = "AWS_ACCOUNT_ID"
                 value = data.aws_caller_identity.current.account_id


### PR DESCRIPTION
Add a more detailed error for PEM parse problems.
Set RUST_LOG=1 for sample-maker, and set RUST_BACKTRACE=1 for all Rust
jobs.