### PR TITLE
facilitator: Add AWS ChainProvider for WebIDP.

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -548,6 +548,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "async-trait",
  "avro-rs",
  "base64 0.12.3",
  "chrono",

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
+async-trait = "0.1"
 anyhow = "1.0"
 avro-rs = { version = "0.11.0", features = ["snappy"] }
 base64 = "0.12.3"

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -843,6 +843,7 @@ pub struct ChainProvider {
     instance_metadata_provider: InstanceMetadataProvider,
     container_provider: ContainerProvider,
     profile_provider: Option<ProfileProvider>,
+    webidp_provider: WebIdentityProvider,
 }
 
 impl ChainProvider {
@@ -871,7 +872,7 @@ async fn chain_provider_credentials(
     if let Ok(creds) = provider.instance_metadata_provider.credentials().await {
         return Ok(creds);
     }
-    if let Ok(creds) = WebIdentityProvider::from_k8s_env().credentials().await {
+    if let Ok(creds) = provider.webidp_provider.credentials().await {
         return Ok(creds);
     }
     Err(CredentialsError::new(
@@ -896,6 +897,7 @@ impl ChainProvider {
             profile_provider: ProfileProvider::new().ok(),
             instance_metadata_provider: InstanceMetadataProvider::new(),
             container_provider: ContainerProvider::new(),
+            webidp_provider: WebIdentityProvider::from_k8s_env(),
         }
     }
 
@@ -907,6 +909,7 @@ impl ChainProvider {
             profile_provider: Some(profile_provider),
             instance_metadata_provider: InstanceMetadataProvider::new(),
             container_provider: ContainerProvider::new(),
+            webidp_provider: WebIdentityProvider::from_k8s_env(),
         }
     }
 }

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -818,15 +818,6 @@ impl ProvideAwsCredentials for DefaultCredentialsProvider {
 ///
 /// # Example
 ///
-/// ```rust
-/// use std::time::Duration;
-///
-/// use rusoto_credential::ChainProvider;
-///
-/// let mut provider = ChainProvider::new();
-/// // you can overwrite the default timeout like this:
-/// provider.set_timeout(Duration::from_secs(60));
-/// ```
 ///
 /// # Warning
 ///

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -8,8 +8,10 @@ use derivative::Derivative;
 use hyper_rustls::HttpsConnector;
 use log::info;
 use rusoto_core::{
+    credential::EnvironmentProvider,
     credential::{
-        AutoRefreshingProvider, CredentialsError, DefaultCredentialsProvider, Secret, Variable,
+        AutoRefreshingProvider, AwsCredentials, ContainerProvider, CredentialsError,
+        InstanceMetadataProvider, ProfileProvider, ProvideAwsCredentials, Secret, Variable,
     },
     ByteStream, Region,
 };
@@ -762,5 +764,155 @@ mod tests {
         writer.write_all(b"fake-content").unwrap();
         writer.complete_upload().unwrap();
         writer.cancel_upload().unwrap();
+    }
+}
+
+// ------------- Everything below here was copied from rusoto/credential/src/lib.rs in the rusoto repo ---------------------------
+// -------------------------------------------------------------------------------------------------------------------------------
+
+/// Wraps a `ChainProvider` in an `AutoRefreshingProvider`.
+///
+/// The underlying `ChainProvider` checks multiple sources for credentials, and the `AutoRefreshingProvider`
+/// refreshes the credentials automatically when they expire.
+///
+/// # Warning
+///
+/// This provider allows the [`credential_process`][credential_process] option in the AWS config
+/// file (`~/.aws/config`), a method of sourcing credentials from an external process. This can
+/// potentially be dangerous, so proceed with caution. Other credential providers should be
+/// preferred if at all possible. If using this option, you should make sure that the config file
+/// is as locked down as possible using security best practices for your operating system.
+///
+/// [credential_process]: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
+#[derive(Clone)]
+pub struct DefaultCredentialsProvider(AutoRefreshingProvider<ChainProvider>);
+
+impl DefaultCredentialsProvider {
+    /// Creates a new thread-safe `DefaultCredentialsProvider`.
+    pub fn new() -> Result<DefaultCredentialsProvider, CredentialsError> {
+        let inner = AutoRefreshingProvider::new(ChainProvider::new())?;
+        Ok(DefaultCredentialsProvider(inner))
+    }
+}
+
+#[async_trait]
+impl ProvideAwsCredentials for DefaultCredentialsProvider {
+    async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+        self.0.credentials().await
+    }
+}
+
+/// Provides AWS credentials from multiple possible sources using a priority order.
+///
+/// The following sources are checked in order for credentials when calling `credentials`:
+///
+/// 1. Environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+/// 2. `credential_process` command in the AWS config file, usually located at `~/.aws/config`.
+/// 3. AWS credentials file. Usually located at `~/.aws/credentials`.
+/// 4. IAM instance profile. Will only work if running on an EC2 instance with an instance profile/role.
+///
+/// If the sources are exhausted without finding credentials, an error is returned.
+///
+/// The provider has a default timeout of 30 seconds. While it should work well for most setups,
+/// you can change the timeout using the `set_timeout` method.
+///
+/// # Example
+///
+/// ```rust
+/// use std::time::Duration;
+///
+/// use rusoto_credential::ChainProvider;
+///
+/// let mut provider = ChainProvider::new();
+/// // you can overwrite the default timeout like this:
+/// provider.set_timeout(Duration::from_secs(60));
+/// ```
+///
+/// # Warning
+///
+/// This provider allows the [`credential_process`][credential_process] option in the AWS config
+/// file (`~/.aws/config`), a method of sourcing credentials from an external process. This can
+/// potentially be dangerous, so proceed with caution. Other credential providers should be
+/// preferred if at all possible. If using this option, you should make sure that the config file
+/// is as locked down as possible using security best practices for your operating system.
+///
+/// [credential_process]: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
+#[derive(Debug, Clone)]
+pub struct ChainProvider {
+    environment_provider: EnvironmentProvider,
+    instance_metadata_provider: InstanceMetadataProvider,
+    container_provider: ContainerProvider,
+    profile_provider: Option<ProfileProvider>,
+}
+
+impl ChainProvider {
+    /// Set the timeout on the provider to the specified duration.
+    #[allow(dead_code)]
+    pub fn set_timeout(&mut self, duration: Duration) {
+        self.instance_metadata_provider.set_timeout(duration);
+        self.container_provider.set_timeout(duration);
+    }
+}
+
+async fn chain_provider_credentials(
+    provider: ChainProvider,
+) -> Result<AwsCredentials, CredentialsError> {
+    if let Ok(creds) = provider.environment_provider.credentials().await {
+        return Ok(creds);
+    }
+    if let Some(ref profile_provider) = provider.profile_provider {
+        if let Ok(creds) = profile_provider.credentials().await {
+            return Ok(creds);
+        }
+    }
+    if let Ok(creds) = provider.container_provider.credentials().await {
+        return Ok(creds);
+    }
+    if let Ok(creds) = provider.instance_metadata_provider.credentials().await {
+        return Ok(creds);
+    }
+    if let Ok(creds) = WebIdentityProvider::from_k8s_env().credentials().await {
+        return Ok(creds);
+    }
+    Err(CredentialsError::new(
+        "Couldn't find AWS credentials in environment, credentials file, or IAM role.",
+    ))
+}
+
+use async_trait::async_trait;
+
+#[async_trait]
+impl ProvideAwsCredentials for ChainProvider {
+    async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+        chain_provider_credentials(self.clone()).await
+    }
+}
+
+impl ChainProvider {
+    /// Create a new `ChainProvider` using a `ProfileProvider` with the default settings.
+    pub fn new() -> ChainProvider {
+        ChainProvider {
+            environment_provider: EnvironmentProvider::default(),
+            profile_provider: ProfileProvider::new().ok(),
+            instance_metadata_provider: InstanceMetadataProvider::new(),
+            container_provider: ContainerProvider::new(),
+        }
+    }
+
+    /// Create a new `ChainProvider` using the provided `ProfileProvider`.
+    #[allow(dead_code)]
+    pub fn with_profile_provider(profile_provider: ProfileProvider) -> ChainProvider {
+        ChainProvider {
+            environment_provider: EnvironmentProvider::default(),
+            profile_provider: Some(profile_provider),
+            instance_metadata_provider: InstanceMetadataProvider::new(),
+            container_provider: ContainerProvider::new(),
+        }
+    }
+}
+
+impl Default for ChainProvider {
+    fn default() -> Self {
+        Self::new()
     }
 }


### PR DESCRIPTION
Rusoto offers a "ChainProvider", which will try each of the various auth
methods available on AWS in order, and return as soon as one works. The
ChainProvider offered by Rusoto omits WebIdentityProvider, which we
need.

This change copies the implementation of ChainProvider, and adds
WebIdentityProvider to the list of providers tried.