### PR TITLE
terraform: vars for aggregation period and grace

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -67,6 +67,24 @@ variable "is_first" {
   description = "Whether the data share processors created by this environment are \"first\" or \"PHA servers\""
 }
 
+variable "aggregation_period" {
+  type        = string
+  default     = "3h"
+  description = <<DESCRIPTION
+Aggregation period used by workflow manager. The value should be a string
+parseable by Go's time.ParseDuration.
+DESCRIPTION
+}
+
+variable "aggregation_grace_period" {
+  type        = string
+  default     = "1h"
+  description = <<DESCRIPTION
+Aggregation grace period used by workflow manager. The value should be a string
+parseable by Go's time.ParseDuration.
+DESCRIPTION
+}
+
 terraform {
   backend "gcs" {}
 
@@ -218,6 +236,8 @@ module "data_share_processors" {
   own_manifest_base_url                   = module.manifest.base_url
   test_peer_environment                   = var.test_peer_environment
   is_first                                = var.is_first
+  aggregation_period                      = var.aggregation_period
+  aggregation_grace_period                = var.aggregation_grace_period
 
   depends_on = [module.gke]
 }

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -72,6 +72,14 @@ variable "is_first" {
   type = bool
 }
 
+variable "aggregation_period" {
+  type = string
+}
+
+variable "aggregation_grace_period" {
+  type = string
+}
+
 locals {
   resource_prefix         = "prio-${var.environment}-${var.data_share_processor_name}"
   is_env_with_ingestor    = lookup(var.test_peer_environment, "env_with_ingestor", "") == var.environment
@@ -369,6 +377,8 @@ module "kubernetes" {
   is_env_with_ingestor                    = local.is_env_with_ingestor
   test_peer_ingestion_bucket              = local.test_peer_ingestion_bucket
   is_first                                = var.is_first
+  aggregation_period                      = var.aggregation_period
+  aggregation_grace_period                = var.aggregation_grace_period
 }
 
 output "data_share_processor_name" {

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -99,6 +99,14 @@ variable "is_first" {
   type = bool
 }
 
+variable "aggregation_period" {
+  type = string
+}
+
+variable "aggregation_grace_period" {
+  type = string
+}
+
 data "aws_caller_identity" "current" {}
 
 # Workload identity[1] lets us map GCP service accounts to Kubernetes service
@@ -278,6 +286,8 @@ resource "kubernetes_cron_job" "workflow_manager" {
               name  = "workflow-manager"
               image = "${var.container_registry}/${var.workflow_manager_image}:${var.workflow_manager_version}"
               args = [
+                "--aggregation-period", var.aggregation_period,
+                "--grace-period", var.aggregation_grace_period,
                 "--is-first=${var.is_first ? "true" : "false"}",
                 "--k8s-namespace", var.kubernetes_namespace,
                 "--k8s-service-account", kubernetes_service_account.workflow_manager.metadata[0].name,

--- a/terraform/variables/gamlin-test.tfvars
+++ b/terraform/variables/gamlin-test.tfvars
@@ -15,3 +15,5 @@ ingestors = {
 peer_share_processor_manifest_base_url = "gamlin-test.manifests.isrg-prio.org/pha"
 portal_server_manifest_base_url        = "gamlin-test.manifests.isrg-prio.org/portal-server"
 is_first                               = false
+aggregation_period                     = "30m"
+aggregation_grace_period               = "30m"


### PR DESCRIPTION
workflow-manager allows configuring the aggregation window and grace
period. This commit plumbs variables from tfvars down to the kubernetes
module so we can tune those values, which will let us run the Narnia
test a little quicker.