### PR TITLE
terraform: add Google's ingestor to gamlin-test

### DIFF
--- a/terraform/variables/gamlin-test.tfvars
+++ b/terraform/variables/gamlin-test.tfvars
@@ -11,6 +11,9 @@ managed_dns_zone = {
 }
 ingestors = {
   apple = "exposure-notification.apple.com/manifest"
+  # This is Google, but we aren't allowed to create GCS buckets with "google" in
+  # their name
+  g-enpa = "www.gstatic.com/prio-manifests"
 }
 peer_share_processor_manifest_base_url = "gamlin-test.manifests.isrg-prio.org/pha"
 portal_server_manifest_base_url        = "gamlin-test.manifests.isrg-prio.org/portal-server"


### PR DESCRIPTION
Google has brought their ingestion server online for the Narnia test.
This commit adds an entry to gamlin-test.tfvar's ingestors map for that
server. We use the ingestor label "g-enpa" because "google" would cause
us to create GCS buckets with forbidden names.