### PR TITLE
GH actions: turn on CI for release branches

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -2,9 +2,9 @@ name: facilitator-ci-build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release/** ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release/** ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
We are going to branch for the Narnia test, creating a `release/narnia`
branch. This commit enables CI tests for that branch as well as pull
requests that target that branch.

The `release/**` matches arbitrary branches under `release`: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet