### PR TITLE
workflow-manager: include tag in build info.

### DIFF
--- a/workflow-manager/build.sh
+++ b/workflow-manager/build.sh
@@ -3,7 +3,7 @@ cd $(dirname $0)
 
 # Embed info about the build.
 COMMIT_ID="$(git rev-parse --short=8 HEAD)"
-BUILD_ID="$(git symbolic-ref --short HEAD 2>/dev/null || true)+${COMMIT_ID}"
+BUILD_ID="$(git symbolic-ref --short HEAD 2>/dev/null || git describe --tags || true)+${COMMIT_ID}"
 BUILD_TIME="$(date)"
 BUILD_INFO="${BUILD_ID} - ${BUILD_TIME}"
 


### PR DESCRIPTION
At build time, we embed the branch and git commit into workflow-manager,
so it can print that when it starts up. However, the `git symbolic-ref`
invocation doesn't work when checked out to a tag rather than a branch.
That meant that our tagged releases wouldn't have an informative build
ID. This adds handling for tags.