### PR TITLE
GH actions: enable deploy-tool-build on release/**

### DIFF
--- a/.github/workflows/deploy-tool-build.yml
+++ b/.github/workflows/deploy-tool-build.yml
@@ -2,9 +2,9 @@ name: deploy-tool-ci-build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, release/** ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release/** ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Last week, when I made the release/narnia branch, I forgot to enable the
jobs in deploy-tool-build.yml for `release/**` branches. This is causing
other PRs onto release/narnia to be unmergeable because required test
jobs don't run.