### PR TITLE
workflow-manager: downcase job names.

### DIFF
--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -463,6 +463,7 @@ func idForJobName(aggregationID string) string {
 	if len(idForJobName) > 30 {
 		idForJobName = idForJobName[:30]
 	}
+	idForJobName = strings.ToLower(idForJobName)
 	return idForJobName
 }
 

--- a/workflow-manager/main_test.go
+++ b/workflow-manager/main_test.go
@@ -1,0 +1,12 @@
+package main
+
+import "testing"
+
+func TestIdForJobName(t *testing.T) {
+	input := "FooBar%012345678901234567890123456789"
+	id := idForJobName(input)
+	expected := "foobar-01234567890123456789012"
+	if id != expected {
+		t.Errorf("expected id %q, got %q", expected, id)
+	}
+}


### PR DESCRIPTION
Kubernetes requires that object names be in lower case.