### PR TITLE
Extend ingestor writer role assumption policy

### DIFF
--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -174,6 +174,10 @@ struct IngestionServerIdentity {
     /// ingestion buckets. While this field's value is a number, facilitator
     /// treats it as an opaque string.
     google_service_account: Option<String>,
+    /// The email address of the GCP service account that this ingestion server
+    /// uses to authenticate via OIDC identity federation to access ingestion
+    /// buckets.
+    gcp_service_account_email: Option<String>,
 }
 
 /// Represents an ingestion server's global manifest.
@@ -697,7 +701,8 @@ mod tests {
 {
     "format": 0,
     "server-identity": {
-        "google-service-account": "112310747466759665351"
+        "google-service-account": "112310747466759665351",
+        "gcp-service-account-email": "foo@bar.com"
     },
     "batch-signing-public-keys": {
         "key-identifier-2": {
@@ -731,6 +736,10 @@ mod tests {
         assert_eq!(
             manifest.server_identity.google_service_account,
             Some("112310747466759665351".to_owned())
+        );
+        assert_eq!(
+            manifest.server_identity.gcp_service_account_email,
+            Some("foo@bar.com".to_owned())
         );
         let batch_signing_public_keys = manifest.batch_signing_public_keys().unwrap();
         batch_signing_public_keys.get("key-identifier-2").unwrap();

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -192,6 +192,7 @@ locals {
       packet_decryption_key_kubernetes_secret = kubernetes_secret.ingestion_packet_decryption_keys[pair[0]].metadata[0].name
       ingestor_aws_role_arn                   = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body).server-identity, "aws-iam-entity", "")
       ingestor_gcp_service_account_id         = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body).server-identity, "google-service-account", "")
+      ingestor_gcp_service_account_email      = lookup(jsondecode(data.http.ingestor_global_manifests[pair[1]].body).server-identity, "gcp-service-account-email", "")
       ingestor_manifest_base_url              = var.ingestors[pair[1]]
     }
   }
@@ -209,6 +210,7 @@ module "data_share_processors" {
   certificate_domain                      = "${var.environment}.certificates.${var.manifest_domain}"
   ingestor_aws_role_arn                   = each.value.ingestor_aws_role_arn
   ingestor_gcp_service_account_id         = each.value.ingestor_gcp_service_account_id
+  ingestor_gcp_service_account_email      = each.value.ingestor_gcp_service_account_email
   ingestor_manifest_base_url              = each.value.ingestor_manifest_base_url
   packet_decryption_key_kubernetes_secret = each.value.packet_decryption_key_kubernetes_secret
   peer_share_processor_aws_account_id     = jsondecode(data.http.peer_share_processor_global_manifest.body).server-identity.aws-account-id


### PR DESCRIPTION
Our role assumption policy was granting access based on the numeric
account ID of the GCP service account. Apparently, the tokens our
colleagues at Google get from GCP IAM sometimes instead contain the
service account's email address. We amend the role assumption policy so
that either will work.

More context: https://enpa-collab.slack.com/archives/C01DD6F1VG8/p1605040844399000