### PR TITLE
facilitator: use instance name in sum part objects

### DIFF
--- a/facilitator/src/aggregation.rs
+++ b/facilitator/src/aggregation.rs
@@ -28,6 +28,7 @@ pub struct BatchAggregator<'a> {
 impl<'a> BatchAggregator<'a> {
     #[allow(clippy::too_many_arguments)] // Grandfathered in
     pub fn new(
+        instance_name: &'a str,
         aggregation_name: &'a str,
         aggregation_start: &'a NaiveDateTime,
         aggregation_end: &'a NaiveDateTime,
@@ -47,6 +48,7 @@ impl<'a> BatchAggregator<'a> {
             ingestion_transport,
             aggregation_batch: BatchWriter::new(
                 Batch::new_sum(
+                    instance_name,
                     aggregation_name,
                     aggregation_start,
                     aggregation_end,

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -50,13 +50,15 @@ impl Batch {
 
     // Creates a batch representing a sum part batch
     pub fn new_sum(
+        instance_name: &str,
         aggregation_name: &str,
         aggregation_start: &NaiveDateTime,
         aggregation_end: &NaiveDateTime,
         is_first: bool,
     ) -> Batch {
         let batch_path = format!(
-            "{}/{}-{}",
+            "{}/{}/{}-{}",
+            instance_name,
             aggregation_name,
             aggregation_start.format(AGGREGATION_DATE_FORMAT),
             aggregation_end.format(AGGREGATION_DATE_FORMAT)
@@ -609,6 +611,7 @@ mod tests {
         let mut read_transport = LocalFileTransport::new(tempdir.path().to_path_buf());
         let mut verify_transport = LocalFileTransport::new(tempdir.path().to_path_buf());
 
+        let instance_name = "fake-instance";
         let aggregation_name = "fake-aggregation";
         let batch_id = Uuid::new_v4();
         let start = NaiveDateTime::from_timestamp(1234567890, 654321);
@@ -616,16 +619,17 @@ mod tests {
 
         let mut batch_writer: BatchWriter<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchWriter::new(
-                Batch::new_sum(&aggregation_name, &start, &end, is_first),
+                Batch::new_sum(&instance_name, &aggregation_name, &start, &end, is_first),
                 &mut write_transport,
             );
         let mut batch_reader: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchReader::new(
-                Batch::new_sum(&aggregation_name, &start, &end, is_first),
+                Batch::new_sum(instance_name, &aggregation_name, &start, &end, is_first),
                 &mut read_transport,
             );
         let batch_path = format!(
-            "{}/{}-{}",
+            "{}/{}/{}-{}",
+            instance_name,
             aggregation_name,
             start.format(AGGREGATION_DATE_FORMAT),
             end.format(AGGREGATION_DATE_FORMAT)

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -762,6 +762,7 @@ fn aggregate(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
 
     let batch_info: Vec<_> = batch_ids.into_iter().zip(batch_dates).collect();
     BatchAggregator::new(
+        instance_name,
         &sub_matches.value_of("aggregation-id").unwrap(),
         &NaiveDateTime::parse_from_str(
             &sub_matches.value_of("aggregation-start").unwrap(),

--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -27,6 +27,7 @@ fn end_to_end() {
     let facilitator_tempdir = tempfile::TempDir::new().unwrap();
     let facilitator_copy_tempdir = tempfile::TempDir::new().unwrap();
 
+    let instance_name = "fake-instance";
     let aggregation_name = "fake-aggregation-1".to_owned();
     let date = NaiveDateTime::from_timestamp(2234567890, 654321);
     let start_date = NaiveDateTime::from_timestamp(1234567890, 654321);
@@ -212,6 +213,7 @@ fn end_to_end() {
         batch_signing_key: default_pha_signing_private_key(),
     };
     BatchAggregator::new(
+        instance_name,
         &aggregation_name,
         &start_date,
         &end_date,
@@ -232,6 +234,7 @@ fn end_to_end() {
         batch_signing_key: default_facilitator_signing_private_key(),
     };
     BatchAggregator::new(
+        instance_name,
         &aggregation_name,
         &start_date,
         &end_date,
@@ -247,7 +250,13 @@ fn end_to_end() {
 
     let mut pha_aggregation_batch_reader: BatchReader<'_, SumPart, IngestionDataSharePacket> =
         BatchReader::new(
-            Batch::new_sum(&aggregation_name, &start_date, &end_date, true),
+            Batch::new_sum(
+                instance_name,
+                &aggregation_name,
+                &start_date,
+                &end_date,
+                true,
+            ),
             &mut *pha_aggregation_transport.transport,
         );
     let pha_sum_part = pha_aggregation_batch_reader.header(&pha_pub_keys).unwrap();
@@ -264,7 +273,13 @@ fn end_to_end() {
         SumPart,
         IngestionDataSharePacket,
     > = BatchReader::new(
-        Batch::new_sum(&aggregation_name, &start_date, &end_date, false),
+        Batch::new_sum(
+            instance_name,
+            &aggregation_name,
+            &start_date,
+            &end_date,
+            false,
+        ),
         &mut *facilitator_aggregation_transport.transport,
     );
     let facilitator_sum_part = facilitator_aggregation_batch_reader


### PR DESCRIPTION
Because there is only a single MITRE sum part bucket for each of ISRG
and NCI, we need to prefix the object keys where we write sum parts so
that (1) sums don't collide with each other and (2) MITRE can figure out
which locality a sum was for.