### PR TITLE
workflow-manager: Use default credentials.

### DIFF
--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -343,19 +343,16 @@ func (b *bucket) listFilesS3(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("making AWS session: %w", err)
 	}
 
-	var creds *credentials.Credentials
+	log.Printf("listing files in s3://%s as %q", bucket, b.identity)
+	config := aws.NewConfig().
+		WithRegion(region)
 	if b.identity != "" {
-		creds, err = webIDP(sess, b.identity)
+		creds, err := webIDP(sess, b.identity)
 		if err != nil {
 			return nil, err
 		}
-	} else {
-		creds = credentials.NewEnvCredentials()
+		config = config.WithCredentials(creds)
 	}
-	log.Printf("listing files in s3://%s as %q", bucket, b.identity)
-	config := aws.NewConfig().
-		WithRegion(region).
-		WithCredentials(creds)
 	svc := s3.New(sess, config)
 	var output []string
 	var nextContinuationToken string = ""


### PR DESCRIPTION
Previously, we tried to use default credentials via
`config.NewEnvCredentials()`, but that only supports a subset of
possible credentialing methods. By leaving the credentials unset, I
believe we can take advantage of a wider role of possible credential
inputs, like AWS_ROLE_ARN / AWS_WEB_IDENTITY_TOKEN_FILE.