### PR TITLE
Fixes the deploy-tool CI

### DIFF
--- a/.github/workflows/deploy-tool-build.yml
+++ b/.github/workflows/deploy-tool-build.yml
@@ -21,12 +21,6 @@ jobs:
       with:
         go-version: 1.15
     
-    - name: Set GOPATH and PATH
-      run: |
-        echo "::set-env name=GOPATH::$(dirname $GITHUB_WORKSPACE)/deploy-tool"
-        echo "::add-path::$(dirname $GITHUB_WORKSPACE)/deploy-tool/bin"
-      shell: bash
-    
     - name: Vet
       run: go vet ./...
       working-directory: deploy-tool
@@ -40,6 +34,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: false
+        file: deploy-tool/coverage.coverprofile
         flags: deploy_tool_tests
         name: deploy tool tests
   


### PR DESCRIPTION
Fixes the deploy-tool CI build since GitHub broke SetEnv https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/