### PR TITLE
facilitator: improve logging

### DIFF
--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -127,6 +127,10 @@ impl<'a, H: Header, P: Packet> BatchReader<'a, H, P> {
         }
     }
 
+    pub fn path(&self) -> String {
+        self.transport.path()
+    }
+
     /// Return the parsed header from this batch, but only if its signature is
     /// valid. The signature is checked by getting the key_identifier value from
     /// the signature message, using that to obtain a public key from the
@@ -220,6 +224,10 @@ impl<'a, H: Header, P: Packet> BatchWriter<'a, H, P> {
             phantom_header: PhantomData,
             phantom_packet: PhantomData,
         }
+    }
+
+    pub fn path(&self) -> String {
+        self.transport.path()
     }
 
     /// Encode the provided header into Avro, sign that representation with the

--- a/facilitator/src/transport.rs
+++ b/facilitator/src/transport.rs
@@ -64,4 +64,6 @@ pub trait Transport {
     /// Returns an std::io::Write instance into which the contents of the value
     /// may be written.
     fn put(&mut self, key: &str) -> Result<Box<dyn TransportWriter>>;
+
+    fn path(&self) -> String;
 }

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -231,7 +231,7 @@ impl Transport for GCSTransport {
 
     fn get(&mut self, key: &str) -> Result<Box<dyn Read>> {
         info!(
-            "get {}{} as {:?}",
+            "get {}/{} as {:?}",
             self.path, key, self.oauth_token_provider
         );
         // Per API reference, the object key must be URL encoded.
@@ -270,7 +270,7 @@ impl Transport for GCSTransport {
 
     fn put(&mut self, key: &str) -> Result<Box<dyn TransportWriter>> {
         info!(
-            "put {}{} as {:?}",
+            "put {}/{} as {:?}",
             self.path, key, self.oauth_token_provider
         );
         // The Oauth token will only be used once, during the call to

--- a/facilitator/src/transport/local.rs
+++ b/facilitator/src/transport/local.rs
@@ -29,6 +29,10 @@ impl LocalFileTransport {
 }
 
 impl Transport for LocalFileTransport {
+    fn path(&self) -> String {
+        self.directory.to_string_lossy().to_string()
+    }
+
     fn get(&mut self, key: &str) -> Result<Box<dyn Read>> {
         let path = self.directory.join(LocalFileTransport::relative_path(key));
         let f =

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -182,8 +182,12 @@ impl S3Transport {
 type ClientProvider = Box<dyn Fn(&Region, Option<String>) -> Result<S3Client>>;
 
 impl Transport for S3Transport {
+    fn path(&self) -> String {
+        self.path.to_string()
+    }
+
     fn get(&mut self, key: &str) -> Result<Box<dyn Read>> {
-        info!("get {} as {:?}", self.path, self.iam_role);
+        info!("get {}{} as {:?}", self.path, key, self.iam_role);
         let mut runtime = basic_runtime()?;
         let client = (self.client_provider)(&self.path.region, self.iam_role.clone())?;
         let get_output = runtime
@@ -200,7 +204,7 @@ impl Transport for S3Transport {
     }
 
     fn put(&mut self, key: &str) -> Result<Box<dyn TransportWriter>> {
-        info!("put {} as {:?}", self.path, self.iam_role);
+        info!("put {}{} as {:?}", self.path, key, self.iam_role);
         let writer = MultipartUploadWriter::new(
             self.path.bucket.to_owned(),
             format!("{}{}", &self.path.key, key),

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -187,7 +187,7 @@ impl Transport for S3Transport {
     }
 
     fn get(&mut self, key: &str) -> Result<Box<dyn Read>> {
-        info!("get {}{} as {:?}", self.path, key, self.iam_role);
+        info!("get {}/{} as {:?}", self.path, key, self.iam_role);
         let mut runtime = basic_runtime()?;
         let client = (self.client_provider)(&self.path.region, self.iam_role.clone())?;
         let get_output = runtime
@@ -204,7 +204,7 @@ impl Transport for S3Transport {
     }
 
     fn put(&mut self, key: &str) -> Result<Box<dyn TransportWriter>> {
-        info!("put {}{} as {:?}", self.path, key, self.iam_role);
+        info!("put {}/{} as {:?}", self.path, key, self.iam_role);
         let writer = MultipartUploadWriter::new(
             self.path.bucket.to_owned(),
             format!("{}{}", &self.path.key, key),


### PR DESCRIPTION
For GETs and PUTs, log not just the bucket name, but also the key.

Remove the derive(Debug)  on OauthTokenProvider and provided a custom
Debug impl, so we don't log the tokens.

Rename the fields of OauthTokenProvider to be shorter.