### PR TITLE
Advertise ingestion writer role ARN from manifest

### DIFF
--- a/deploy-tool/main.go
+++ b/deploy-tool/main.go
@@ -61,6 +61,10 @@ type SpecificManifest struct {
 	// IngestionBucket is the region+name of the bucket that the data share
 	// processor which owns the manifest reads ingestion batches from.
 	IngestionBucket string `json:"ingestion-bucket"`
+	// IngestionIdentity is the ARN of the AWS IAM role that should be assumed
+	// by an ingestion server to write to this data share processor's ingestion
+	// bucket, if the ingestor does not have an AWS account of their own.
+	IngestionIdentity string `json:"ingestion-identity"`
 	// PeerValidationBucket is the region+name of the bucket that the data share
 	// processor which owns the manifest reads peer validation batches from.
 	PeerValidationBucket string `json:"peer-validation-bucket"`

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -96,6 +96,10 @@ pub struct SpecificManifest {
     /// Region and name of the ingestion S3 bucket owned by this data share
     /// processor.
     ingestion_bucket: String,
+    // The ARN of the AWS IAM role that should be assumed by an ingestion server
+    // to write to this data share processor's ingestion bucket, if the ingestor
+    // does not have an AWS account of their own.
+    ingestion_identity: String,
     /// Region and name of the peer validation S3 bucket owned by this data
     /// share processor.
     peer_validation_bucket: String,
@@ -481,6 +485,7 @@ mod tests {
       }}
     }},
     "ingestion-bucket": "us-west-1/ingestion",
+    "ingestion-identity": "arn:aws:iam:something:fake",
     "peer-validation-bucket": "us-west-1/validation"
 }}
     "#,
@@ -510,8 +515,9 @@ mod tests {
             format: 0,
             batch_signing_public_keys: expected_batch_keys,
             packet_encryption_certificates: expected_packet_encryption_certificates,
-            ingestion_bucket: "us-west-1/ingestion".to_string(),
-            peer_validation_bucket: "us-west-1/validation".to_string(),
+            ingestion_bucket: "us-west-1/ingestion".to_owned(),
+            ingestion_identity: "arn:aws:iam:something:fake".to_owned(),
+            peer_validation_bucket: "us-west-1/validation".to_owned(),
         };
         assert_eq!(manifest, expected_manifest);
         let batch_signing_keys = manifest.batch_signing_public_keys().unwrap();
@@ -560,6 +566,7 @@ mod tests {
       }
     },
     "ingestion-bucket": "us-west-1/ingestion",
+    "ingestion-identity": "arn:aws:iam:something:fake",
     "peer-validation-bucket": "us-west-1/validation"
 }
     "#,
@@ -579,6 +586,7 @@ mod tests {
       }
     },
     "ingestion-bucket": "us-west-1/ingestion",
+    "ingestion-identity": "arn:aws:iam:something:fake",
     "peer-validation-bucket": "us-west-1/validation"
 }
     "#,
@@ -598,9 +606,30 @@ mod tests {
       }
     },
     "ingestion-bucket": "us-west-1/ingestion",
+    "ingestion-identity": "arn:aws:iam:something:fake",
     "peer-validation-bucket": "us-west-1/validation"
 }
     "#,
+            // Role ARN with wrong type
+            r#"
+{
+    "format": 0,
+    "packet-encryption-certificates": {
+        "fake-key-1": {
+            "certificate": "who cares"
+        }
+    },
+    "batch-signing-public-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\nfoo\n-----END PUBLIC KEY-----"
+      }
+    },
+    "ingestion-bucket": "us-west-1/ingestion",
+    "ingestion-identity": 1,
+    "peer-validation-bucket": "us-west-1/validation"
+}
+"#,
         ];
 
         for invalid_manifest in &invalid_manifests {
@@ -628,6 +657,7 @@ mod tests {
       }
     },
     "ingestion-bucket": "us-west-1/ingestion",
+    "ingestion-identity": "arn:aws:iam:something:fake",
     "peer-validation-bucket": "us-west-1/validation"
 }
     "#,
@@ -647,6 +677,7 @@ mod tests {
       }
     },
     "ingestion-bucket": "us-west-1/ingestion",
+    "ingestion-identity": "arn:aws:iam:something:fake",
     "peer-validation-bucket": "us-west-1/validation"
 }
     "#,
@@ -666,6 +697,7 @@ mod tests {
       }
     },
     "ingestion-bucket": "us-west-1/ingestion",
+    "ingestion-identity": "arn:aws:iam:something:fake",
     "peer-validation-bucket": "us-west-1/validation"
 }
     "#,

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -391,6 +391,7 @@ output "specific_manifest" {
   value = {
     format                 = 0
     ingestion-bucket       = "${aws_s3_bucket.ingestion_bucket.region}/${aws_s3_bucket.ingestion_bucket.bucket}",
+    ingestion-identity     = local.ingestion_bucket_writer_role_arn
     peer-validation-bucket = "${aws_s3_bucket.peer_validation_bucket.region}/${aws_s3_bucket.peer_validation_bucket.bucket}",
     batch-signing-public-keys = {
       (module.kubernetes.batch_signing_key) = {


### PR DESCRIPTION
In order for ingestors in GCP to be able to write to ingestion buckets,
they must know what AWS IAM role to assume. We were already creating the
necessary role and configuring ingestion buckets to allow it to write,
but we hadn't exposed the ARN in the specific manifest, which this
commit fixes.