### PR TITLE
workflow-manager: add to CI

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -7,28 +7,31 @@ on:
     branches: [ main, release/** ]
   workflow_dispatch:
 
-env:
-  GO111MODULE: on
-
 jobs:
   deploy-tool:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    
+
     - name: Setup go
       uses: actions/setup-go@v1
       with:
         go-version: 1.15
-    
+
     - name: Vet
       run: go vet ./...
       working-directory: deploy-tool
-    
+
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.31
+        working-directory: deploy-tool
+
     - name: Test
       run: go test -race --coverprofile=coverage.coverprofile --covermode=atomic ./...
       working-directory: deploy-tool
-    
+
     - name: Upload test coverage
       if: success()
       uses: codecov/codecov-action@v1
@@ -37,13 +40,38 @@ jobs:
         file: deploy-tool/coverage.coverprofile
         flags: deploy_tool_tests
         name: deploy tool tests
-  
-  deploy-tool-lint:
+
+  workflow-manager:
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v2
+
+    - name: Setup go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.15
+
+    - name: Vet
+      run: go vet ./...
+      working-directory: workflow-manager
+
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
         version: v1.31
-        working-directory: deploy-tool
+        working-directory: workflow-manager
+
+    - name: Test
+      run: go test -race --coverprofile=coverage.coverprofile --covermode=atomic ./...
+      working-directory: workflow-manager
+
+    - name: Upload test coverage
+      if: success()
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: false
+        file: deploy-tool/coverage.coverprofile
+        flags: deploy_tool_tests
+        name: deploy tool tests
+        working-directory: workflow-manager


### PR DESCRIPTION
Also, rename the deploy-tool-ci-build to indicate its use for both Go
modules, and tidy up some things in the YAML.