### PR TITLE
facilitator: hex_dump packet file digests

### DIFF
--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -115,6 +115,15 @@ pub struct BatchSigningKey {
     pub identifier: String,
 }
 
+/// Pretty print a byte array as a hex string.
+fn hex_dump(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<Vec<_>>()
+        .concat()
+}
+
 #[cfg(test)]
 mod tests {
     use crate::DigestWriter;


### PR DESCRIPTION
As a debugging aid, adds a pretty-print function for byte arrays, and
uses it to print packet file digests when there is a mismatch.