### PR TITLE
Move storage to Google Cloud Storage

### DIFF
--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -18,10 +18,6 @@ pub use workflow::{workflow_main, WorkflowArgs};
 
 pub const DATE_FORMAT: &str = "%Y/%m/%d/%H/%M";
 
-/// Identity represents a cloud identity: Either an AWS IAM ARN (i.e. "arn:...")
-/// or a GCP ServiceAccount (i.e. "foo@bar.com").
-pub type Identity = String;
-
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// Compatibility enum entry to ease migration.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -199,7 +199,7 @@ module "gke" {
 
   depends_on = [
     google_project_service.compute,
-    google_project_service.gke,
+    google_project_service.container,
     google_project_service.kms,
   ]
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,6 +10,10 @@ variable "gcp_project" {
   type = string
 }
 
+variable "use_aws" {
+  type = bool
+}
+
 variable "aws_region" {
   type = string
 }
@@ -140,14 +144,7 @@ provider "google-beta" {
   project = var.gcp_project
 }
 
-# Activate some services which the deployment will require. Note that while this
-# can save you from having to go to the GCP console and manually activate them,
-# often a new deploy will still fail due to a race condition between the service
-# being activated and terraform trying to use it. This could probably be greatly
-# ameliorated by adding manual dependencies between the service activation and
-# the resources, but the maintenance cost of that exceeds the benefit. For now,
-# simply retrying the apply after a minute should let it continue.
-
+# Activate some services which the deployment will require.
 resource "google_project_service" "compute" {
   provider = google-beta
   service  = "compute.googleapis.com"
@@ -156,6 +153,12 @@ resource "google_project_service" "compute" {
 resource "google_project_service" "container" {
   provider = google-beta
   service  = "container.googleapis.com"
+}
+
+resource "google_project_service" "kms" {
+  provider = google-beta
+  project  = var.gcp_project
+  service  = "cloudkms.googleapis.com"
 }
 
 provider "aws" {
@@ -173,12 +176,15 @@ provider "kubernetes" {
   load_config_file       = false
 }
 
+
 module "manifest" {
   source                                = "./modules/manifest"
   environment                           = var.environment
   gcp_region                            = var.gcp_region
   managed_dns_zone                      = var.managed_dns_zone
   sum_part_bucket_service_account_email = google_service_account.sum_part_bucket_writer.email
+
+  depends_on = [google_project_service.compute]
 }
 
 module "gke" {
@@ -190,6 +196,12 @@ module "gke" {
   machine_type    = var.machine_type
   network         = google_compute_network.network.self_link
   base_subnet     = local.cluster_subnet_block
+
+  depends_on = [
+    google_project_service.compute,
+    google_project_service.gke,
+    google_project_service.kms,
+  ]
 }
 
 # For each peer data share processor, we will receive ingestion batches from two
@@ -252,12 +264,11 @@ locals {
       ingestor                                = pair[1]
       kubernetes_namespace                    = kubernetes_namespace.namespaces[pair[0]].metadata[0].name
       packet_decryption_key_kubernetes_secret = kubernetes_secret.ingestion_packet_decryption_keys[pair[0]].metadata[0].name
-      ingestor_aws_role_arn                   = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body).server-identity, "aws-iam-entity", "")
-      ingestor_gcp_service_account_id         = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body).server-identity, "google-service-account", "")
-      ingestor_gcp_service_account_email      = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body).server-identity, "gcp-service-account-email", "")
+      ingestor_gcp_service_account_email      = jsondecode(data.http.ingestor_global_manifests[pair[1]].body).server-identity.gcp-service-account-id
       ingestor_manifest_base_url              = var.ingestors[pair[1]]
     }
   }
+  peer_share_processor_server_identity = jsondecode(data.http.peer_share_processor_global_manifest.body).server-identity
 }
 
 # Call the locality_kubernetes module per
@@ -278,30 +289,31 @@ module "locality_kubernetes" {
 }
 
 module "data_share_processors" {
-  for_each                                = local.locality_ingestor_pairs
-  source                                  = "./modules/data_share_processor"
-  environment                             = var.environment
-  data_share_processor_name               = each.key
-  ingestor                                = each.value.ingestor
-  gcp_region                              = var.gcp_region
-  gcp_project                             = var.gcp_project
-  manifest_bucket                         = module.manifest.bucket
-  kubernetes_namespace                    = each.value.kubernetes_namespace
-  certificate_domain                      = "${var.environment}.certificates.${var.manifest_domain}"
-  ingestor_aws_role_arn                   = each.value.ingestor_aws_role_arn
-  ingestor_gcp_service_account_id         = each.value.ingestor_gcp_service_account_id
-  ingestor_gcp_service_account_email      = each.value.ingestor_gcp_service_account_email
-  ingestor_manifest_base_url              = each.value.ingestor_manifest_base_url
-  packet_decryption_key_kubernetes_secret = each.value.packet_decryption_key_kubernetes_secret
-  peer_share_processor_aws_account_id     = jsondecode(data.http.peer_share_processor_global_manifest.body).server-identity.aws-account-id
-  peer_share_processor_manifest_base_url  = var.peer_share_processor_manifest_base_url
-  sum_part_bucket_service_account_email   = google_service_account.sum_part_bucket_writer.email
-  portal_server_manifest_base_url         = var.portal_server_manifest_base_url
-  own_manifest_base_url                   = module.manifest.base_url
-  test_peer_environment                   = var.test_peer_environment
-  is_first                                = var.is_first
-  aggregation_period                      = var.aggregation_period
-  aggregation_grace_period                = var.aggregation_grace_period
+  for_each                                       = local.locality_ingestor_pairs
+  source                                         = "./modules/data_share_processor"
+  environment                                    = var.environment
+  data_share_processor_name                      = each.key
+  ingestor                                       = each.value.ingestor
+  use_aws                                        = var.use_aws
+  aws_region                                     = var.aws_region
+  gcp_region                                     = var.gcp_region
+  gcp_project                                    = var.gcp_project
+  manifest_bucket                                = module.manifest.bucket
+  kubernetes_namespace                           = each.value.kubernetes_namespace
+  certificate_domain                             = "${var.environment}.certificates.${var.manifest_domain}"
+  ingestor_gcp_service_account_email             = each.value.ingestor_gcp_service_account_email
+  ingestor_manifest_base_url                     = each.value.ingestor_manifest_base_url
+  packet_decryption_key_kubernetes_secret        = each.value.packet_decryption_key_kubernetes_secret
+  peer_share_processor_aws_account_id            = local.peer_share_processor_server_identity.aws-account-id
+  peer_share_processor_gcp_service_account_email = local.peer_share_processor_server_identity.gcp-service-account-email
+  peer_share_processor_manifest_base_url         = var.peer_share_processor_manifest_base_url
+  remote_bucket_writer_gcp_service_account_email = google_service_account.sum_part_bucket_writer.email
+  portal_server_manifest_base_url                = var.portal_server_manifest_base_url
+  own_manifest_base_url                          = module.manifest.base_url
+  test_peer_environment                          = var.test_peer_environment
+  is_first                                       = var.is_first
+  aggregation_period                             = var.aggregation_period
+  aggregation_grace_period                       = var.aggregation_grace_period
 
   depends_on = [module.gke]
 }
@@ -322,7 +334,7 @@ resource "google_service_account_iam_binding" "data_share_processors_to_sum_part
   provider           = google-beta
   service_account_id = google_service_account.sum_part_bucket_writer.name
   role               = "roles/iam.serviceAccountTokenCreator"
-  members            = [for v in module.data_share_processors : v.service_account_email]
+  members            = [for v in module.data_share_processors : "serviceAccount:${v.service_account_email}"]
 }
 
 module "fake_server_resources" {

--- a/terraform/modules/cloud_storage_aws/cloud_storage_aws.tf
+++ b/terraform/modules/cloud_storage_aws/cloud_storage_aws.tf
@@ -1,0 +1,126 @@
+variable "environment" {
+  type = string
+}
+
+variable "ingestion_bucket_name" {
+  type = string
+}
+
+variable "ingestion_bucket_writer" {
+  type = string
+}
+
+variable "ingestion_bucket_reader" {
+  type = string
+}
+
+variable "local_peer_validation_bucket_name" {
+  type = string
+}
+
+variable "local_peer_validation_bucket_writer" {
+  type = string
+}
+
+variable "local_peer_validation_bucket_reader" {
+  type = string
+}
+
+# The S3 ingestion bucket. It is configured to allow writes from the AWS
+# account used by the ingestor and reads from the AWS IAM role assumed by this
+# data share processor.
+resource "aws_s3_bucket" "ingestion_bucket" {
+  bucket = var.ingestion_bucket_name
+  # Force deletion of bucket contents on bucket destroy.
+  force_destroy = true
+  policy        = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${var.ingestion_bucket_writer}"
+      },
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:PutObject",
+        "s3:ListMultipartUploadParts",
+        "s3:ListBucketMultipartUploads"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${var.ingestion_bucket_name}/*",
+        "arn:aws:s3:::${var.ingestion_bucket_name}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${var.ingestion_bucket_reader}"
+      },
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${var.ingestion_bucket_name}/*",
+        "arn:aws:s3:::${var.ingestion_bucket_name}"
+      ]
+    }
+  ]
+}
+POLICY
+
+  tags = {
+    environment = "prio-${var.environment}"
+  }
+}
+
+# The peer validation bucket for this data share processor, configured to permit
+# the peer share processor to write to it.
+resource "aws_s3_bucket" "local_peer_validation_bucket" {
+  bucket = var.local_peer_validation_bucket_name
+  # Force deletion of bucket contents on bucket destroy.
+  force_destroy = true
+  policy        = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${var.local_peer_validation_bucket_writer}"
+      },
+      "Action": [
+        "s3:AbortMultipartUpload",
+        "s3:PutObject",
+        "s3:ListMultipartUploadParts",
+        "s3:ListBucketMultipartUploads"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${var.local_peer_validation_bucket_name}/*",
+        "arn:aws:s3:::${var.local_peer_validation_bucket_name}"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${var.local_peer_validation_bucket_reader}"
+      },
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${var.local_peer_validation_bucket_name}/*",
+        "arn:aws:s3:::${var.local_peer_validation_bucket_name}"
+      ]
+    }
+  ]
+}
+POLICY
+
+  tags = {
+    environment = "prio-${var.environment}"
+  }
+}

--- a/terraform/modules/cloud_storage_aws/cloud_storage_aws.tf
+++ b/terraform/modules/cloud_storage_aws/cloud_storage_aws.tf
@@ -14,15 +14,15 @@ variable "ingestion_bucket_reader" {
   type = string
 }
 
-variable "local_peer_validation_bucket_name" {
+variable "peer_validation_bucket_name" {
   type = string
 }
 
-variable "local_peer_validation_bucket_writer" {
+variable "peer_validation_bucket_writer" {
   type = string
 }
 
-variable "local_peer_validation_bucket_reader" {
+variable "peer_validation_bucket_reader" {
   type = string
 }
 
@@ -78,8 +78,8 @@ POLICY
 
 # The peer validation bucket for this data share processor, configured to permit
 # the peer share processor to write to it.
-resource "aws_s3_bucket" "local_peer_validation_bucket" {
-  bucket = var.local_peer_validation_bucket_name
+resource "aws_s3_bucket" "peer_validation_bucket" {
+  bucket = var.peer_validation_bucket_name
   # Force deletion of bucket contents on bucket destroy.
   force_destroy = true
   policy        = <<POLICY
@@ -89,7 +89,7 @@ resource "aws_s3_bucket" "local_peer_validation_bucket" {
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "${var.local_peer_validation_bucket_writer}"
+        "AWS": "${var.peer_validation_bucket_writer}"
       },
       "Action": [
         "s3:AbortMultipartUpload",
@@ -98,22 +98,22 @@ resource "aws_s3_bucket" "local_peer_validation_bucket" {
         "s3:ListBucketMultipartUploads"
       ],
       "Resource": [
-        "arn:aws:s3:::${var.local_peer_validation_bucket_name}/*",
-        "arn:aws:s3:::${var.local_peer_validation_bucket_name}"
+        "arn:aws:s3:::${var.peer_validation_bucket_name}/*",
+        "arn:aws:s3:::${var.peer_validation_bucket_name}"
       ]
     },
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "${var.local_peer_validation_bucket_reader}"
+        "AWS": "${var.peer_validation_bucket_reader}"
       },
       "Action": [
         "s3:GetObject",
         "s3:ListBucket"
       ],
       "Resource": [
-        "arn:aws:s3:::${var.local_peer_validation_bucket_name}/*",
-        "arn:aws:s3:::${var.local_peer_validation_bucket_name}"
+        "arn:aws:s3:::${var.peer_validation_bucket_name}/*",
+        "arn:aws:s3:::${var.peer_validation_bucket_name}"
       ]
     }
   ]

--- a/terraform/modules/cloud_storage_gcp/cloud_storage_gcp.tf
+++ b/terraform/modules/cloud_storage_gcp/cloud_storage_gcp.tf
@@ -14,15 +14,15 @@ variable "ingestion_bucket_reader" {
   type = string
 }
 
-variable "local_peer_validation_bucket_name" {
+variable "peer_validation_bucket_name" {
   type = string
 }
 
-variable "local_peer_validation_bucket_writer" {
+variable "peer_validation_bucket_writer" {
   type = string
 }
 
-variable "local_peer_validation_bucket_reader" {
+variable "peer_validation_bucket_reader" {
   type = string
 }
 
@@ -58,9 +58,9 @@ resource "google_storage_bucket_iam_binding" "ingestion_bucket_reader" {
 
 # The peer validation bucket for this data share processor, to which peer data
 # share processors write validation batches.
-resource "google_storage_bucket" "local_peer_validation_bucket" {
+resource "google_storage_bucket" "peer_validation_bucket" {
   provider                    = google-beta
-  name                        = var.local_peer_validation_bucket_name
+  name                        = var.peer_validation_bucket_name
   location                    = var.gcp_region
   force_destroy               = true
   uniform_bucket_level_access = true
@@ -69,20 +69,20 @@ resource "google_storage_bucket" "local_peer_validation_bucket" {
 # Permit the peer data share processors to write to the ingestion bucket. It is
 # assumed that all peer DSPs will impersonate a single GCP SA whose email is
 # advertised from the peer DSP global manifest.
-resource "google_storage_bucket_iam_binding" "local_peer_validation_bucket_writer" {
-  bucket = google_storage_bucket.local_peer_validation_bucket.name
+resource "google_storage_bucket_iam_binding" "peer_validation_bucket_writer" {
+  bucket = google_storage_bucket.peer_validation_bucket.name
   role   = "roles/storage.objectCreator"
   members = [
-    "serviceAccount:${var.local_peer_validation_bucket_writer}"
+    "serviceAccount:${var.peer_validation_bucket_writer}"
   ]
 }
 
 # Permit our own data share processor's workflow manager and facilitators to
 # read content from the peer validation bucket.
-resource "google_storage_bucket_iam_binding" "local_peer_validation_bucket_reader" {
-  bucket = google_storage_bucket.local_peer_validation_bucket.name
+resource "google_storage_bucket_iam_binding" "peer_validation_bucket_reader" {
+  bucket = google_storage_bucket.peer_validation_bucket.name
   role   = "roles/storage.objectViewer"
   members = [
-    "serviceAccount:${var.local_peer_validation_bucket_reader}"
+    "serviceAccount:${var.peer_validation_bucket_reader}"
   ]
 }

--- a/terraform/modules/cloud_storage_gcp/cloud_storage_gcp.tf
+++ b/terraform/modules/cloud_storage_gcp/cloud_storage_gcp.tf
@@ -1,0 +1,88 @@
+variable "gcp_region" {
+  type = string
+}
+
+variable "ingestion_bucket_name" {
+  type = string
+}
+
+variable "ingestion_bucket_writer" {
+  type = string
+}
+
+variable "ingestion_bucket_reader" {
+  type = string
+}
+
+variable "local_peer_validation_bucket_name" {
+  type = string
+}
+
+variable "local_peer_validation_bucket_writer" {
+  type = string
+}
+
+variable "local_peer_validation_bucket_reader" {
+  type = string
+}
+
+# The ingestion bucket for this data share processor, to which ingestors write
+# ingestion batches.
+resource "google_storage_bucket" "ingestion_bucket" {
+  provider                    = google-beta
+  name                        = var.ingestion_bucket_name
+  location                    = var.gcp_region
+  force_destroy               = true
+  uniform_bucket_level_access = true
+}
+
+# Permit the ingestion server to write to the ingestion bucket. It is assumed
+# that the ingestion server advertises a GCP service account email.
+resource "google_storage_bucket_iam_binding" "ingestion_bucket_writer" {
+  bucket = google_storage_bucket.ingestion_bucket.name
+  role   = "roles/storage.objectCreator"
+  members = [
+    "serviceAccount:${var.ingestion_bucket_writer}"
+  ]
+}
+
+# Permit our own data share processor's workflow manager and facilitators to
+# read content from the ingestion bucket.
+resource "google_storage_bucket_iam_binding" "ingestion_bucket_reader" {
+  bucket = google_storage_bucket.ingestion_bucket.name
+  role   = "roles/storage.objectViewer"
+  members = [
+    "serviceAccount:${var.ingestion_bucket_reader}"
+  ]
+}
+
+# The peer validation bucket for this data share processor, to which peer data
+# share processors write validation batches.
+resource "google_storage_bucket" "local_peer_validation_bucket" {
+  provider                    = google-beta
+  name                        = var.local_peer_validation_bucket_name
+  location                    = var.gcp_region
+  force_destroy               = true
+  uniform_bucket_level_access = true
+}
+
+# Permit the peer data share processors to write to the ingestion bucket. It is
+# assumed that all peer DSPs will impersonate a single GCP SA whose email is
+# advertised from the peer DSP global manifest.
+resource "google_storage_bucket_iam_binding" "local_peer_validation_bucket_writer" {
+  bucket = google_storage_bucket.local_peer_validation_bucket.name
+  role   = "roles/storage.objectCreator"
+  members = [
+    "serviceAccount:${var.local_peer_validation_bucket_writer}"
+  ]
+}
+
+# Permit our own data share processor's workflow manager and facilitators to
+# read content from the peer validation bucket.
+resource "google_storage_bucket_iam_binding" "local_peer_validation_bucket_reader" {
+  bucket = google_storage_bucket.local_peer_validation_bucket.name
+  role   = "roles/storage.objectViewer"
+  members = [
+    "serviceAccount:${var.local_peer_validation_bucket_reader}"
+  ]
+}

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -325,9 +325,8 @@ resource "google_storage_bucket_object" "specific_manifest" {
   cache_control = "no-cache"
   content = jsonencode({
     format                     = 1
-    ingestion-bucket           = "${aws_s3_bucket.ingestion_bucket.region}/${aws_s3_bucket.ingestion_bucket.bucket}",
-    ingestion-identity         = local.ingestion_bucket_writer_role_arn
-    peer-validation-bucket     = "${aws_s3_bucket.peer_validation_bucket.region}/${aws_s3_bucket.peer_validation_bucket.bucket}",
+    ingestion-bucket           = local.ingestion_bucket_url
+    peer-validation-bucket     = local.local_peer_validation_bucket_url
     batch-signing-public-keys  = {}
     packet-encryption-key-csrs = {}
   })

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -22,6 +22,14 @@ variable "manifest_bucket" {
   type = string
 }
 
+variable "use_aws" {
+  type = bool
+}
+
+variable "aws_region" {
+  type = string
+}
+
 variable "kubernetes_namespace" {
   type = string
 }
@@ -38,19 +46,15 @@ variable "ingestor_manifest_base_url" {
   type = string
 }
 
-variable "ingestor_aws_role_arn" {
-  type = string
-}
-
-variable "ingestor_gcp_service_account_id" {
-  type = string
-}
-
 variable "ingestor_gcp_service_account_email" {
   type = string
 }
 
 variable "peer_share_processor_aws_account_id" {
+  type = string
+}
+
+variable "peer_share_processor_gcp_service_account_email" {
   type = string
 }
 
@@ -62,7 +66,7 @@ variable "own_manifest_base_url" {
   type = string
 }
 
-variable "sum_part_bucket_service_account_email" {
+variable "remote_bucket_writer_gcp_service_account_email" {
   type = string
 }
 
@@ -92,55 +96,116 @@ locals {
   resource_prefix         = "prio-${var.environment}-${var.data_share_processor_name}"
   is_env_with_ingestor    = lookup(var.test_peer_environment, "env_with_ingestor", "") == var.environment
   is_env_without_ingestor = lookup(var.test_peer_environment, "env_without_ingestor", "") == var.environment
-  # There are four cases for who is writing to this data share processor's
-  # ingestion bucket, listed in the order we check for them:
+  # There are three cases for who is accessing this data share processor's
+  # storage buckets, listed in the order we check for them:
   #
-  # 1 - This is a test environment that creates fake ingestors. The fake
-  #     ingestors assume this data share processor's aws_iam_role.bucket_role,
-  #     so grant that role write permissions on the ingestion bucket.
-  # 2 - This is a test environment that does _not_ create fake ingestors.
-  #     We assume the other test env (our peer) uses the same AWS account ID and
-  #     that it follows the same naming conventions we do, and grant what should
-  #     be the corresponding data share processor's aws_iam_role.bucket_role
-  #     access.
-  # 3 - This is a non-test environment for an ingestor that advertises a GCP
-  #     service account. We will have created
-  #     aws_iam_role.ingestor_bucket_writer_role and grant it write access.
-  # 4 - This is a non-test environment for an ingestor that advertises an AWS
-  #     role. We grant that role write access.
-  ingestion_bucket_writer_role_arn = local.is_env_with_ingestor ? (
-    aws_iam_role.bucket_role.arn
+  # 1 - This is a test environment that creates fake ingestors and whose storage
+  #     is exclusively in GCS.
+  # 2 - This is a test environment that does _not_ create fake ingestors and
+  #     whose storage is partially in S3.
+  # 3 - This is a non-test environment whose storage is exclusively in GCS and
+  #     for an ingestor that advertises a GCP service account email.
+  #
+  # The case we no longer support is a non-test environment for an ingestor that
+  # advertises an AWS role.
+  bucket_access_identities = local.is_env_with_ingestor ? (
+    {
+      # Our sample-maker jobs write to our own ingestion bucket in GCS, so no
+      # special auth is needed
+      ingestion_bucket_writer = module.kubernetes.service_account_email
+      # No special auth is needed to read from the ingestion bucket in GCS
+      ingestion_bucket_reader = module.kubernetes.service_account_email
+      # The identity that GKE jobs should assume or impersonate to access the
+      # ingestion bucket.
+      ingestion_identity = ""
+      # We assume this AWS IAM role to write our validations to the peer DSP's
+      # bucket
+      remote_validation_bucket_writer = aws_iam_role.bucket_role.arn
+      # We permit the peer's GCP service account to write their validations to
+      # our bucket
+      local_peer_validation_bucket_writer = var.peer_share_processor_gcp_service_account_email
+      local_peer_validation_bucket_reader = module.kubernetes.service_account_email
+      # The identity that GKE jobs should assume or impersonate to access the
+      # local peer validation bucket
+      local_peer_validation_identity = ""
+    }
     ) : local.is_env_without_ingestor ? (
-    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/prio-${var.test_peer_environment.env_with_ingestor}-${var.data_share_processor_name}-bucket-role"
-    ) : var.ingestor_gcp_service_account_id != "" ? (
-    aws_iam_role.ingestor_bucket_writer_role[0].arn
+    {
+      # In the test setup, the peer env hosts the sample-makers, so allow
+      # entities in the peer's AWS account to write to our ingeston bucket
+      ingestion_bucket_writer = var.peer_share_processor_aws_account_id
+      # We must assume this AWS role to read our ingestion bucket
+      ingestion_bucket_reader = aws_iam_role.bucket_role.arn
+      # The identity that GKE jobs should assume or impersonate to access the
+      # ingestion bucket.
+      ingestion_identity = aws_iam_role.bucket_role.arn
+      # We impersonate this GCP SA to write to the peer's validation bucket
+      remote_validation_bucket_writer = var.remote_bucket_writer_gcp_service_account_email
+      # We permit entities in the peer's AWS account to write their validations
+      # to our bucket
+      local_peer_validation_bucket_writer = var.peer_share_processor_aws_account_id
+      # We assume this AWS role to read the bucket to which peers wrote their
+      # validations
+      local_peer_validation_bucket_reader = aws_iam_role.bucket_role.arn
+      # The identity that GKE jobs should assume or impersonate to access the
+      # local peer validation bucket
+      local_peer_validation_identity = aws_iam_role.bucket_role.arn
+    }
     ) : (
-    var.ingestor_aws_role_arn
+    {
+      # Ingestors always act as a GCP service account, to which we grant write
+      # permissions.
+      ingestion_bucket_writer = var.ingestor_gcp_service_account_email
+      # No special auth is needed to read from the ingestion bucket in GCS
+      ingestion_bucket_reader = module.kubernetes.service_account_email
+      # The identity that GKE jobs should assume or impersonate to access the
+      # ingestion bucket.
+      ingestion_identity = ""
+      # We assume this AWS IAM role to write our validations to the peer DSP's
+      # bucket
+      remote_validation_bucket_writer = aws_iam_role.bucket_role.arn
+      # We permit the peer's GCP service account to write their validations to
+      # our bucket
+      local_peer_validation_bucket_writer = var.peer_share_processor_gcp_service_account_email
+      # No special auth is needed to read from the validation bucket in GCS
+      local_peer_validation_bucket_reader = module.kubernetes.service_account_email
+      # The identity that GKE jobs should assume or impersonate to access the
+      # local peer validation bucket
+      local_peer_validation_identity = ""
+    }
   )
-  ingestion_bucket_name       = "${local.resource_prefix}-ingestion"
-  peer_validation_bucket_name = "${local.resource_prefix}-peer-validation"
+  ingestion_bucket_name = "${local.resource_prefix}-ingestion"
+  ingestion_bucket_url = var.use_aws ? (
+    "s3://${var.aws_region}/${local.ingestion_bucket_name}"
+    ) : (
+    "gs://${local.ingestion_bucket_name}"
+  )
+  local_peer_validation_bucket_name = "${local.resource_prefix}-peer-validation"
+  local_peer_validation_bucket_url = var.use_aws ? (
+    "s3://${var.aws_region}/${local.local_peer_validation_bucket_name}"
+    ) : (
+    "gs://${local.local_peer_validation_bucket_name}"
+  )
   # If this environment creates fake ingestors, we make an educated guess about
   # the name of the other test environment's ingestion bucket so our fake
   # ingestors can write ingestion batches to them. This assumes that the
   # other test environment follows our naming convention and that they are in
   # the same AWS region as we are.
   test_peer_ingestion_bucket = local.is_env_with_ingestor ? (
-    "${aws_s3_bucket.ingestion_bucket.region}/prio-${var.test_peer_environment.env_without_ingestor}-${var.data_share_processor_name}-ingestion"
+    "s3://${var.aws_region}/prio-${var.test_peer_environment.env_without_ingestor}-${var.data_share_processor_name}-ingestion"
   ) : ""
 }
 
 data "aws_caller_identity" "current" {}
 
-# This is the role in AWS we use to construct policy on the S3 buckets. It is
-# configured to allow access to the GCP service account for this data share
-# processor via Web Identity Federation
+# This is the role in AWS we use to access S3 buckets. Generally that means
+# buckets owned by peers, but in some test deployments which use S3, this role
+# also governs access to those S3 buckets. It is configured to allow access to
+# the GCP service account for this data share processor via Web Identity
+# Federation
 # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html
 resource "aws_iam_role" "bucket_role" {
   name = "${local.resource_prefix}-bucket-role"
-  # We currently use a single role per facilitator to gate read/write access to
-  # all buckets. We could define more GCP service accounts and corresponding AWS
-  # IAM roles for read/write on each of the ingestion, validation and sum part
-  # buckets.
   # Since azp is set in the auth token Google generates, we must check oaud in
   # the role assumption policy, and the value must match what we request when
   # requesting tokens from the GKE metadata service in
@@ -199,162 +264,34 @@ resource "aws_iam_role_policy" "bucket_role_policy" {
 POLICY
 }
 
-# If the ingestor authenticates using a GCP service account, this is the role in
-# AWS that their service account assumes. Note the "count" parameter in the
-# block, which seems to be the Terraform convention to conditionally create
-# resources (c.f. lots of StackOverflow questions and GitHub issues).
-# We have two statements in this policy, one granting access to the account by
-# numeric ID, and the other by account email. This is a workaround for behavior
-# observed by our Google colleagues, where auth tokens they get from the IAM API
-# sometimes have one or the other value in azp.
-resource "aws_iam_role" "ingestor_bucket_writer_role" {
-  count              = var.ingestor_gcp_service_account_id != "" ? 1 : 0
-  name               = "${local.resource_prefix}-bucket-writer"
-  assume_role_policy = <<ROLE
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Federated": "accounts.google.com"
-      },
-      "Action": "sts:AssumeRoleWithWebIdentity",
-      "Condition": {
-        "StringEquals": {
-          "accounts.google.com:sub": "${var.ingestor_gcp_service_account_id}"
-        }
-      }
-    },
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Federated": "accounts.google.com"
-      },
-      "Action": "sts:AssumeRoleWithWebIdentity",
-      "Condition": {
-        "StringEquals": {
-          "accounts.google.com:aud": "${var.ingestor_gcp_service_account_email}"
-        }
-      }
-    }
-  ]
-}
-ROLE
-
-  tags = {
-    environment = "prio-${var.environment}"
-  }
+# For test purposes, we support creating the ingestion and peer validation
+# buckets in AWS S3, even though all ISRG storage is in Google Cloud Storage. We
+# only create the ingestion bucket and peer validation bucket there, so that we
+# can exercise the parameter exchange and authentication flows.
+# https://github.com/abetterinternet/prio-server/issues/68
+module "cloud_storage_aws" {
+  count                               = var.use_aws ? 1 : 0
+  source                              = "../../modules/cloud_storage_aws"
+  environment                         = var.environment
+  ingestion_bucket_name               = local.ingestion_bucket_name
+  ingestion_bucket_writer             = local.bucket_access_identities.ingestion_bucket_writer
+  ingestion_bucket_reader             = local.bucket_access_identities.ingestion_bucket_reader
+  local_peer_validation_bucket_name   = local.local_peer_validation_bucket_name
+  local_peer_validation_bucket_writer = local.bucket_access_identities.local_peer_validation_bucket_writer
+  local_peer_validation_bucket_reader = local.bucket_access_identities.local_peer_validation_bucket_reader
 }
 
-# The ingestion bucket for this data share processor. This one is different from
-# the other two in that we must grant write access to the ingestor but no access
-# to the peer share processor.
-resource "aws_s3_bucket" "ingestion_bucket" {
-  bucket = local.ingestion_bucket_name
-  # Force deletion of bucket contents on bucket destroy.
-  force_destroy = true
-  policy        = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${local.ingestion_bucket_writer_role_arn}"
-      },
-      "Action": [
-        "s3:AbortMultipartUpload",
-        "s3:PutObject",
-        "s3:ListMultipartUploadParts",
-        "s3:ListBucketMultipartUploads"
-      ],
-      "Resource": [
-        "arn:aws:s3:::${local.ingestion_bucket_name}/*",
-        "arn:aws:s3:::${local.ingestion_bucket_name}"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${aws_iam_role.bucket_role.arn}"
-      },
-      "Action": [
-        "s3:GetObject",
-        "s3:ListBucket"
-      ],
-      "Resource": [
-        "arn:aws:s3:::${local.ingestion_bucket_name}/*",
-        "arn:aws:s3:::${local.ingestion_bucket_name}"
-      ]
-    }
-  ]
-}
-POLICY
-
-  tags = {
-    environment = var.environment
-  }
-}
-
-# The peer validation bucket for this data share processor, configured to permit
-# the peer share processor to write to it. The policy grants write permissions
-# to any role or user in the peer data share processor's AWS account because
-# Amazon S3 won't let you define policies in terms of roles that don't exist. In
-# any case, since we have no control over or insight into the role assumption
-# policies in the other account, we gain nothing by specifying anything beyond
-# the AWS account.
-# For the aws_iam_role.bucket_role.arn section (the second entry), we temporarily
-# allow the various write permissions, so that sample_maker can write sample data.
-resource "aws_s3_bucket" "peer_validation_bucket" {
-  bucket = local.peer_validation_bucket_name
-  # Force deletion of bucket contents on bucket destroy.
-  force_destroy = true
-  policy        = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${var.peer_share_processor_aws_account_id}"
-      },
-      "Action": [
-        "s3:AbortMultipartUpload",
-        "s3:PutObject",
-        "s3:ListMultipartUploadParts",
-        "s3:ListBucketMultipartUploads"
-      ],
-      "Resource": [
-        "arn:aws:s3:::${local.peer_validation_bucket_name}/*",
-        "arn:aws:s3:::${local.peer_validation_bucket_name}"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "AWS": "${aws_iam_role.bucket_role.arn}"
-      },
-      "Action": [
-        "s3:GetObject",
-        "s3:ListBucket",
-        "s3:AbortMultipartUpload",
-        "s3:PutObject",
-        "s3:ListMultipartUploadParts",
-        "s3:ListBucketMultipartUploads"
-      ],
-      "Resource": [
-        "arn:aws:s3:::${local.peer_validation_bucket_name}/*",
-        "arn:aws:s3:::${local.peer_validation_bucket_name}"
-      ]
-    }
-  ]
-}
-POLICY
-
-  tags = {
-    environment = var.environment
-  }
+# In real ISRG deployments, all of our storage is in GCS
+module "cloud_storage_gcp" {
+  count                               = var.use_aws ? 0 : 1
+  source                              = "../../modules/cloud_storage_gcp"
+  gcp_region                          = var.gcp_region
+  ingestion_bucket_name               = local.ingestion_bucket_name
+  ingestion_bucket_writer             = local.bucket_access_identities.ingestion_bucket_writer
+  ingestion_bucket_reader             = local.bucket_access_identities.ingestion_bucket_reader
+  local_peer_validation_bucket_name   = local.local_peer_validation_bucket_name
+  local_peer_validation_bucket_writer = local.bucket_access_identities.local_peer_validation_bucket_writer
+  local_peer_validation_bucket_reader = local.bucket_access_identities.local_peer_validation_bucket_reader
 }
 
 # Besides the validation bucket owned by the peer data share processor, we write
@@ -376,7 +313,7 @@ resource "google_storage_bucket_iam_binding" "own_validation_bucket_admin" {
   bucket = google_storage_bucket.own_validation_bucket.name
   role   = "roles/storage.objectAdmin"
   members = [
-    module.kubernetes.service_account_email
+    "serviceAccount:${module.kubernetes.service_account_email}"
   ]
 }
 
@@ -403,16 +340,17 @@ module "kubernetes" {
   gcp_project                             = var.gcp_project
   environment                             = var.environment
   kubernetes_namespace                    = var.kubernetes_namespace
-  ingestion_bucket                        = "${aws_s3_bucket.ingestion_bucket.region}/${aws_s3_bucket.ingestion_bucket.bucket}"
-  ingestion_bucket_role                   = aws_iam_role.bucket_role.arn
+  ingestion_bucket                        = local.ingestion_bucket_url
+  ingestion_bucket_identity               = local.bucket_access_identities.ingestion_identity
   ingestor_manifest_base_url              = var.ingestor_manifest_base_url
   packet_decryption_key_kubernetes_secret = var.packet_decryption_key_kubernetes_secret
   peer_manifest_base_url                  = var.peer_share_processor_manifest_base_url
-  peer_validation_bucket                  = "${aws_s3_bucket.peer_validation_bucket.region}/${aws_s3_bucket.peer_validation_bucket.bucket}"
-  peer_validation_bucket_role             = aws_iam_role.bucket_role.arn
-  own_validation_bucket                   = google_storage_bucket.own_validation_bucket.name
+  remote_peer_validation_bucket_identity  = local.bucket_access_identities.remote_validation_bucket_writer
+  local_peer_validation_bucket            = local.local_peer_validation_bucket_url
+  local_peer_validation_bucket_identity   = local.bucket_access_identities.local_peer_validation_identity
+  own_validation_bucket                   = "gs://${google_storage_bucket.own_validation_bucket.name}"
   own_manifest_base_url                   = var.own_manifest_base_url
-  sum_part_bucket_service_account_email   = var.sum_part_bucket_service_account_email
+  sum_part_bucket_service_account_email   = var.remote_bucket_writer_gcp_service_account_email
   portal_server_manifest_base_url         = var.portal_server_manifest_base_url
   is_env_with_ingestor                    = local.is_env_with_ingestor
   test_peer_ingestion_bucket              = local.test_peer_ingestion_bucket
@@ -439,10 +377,9 @@ output "service_account_email" {
 
 output "specific_manifest" {
   value = {
-    format                 = 0
-    ingestion-bucket       = "${aws_s3_bucket.ingestion_bucket.region}/${aws_s3_bucket.ingestion_bucket.bucket}",
-    ingestion-identity     = local.ingestion_bucket_writer_role_arn
-    peer-validation-bucket = "${aws_s3_bucket.peer_validation_bucket.region}/${aws_s3_bucket.peer_validation_bucket.bucket}",
+    format                 = 1
+    ingestion-bucket       = local.ingestion_bucket_url,
+    peer-validation-bucket = local.local_peer_validation_bucket_url,
     batch-signing-public-keys = {
       (module.kubernetes.batch_signing_key) = {
         public-key = ""

--- a/terraform/modules/fake_server_resources/fake_server_resources.tf
+++ b/terraform/modules/fake_server_resources/fake_server_resources.tf
@@ -54,11 +54,11 @@ resource "google_storage_bucket_object" "portal_server_global_manifest" {
   bucket       = var.manifest_bucket
   content_type = "application/json"
   content = jsonencode({
-    format = 0
+    format = 1
     # We're cheating here by listing the same bucket twice, but the other env
     # will consult a totally different portal server global manifest.
-    facilitator-sum-part-bucket = google_storage_bucket.sum_part_output.name
-    pha-sum-part-bucket         = google_storage_bucket.sum_part_output.name
+    facilitator-sum-part-bucket = "gs://${google_storage_bucket.sum_part_output.name}"
+    pha-sum-part-bucket         = "gs://${google_storage_bucket.sum_part_output.name}"
   })
 }
 
@@ -71,10 +71,12 @@ resource "google_storage_bucket_object" "ingestor_global_manifests" {
   bucket       = var.manifest_bucket
   content_type = "application/json"
   content = jsonencode({
-    format = 0
+    format = 1
     server-identity = {
-      # this value is ignored in our test setup; see data_share_processor.tf
-      aws-iam-entity = "irrelevant in test environment"
+      # these values are ignored in our test setup; see data_share_processor.tf
+      aws-iam-entity            = "irrelevant in test environment"
+      gcp-service-account-id    = "0"
+      gcp-service-account-email = "irrelevant in test environment"
     }
     batch-signing-public-keys = {
       # This key identifier matches the one passed to sample_maker's

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -51,11 +51,11 @@ variable "ingestor_manifest_base_url" {
   type = string
 }
 
-variable "local_peer_validation_bucket" {
+variable "peer_validation_bucket" {
   type = string
 }
 
-variable "local_peer_validation_bucket_identity" {
+variable "peer_validation_bucket_identity" {
   type = string
 }
 
@@ -214,8 +214,8 @@ resource "kubernetes_config_map" "aggregate_job_config_map" {
     INSTANCE_NAME                        = var.data_share_processor_name
     OWN_INPUT                            = var.own_validation_bucket
     OWN_MANIFEST_BASE_URL                = var.own_manifest_base_url
-    PEER_INPUT                           = var.local_peer_validation_bucket
-    PEER_IDENTITY                        = var.local_peer_validation_bucket_identity
+    PEER_INPUT                           = var.peer_validation_bucket
+    PEER_IDENTITY                        = var.peer_validation_bucket_identity
     PEER_MANIFEST_BASE_URL               = "https://${var.peer_manifest_base_url}"
     PORTAL_IDENTITY                      = var.sum_part_bucket_service_account_email
     PORTAL_MANIFEST_BASE_URL             = "https://${var.portal_server_manifest_base_url}"
@@ -268,8 +268,8 @@ resource "kubernetes_cron_job" "workflow_manager" {
                 "--ingestor-input", var.ingestion_bucket,
                 "--ingestor-identity", var.ingestion_bucket_identity,
                 "--own-validation-input", var.own_validation_bucket,
-                "--peer-validation-input", var.local_peer_validation_bucket,
-                "--peer-validation-identity", var.local_peer_validation_bucket_identity,
+                "--peer-validation-input", var.peer_validation_bucket,
+                "--peer-validation-identity", var.peer_validation_bucket_identity,
                 "--bsk-secret-name", kubernetes_secret.batch_signing_key.metadata[0].name,
                 "--pdks-secret-name", var.packet_decryption_key_kubernetes_secret,
                 "--intake-batch-config-map", kubernetes_config_map.intake_batch_job_config_map.metadata[0].name,

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -43,7 +43,7 @@ variable "ingestion_bucket" {
   type = string
 }
 
-variable "ingestion_bucket_role" {
+variable "ingestion_bucket_identity" {
   type = string
 }
 
@@ -51,15 +51,19 @@ variable "ingestor_manifest_base_url" {
   type = string
 }
 
-variable "peer_validation_bucket" {
+variable "local_peer_validation_bucket" {
   type = string
 }
 
-variable "peer_validation_bucket_role" {
+variable "local_peer_validation_bucket_identity" {
   type = string
 }
 
 variable "peer_manifest_base_url" {
+  type = string
+}
+
+variable "remote_peer_validation_bucket_identity" {
   type = string
 }
 
@@ -178,13 +182,13 @@ resource "kubernetes_config_map" "intake_batch_job_config_map" {
     IS_FIRST                             = var.is_first ? "true" : "false"
     AWS_ACCOUNT_ID                       = data.aws_caller_identity.current.account_id
     BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER = kubernetes_secret.batch_signing_key.metadata[0].name
-    INGESTOR_IDENTITY                    = var.ingestion_bucket_role
-    INGESTOR_INPUT                       = "s3://${var.ingestion_bucket}"
+    INGESTOR_IDENTITY                    = var.ingestion_bucket_identity
+    INGESTOR_INPUT                       = var.ingestion_bucket
     INGESTOR_MANIFEST_BASE_URL           = "https://${var.ingestor_manifest_base_url}"
     INSTANCE_NAME                        = var.data_share_processor_name
-    PEER_IDENTITY                        = var.peer_validation_bucket_role
+    PEER_IDENTITY                        = var.remote_peer_validation_bucket_identity
     PEER_MANIFEST_BASE_URL               = "https://${var.peer_manifest_base_url}"
-    OWN_OUTPUT                           = "gs://${var.own_validation_bucket}"
+    OWN_OUTPUT                           = var.own_validation_bucket
     RUST_LOG                             = "info"
     RUST_BACKTRACE                       = "1"
   }
@@ -204,14 +208,14 @@ resource "kubernetes_config_map" "aggregate_job_config_map" {
     IS_FIRST                             = var.is_first ? "true" : "false"
     AWS_ACCOUNT_ID                       = data.aws_caller_identity.current.account_id
     BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER = kubernetes_secret.batch_signing_key.metadata[0].name
-    INGESTOR_INPUT                       = "s3://${var.ingestion_bucket}"
-    INGESTOR_IDENTITY                    = var.ingestion_bucket_role
+    INGESTOR_INPUT                       = var.ingestion_bucket
+    INGESTOR_IDENTITY                    = var.ingestion_bucket_identity
     INGESTOR_MANIFEST_BASE_URL           = "https://${var.ingestor_manifest_base_url}"
     INSTANCE_NAME                        = var.data_share_processor_name
-    OWN_INPUT                            = "gs://${var.own_validation_bucket}"
+    OWN_INPUT                            = var.own_validation_bucket
     OWN_MANIFEST_BASE_URL                = var.own_manifest_base_url
-    PEER_INPUT                           = "s3://${var.peer_validation_bucket}"
-    PEER_IDENTITY                        = var.peer_validation_bucket_role
+    PEER_INPUT                           = var.local_peer_validation_bucket
+    PEER_IDENTITY                        = var.local_peer_validation_bucket_identity
     PEER_MANIFEST_BASE_URL               = "https://${var.peer_manifest_base_url}"
     PORTAL_IDENTITY                      = var.sum_part_bucket_service_account_email
     PORTAL_MANIFEST_BASE_URL             = "https://${var.portal_server_manifest_base_url}"
@@ -261,11 +265,11 @@ resource "kubernetes_cron_job" "workflow_manager" {
                 "--is-first=${var.is_first ? "true" : "false"}",
                 "--k8s-namespace", var.kubernetes_namespace,
                 "--k8s-service-account", module.account_mapping.kubernetes_account_name,
-                "--ingestor-input", "s3://${var.ingestion_bucket}",
-                "--ingestor-identity", var.ingestion_bucket_role,
-                "--own-validation-input", "gs://${var.own_validation_bucket}",
-                "--peer-validation-input", "s3://${var.peer_validation_bucket}",
-                "--peer-validation-identity", var.ingestion_bucket_role,
+                "--ingestor-input", var.ingestion_bucket,
+                "--ingestor-identity", var.ingestion_bucket_identity,
+                "--own-validation-input", var.own_validation_bucket,
+                "--peer-validation-input", var.local_peer_validation_bucket,
+                "--peer-validation-identity", var.local_peer_validation_bucket_identity,
                 "--bsk-secret-name", kubernetes_secret.batch_signing_key.metadata[0].name,
                 "--pdks-secret-name", var.packet_decryption_key_kubernetes_secret,
                 "--intake-batch-config-map", kubernetes_config_map.intake_batch_job_config_map.metadata[0].name,
@@ -323,10 +327,9 @@ resource "kubernetes_cron_job" "sample_maker" {
               image = "${var.container_registry}/${var.facilitator_image}:${var.facilitator_version}"
               args = [
                 "generate-ingestion-sample",
-                "--own-output", "s3://${var.ingestion_bucket}",
-                "--own-identity", var.ingestion_bucket_role,
-                "--peer-output", "s3://${var.test_peer_ingestion_bucket}",
-                "--peer-identity", var.ingestion_bucket_role,
+                "--own-output", var.ingestion_bucket,
+                "--peer-output", var.test_peer_ingestion_bucket,
+                "--peer-identity", var.remote_peer_validation_bucket_identity,
                 "--aggregation-id", "kittens-seen",
                 # All instances of the sample maker use the same batch signing
                 # key, thus simulating being a single server.
@@ -416,7 +419,7 @@ output "service_account_unique_id" {
 }
 
 output "service_account_email" {
-  value = "serviceAccount:${module.account_mapping.google_service_account_email}"
+  value = module.account_mapping.google_service_account_email
 }
 
 output "batch_signing_key" {

--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -296,7 +296,7 @@ func newBucket(bucketURL, identity string) (*bucket, error) {
 	if !strings.HasPrefix(bucketURL, "s3://") && !strings.HasPrefix(bucketURL, "gs://") {
 		return nil, fmt.Errorf("invalid bucket %q with identity %q", bucketURL, identity)
 	}
-	if strings.HasPrefix(bucketURL, "gs://") && identity != "" {
+	if strings.HasPrefix(bucketURL, "gs://") && identity != "" && identity != "default" {
 		return nil, fmt.Errorf("workflow-manager doesn't support alternate identities (%s) for gs:// bucket (%q)",
 			identity, bucketURL)
 	}
@@ -384,7 +384,7 @@ func (b *bucket) listFilesS3(ctx context.Context) ([]string, error) {
 }
 
 func (b *bucket) listFilesGS(ctx context.Context) ([]string, error) {
-	if b.identity != "" {
+	if b.identity != "" && b.identity != "default" {
 		return nil, fmt.Errorf("workflow-manager doesn't support non-default identity %q for GS bucket %q", b.identity, b.bucketName)
 	}
 	client, err := storage.NewClient(ctx)

--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -296,7 +296,7 @@ func newBucket(bucketURL, identity string) (*bucket, error) {
 	if !strings.HasPrefix(bucketURL, "s3://") && !strings.HasPrefix(bucketURL, "gs://") {
 		return nil, fmt.Errorf("invalid bucket %q with identity %q", bucketURL, identity)
 	}
-	if strings.HasPrefix(bucketURL, "gs://") && identity != "" && identity != "default" {
+	if strings.HasPrefix(bucketURL, "gs://") && identity != "" {
 		return nil, fmt.Errorf("workflow-manager doesn't support alternate identities (%s) for gs:// bucket (%q)",
 			identity, bucketURL)
 	}
@@ -384,7 +384,7 @@ func (b *bucket) listFilesS3(ctx context.Context) ([]string, error) {
 }
 
 func (b *bucket) listFilesGS(ctx context.Context) ([]string, error) {
-	if b.identity != "" && b.identity != "default" {
+	if b.identity != "" {
 		return nil, fmt.Errorf("workflow-manager doesn't support non-default identity %q for GS bucket %q", b.identity, b.bucketName)
 	}
 	client, err := storage.NewClient(ctx)


### PR DESCRIPTION
This commit moves ISRG's storage from S3 to GCP, and sets up the peer
test env so that one has its ingestion and peer validation buckets in S3
and the other has all its storage in GCS. This also includes bumps to
the format versions of various manifests, though they will change some
more before we can finalize format = 1 of various documents. Finally,
facilitator and workflow-manager now accept the argument "" for
their various identity parameters, indicating that no special role
assumption or service account impersonation should take place.