### PR TITLE
facilitator: linter for manifests

### DIFF
--- a/facilitator/README.md
+++ b/facilitator/README.md
@@ -14,6 +14,14 @@ To generate sample ingestion data, see the `generate-ingestion-sample` command a
 
 To build a Docker image, try `docker build -t my-image-repository/facilitator:x.y.z -f facilitator/Dockerfile .` *from the root directory of `prio-server`*. This is important because building `facilitator` depends on the schema files in `avro-schema`.
 
+## Linting manifest files
+
+The `facilitator lint-manifest` subcommand can validate the various manifest files used in the system. See that subcommand's help text for more information on usage.
+
+## Working with Avro files
+
+If you want to examine Avro-encoded messages, you can use the `avro-tools` jar from the [Apache Avro project's releases](https://downloads.apache.org/avro/avro-1.10.0/java/), and then [use it from the command line to examine individual Avro encoded objects](https://www.michael-noll.com/blog/2013/03/17/reading-and-writing-avro-files-from-the-command-line/).
+
 ## References
 
 [Prio Data Share Batch IDL](https://docs.google.com/document/d/1L06dpE7OcC4CXho2UswrfHrnWKtbA9aSSmO_5o7Ku6I/edit#heading=h.3kq1yexquq2g)

--- a/facilitator/src/config.rs
+++ b/facilitator/src/config.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use chrono::Duration;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -162,6 +162,39 @@ impl<'de> Deserialize<'de> for StoragePath {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
         s.parse().map_err(de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ManifestKind {
+    IngestorGlobal,
+    DataShareProcessorGlobal,
+    DataShareProcessorSpecific,
+    PortalServerGlobal,
+}
+
+impl FromStr for ManifestKind {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<ManifestKind> {
+        match s {
+            "ingestor-global" => Ok(ManifestKind::IngestorGlobal),
+            "data-share-processor-global" => Ok(ManifestKind::DataShareProcessorGlobal),
+            "data-share-processor-specific" => Ok(ManifestKind::DataShareProcessorSpecific),
+            "portal-global" => Ok(ManifestKind::PortalServerGlobal),
+            _ => Err(anyhow!(format!("unrecognized manifest kind {}", s))),
+        }
+    }
+}
+
+impl Display for ManifestKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ManifestKind::IngestorGlobal => write!(f, "ingestor-global"),
+            ManifestKind::DataShareProcessorGlobal => write!(f, "data-share-processor-global"),
+            ManifestKind::DataShareProcessorSpecific => write!(f, "data-share-processor-specific"),
+            ManifestKind::PortalServerGlobal => write!(f, "portal-global"),
+        }
     }
 }
 


### PR DESCRIPTION
Adds a `lint-manifest` subcommand to facilitator that can parse and
validate all kinds of manifests from either local files or fetches over
HTTPS.

I was going to write a pretty-printer and validator for Avro messages, too, but then I learned that Avro already publishes a Java jar that can do that (https://www.michael-noll.com/blog/2013/03/17/reading-and-writing-avro-files-from-the-command-line/).