### PR TITLE
facilitator: Keep the full Alpine image.

### DIFF
--- a/facilitator/Dockerfile
+++ b/facilitator/Dockerfile
@@ -33,8 +33,5 @@ RUN cargo build --manifest-path ./facilitator/Cargo.toml
 RUN strip facilitator/target/debug/facilitator
 
 # Build a minimal container containing only the binary, the one .so it needs, and root certs.
-FROM scratch
-COPY --from=builder /lib/ld-musl-x86_64.so.1 /lib/ld-musl-x86_64.so.1
-COPY --from=builder /usr/src/prio-server/facilitator/target/debug/facilitator /facilitator
-COPY --from=builder /etc/ssl/cert.pem /etc/ssl/cert.pem
+RUN cp /usr/src/prio-server/facilitator/target/debug/facilitator /facilitator
 ENTRYPOINT ["/facilitator"]


### PR DESCRIPTION
We've found in some conditions, the bare-binary variant fails to look up
DNS. We should figure that out, but in the meantime, building a full-fat
image will probably make things work.