### PR TITLE
workflow-manager: make build more self-contained.

### DIFF
--- a/workflow-manager/Dockerfile
+++ b/workflow-manager/Dockerfile
@@ -1,4 +1,23 @@
+FROM golang:1.15 as builder
+# set GOPATH to empty since we're building with modules.
+ENV GOPATH=
+WORKDIR /workspace/
+COPY go.mod go.mod
+COPY go.sum go.sum
+RUN go mod download
+COPY . .
+ARG BUILD_INFO=unspecified
+RUN \
+  CGO_ENABLED=0 \
+  GOOS=linux \
+  go build -ldflags="-w -X 'main.BuildInfo=${BUILD_INFO}'" -o workflow-manager ./
+
 FROM scratch
-COPY ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY workflow-manager workflow-manager
+ARG BUILD_INFO=unspecified
+LABEL build_info="${BUILD_INFO}"
+# The container needs a copy of trusted roots. Copy them from the builder image.
+# See
+# https://medium.com/@kelseyhightower/optimizing-docker-images-for-static-binaries-b5696e26eb07
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /workspace/workflow-manager workflow-manager
 ENTRYPOINT ["/workflow-manager"]

--- a/workflow-manager/build.sh
+++ b/workflow-manager/build.sh
@@ -1,20 +1,10 @@
 #!/bin/bash -eux
-# The container needs a copy of trusted roots. Try to copy them from the OS.
-# See
-# https://medium.com/@kelseyhightower/optimizing-docker-images-for-static-binaries-b5696e26eb07
-# and
-# https://github.com/golang/go/blob/master/src/crypto/x509/root_linux.go#L7
 cd $(dirname $0)
 
 # Embed info about the build.
 COMMIT_ID="$(git rev-parse --short=8 HEAD)"
 BUILD_ID="$(git symbolic-ref --short HEAD 2>/dev/null || true)+${COMMIT_ID}"
-BUILD_TIME="$(date -u)"
-GO_BUILD_FLAGS="-ldflags=-w -X 'main.BuildID=${BUILD_ID}' -X 'main.BuildTime=${BUILD_TIME}'"
+BUILD_TIME="$(date)"
+BUILD_INFO="${BUILD_ID} - ${BUILD_TIME}"
 
-cp /etc/ssl/certs/ca-certificates.crt . \
- || cp /etc/pki/tls/certs/ca-bundle.crt ca-certificates.crt \
- || cp /etc/pki/tls/certs/ca-bundle.crt ca-certificates.crt
-CGO_ENABLED=0 GOOS=linux go build "$GO_BUILD_FLAGS" -o workflow-manager main.go
-docker build --tag letsencrypt/prio-workflow-manager .
-rm ca-certificates.crt
+docker build --tag letsencrypt/prio-workflow-manager --build-arg BUILD_INFO="${BUILD_INFO}" .

--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -38,11 +38,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// BuildID is generated at build time and contains the branch and short hash.
-var BuildID string
-
-// BuildTime is generated at build time and contains the build time.
-var BuildTime string
+// BuildInfo is generated at build time - see the Dockerfile.
+var BuildInfo string
 
 type batchPath struct {
 	aggregationID  string
@@ -158,7 +155,7 @@ var aggregationPeriod = flag.String("aggregation-period", "3h", "How much time e
 var gracePeriod = flag.String("grace-period", "1h", "Wait this amount of time after the end of an aggregation timeslice to run the aggregation")
 
 func main() {
-	log.Printf("starting %s version %s - %s. Args: %s", os.Args[0], BuildID, BuildTime, os.Args[1:])
+	log.Printf("starting %s version %s. Args: %s", os.Args[0], BuildInfo, os.Args[1:])
 	flag.Parse()
 
 	ownValidationBucket, err := newBucket(*ownValidationInput, *ownValidationIdentity)


### PR DESCRIPTION
Taking some ideas from #168, this builds off a Go image instead of
relying on the person building to have Go installed. It uses go mod
download to build a layer with dependencies cached.

This still relies on a build.sh run on the host, which gathers
information about the git branch. To streamline things, it combines
all the build info into a single variable.

Sets the build timestamp to local time on the build machine. This
is easier to reference when building on a dev workstation; for release
builds this will be whatever GH Actions sets, which I'm pretty sure is UTC.

Attach a label with the build info to the image. This lets us check
the metadata for an image in a registry to confirm when it was built
and what branch.