### PR TITLE
facilitator: refactor manifest fetching.

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -2309,9 +2309,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "ureq"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed21e32e4e3ff89891022affaa7091c3a164d5049cb3872f1cf0fd6ccd9fc8f7"
+checksum = "a599426c7388ab189dfd0eeb84c8d879490abc73e3e62a0b6a40e286f6427ab7"
 dependencies = [
  "base64 0.13.0",
  "chunked_transfer",

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -33,7 +33,7 @@ structopt = "0.3"
 tempfile = "3.1.0"
 thiserror = "1.0"
 tokio = { version = "0.2", features = ["rt-core", "io-util"] }
-ureq = { version = "1.5.1", features = ["json"] }
+ureq = { version = "1.5.2", features = ["json"] }
 urlencoding = "1.1.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -6,7 +6,7 @@ use ring::signature::{
     EcdsaKeyPair, KeyPair, UnparsedPublicKey, ECDSA_P256_SHA256_ASN1,
     ECDSA_P256_SHA256_ASN1_SIGNING,
 };
-use std::{collections::HashMap, fs::File, io::Read, str::FromStr};
+use std::{collections::HashMap, fs, fs::File, io::Read, str::FromStr};
 use uuid::Uuid;
 
 use facilitator::{
@@ -869,8 +869,8 @@ fn aggregate(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
 
 fn lint_manifest(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
     let manifest_base_url = sub_matches.value_of("manifest-base-url");
-    let manifest_file_reader = match sub_matches.value_of("manifest-path") {
-        Some(path) => Some(File::open(path).context("failed to open manifest file")?),
+    let manifest_body: Option<String> = match sub_matches.value_of("manifest-path") {
+        Some(f) => Some(fs::read_to_string(f)?),
         None => None,
     };
 
@@ -884,8 +884,8 @@ fn lint_manifest(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
         ManifestKind::IngestorGlobal => {
             let manifest = if let Some(base_url) = manifest_base_url {
                 IngestionServerGlobalManifest::from_https(base_url)?
-            } else if let Some(reader) = manifest_file_reader {
-                IngestionServerGlobalManifest::from_reader(reader)?
+            } else if let Some(body) = manifest_body {
+                IngestionServerGlobalManifest::from_slice(body.as_bytes())?
             } else {
                 return Err(anyhow!(
                     "one of manifest-base-url or manifest-path is required"
@@ -896,8 +896,8 @@ fn lint_manifest(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
         ManifestKind::DataShareProcessorGlobal => {
             let manifest = if let Some(base_url) = manifest_base_url {
                 DataShareProcessorGlobalManifest::from_https(base_url)?
-            } else if let Some(reader) = manifest_file_reader {
-                DataShareProcessorGlobalManifest::from_reader(reader)?
+            } else if let Some(body) = manifest_body {
+                DataShareProcessorGlobalManifest::from_slice(body.as_bytes())?
             } else {
                 return Err(anyhow!(
                     "one of manifest-base-url or manifest-path is required"
@@ -911,8 +911,8 @@ fn lint_manifest(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
                 .context("instance is required when manifest-kind=data-share-processor-specific")?;
             let manifest = if let Some(base_url) = manifest_base_url {
                 SpecificManifest::from_https(base_url, instance)?
-            } else if let Some(reader) = manifest_file_reader {
-                SpecificManifest::from_reader(reader)?
+            } else if let Some(body) = manifest_body {
+                SpecificManifest::from_slice(body.as_bytes())?
             } else {
                 return Err(anyhow!(
                     "one of manifest-base-url or manifest-path is required"
@@ -923,8 +923,8 @@ fn lint_manifest(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
         ManifestKind::PortalServerGlobal => {
             let manifest = if let Some(base_url) = manifest_base_url {
                 PortalServerGlobalManifest::from_https(base_url)?
-            } else if let Some(reader) = manifest_file_reader {
-                PortalServerGlobalManifest::from_reader(reader)?
+            } else if let Some(body) = manifest_body {
+                PortalServerGlobalManifest::from_slice(body.as_bytes())?
             } else {
                 return Err(anyhow!(
                     "one of manifest-base-url or manifest-path is required"

--- a/facilitator/src/http.rs
+++ b/facilitator/src/http.rs
@@ -1,0 +1,22 @@
+use anyhow::{anyhow, Result};
+
+pub(crate) fn get_url(url: &str) -> Result<String> {
+    let resp = ureq::get(url)
+        // By default, ureq will wait forever to connect or
+        // read.
+        .timeout_connect(10_000) // ten seconds
+        .timeout_read(10_000) // ten seconds
+        .call();
+    if resp.synthetic_error().is_some() {
+        Err(anyhow!(
+            "fetching {}: {}",
+            url,
+            resp.into_synthetic_error().unwrap()
+        ))
+    } else if !resp.ok() {
+        Err(anyhow!("fetching {}: status {}", url, resp.status()))
+    } else {
+        resp.into_string()
+            .map_err(|e| anyhow!("reading body of {}: {}", url, e))
+    }
+}

--- a/facilitator/src/http.rs
+++ b/facilitator/src/http.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 
 pub(crate) fn get_url(url: &str) -> Result<String> {
     let resp = ureq::get(url)
@@ -17,6 +17,6 @@ pub(crate) fn get_url(url: &str) -> Result<String> {
         Err(anyhow!("fetching {}: status {}", url, resp.status()))
     } else {
         resp.into_string()
-            .map_err(|e| anyhow!("reading body of {}: {}", url, e))
+            .context(format!("reading body of {}", url))
     }
 }

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 pub mod aggregation;
 pub mod batch;
 pub mod config;
+pub mod http;
 pub mod idl;
 pub mod intake;
 pub mod manifest;


### PR DESCRIPTION
This adds a new get_url function that wraps ureq gets, turning ureq's
synthetic_errors into Results, and using anyhow to add context about
which URL failed.

This also changes the manifest reader functions to take a slice of bytes
instead of a reader.