### PR TITLE
Pin gamlin-test/narnia env to 0.4.8 containers

### DIFF
--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -22,7 +22,7 @@ variable "workflow_manager_image" {
 
 variable "workflow_manager_version" {
   type    = string
-  default = "latest"
+  default = "0.4.8"
 }
 
 variable "facilitator_image" {
@@ -32,7 +32,7 @@ variable "facilitator_image" {
 
 variable "facilitator_version" {
   type    = string
-  default = "latest"
+  default = "0.4.8"
 }
 
 variable "gcp_project" {


### PR DESCRIPTION
We got through Narnia tests with the 0.4.8 release of workflow-manager
and facilitator. This commit pins the gamlin-test environment to that
version (instead of pulling latest) so that we can continue to release
newer bits from main without breaking the test env, which we will keep
around for a bit longer in case our GAMLIN partners want to continue to
push data through it.