### PR TITLE
workflow-manager: set a backoffLimit of 1 for spawned jobs

### DIFF
--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -490,12 +490,14 @@ func launchAggregationJob(ctx context.Context, readyBatches []*batchPath, inter 
 
 	log.Printf("starting aggregation job %s (interval %s) with args %s", jobName, inter, args)
 
+	var one int32 = 1
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: *k8sNS,
 		},
 		Spec: batchv1.JobSpec{
+			BackoffLimit: &one,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					ServiceAccountName: *k8sServiceAccount,
@@ -601,12 +603,14 @@ func startIntakeJob(
 		"--date", batchPath.dateString(),
 	}
 	log.Printf("starting job for batch %s with args %s", batchPath, args)
+	var one int32 = 1
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      jobName,
 			Namespace: *k8sNS,
 		},
 		Spec: batchv1.JobSpec{
+			BackoffLimit: &one,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					ServiceAccountName: *k8sServiceAccount,


### PR DESCRIPTION
Usually when one of those jobs fails, it will fail repeatedly. This prevents us from clogging up the podspace with dead jobs. We will eventually implement retry at a higher level in the workflow-manager.