### PR TITLE
terraform: add gamlin-test tfvars

### DIFF
--- a/terraform/variables/gamlin-test.tfvars
+++ b/terraform/variables/gamlin-test.tfvars
@@ -1,0 +1,17 @@
+environment     = "gamlin-test"
+gcp_region      = "us-west1"
+gcp_project     = "gamlin-test"
+machine_type    = "e2-standard-8"
+localities      = ["narnia", "gondor", "asgard"]
+aws_region      = "us-west-1"
+manifest_domain = "isrg-prio.org"
+managed_dns_zone = {
+  name        = "manifests"
+  gcp_project = "prio-bringup-290620"
+}
+ingestors = {
+  apple = "exposure-notification.apple.com/manifest"
+}
+peer_share_processor_manifest_base_url = "gamlin-test.manifests.isrg-prio.org/pha"
+portal_server_manifest_base_url        = "gamlin-test.manifests.isrg-prio.org/portal-server"
+is_first                               = false


### PR DESCRIPTION
Adds a tfvars file for the gamlin-test deploy ISRG will be using for the
infamous Narnia test.

At the moment, we only have one ingestor listed. We will add Google's
once their global manifest is ready. We also use well-formed but bogus
peer data share processor and portal server global manifests. Those
values will be updated as NCI and MITRE bring their Narnia
infrastructure online.