### PR TITLE
Increases timeout on deploy-tool linting

### DIFF
--- a/.github/workflows/deploy-tool-build.yml
+++ b/.github/workflows/deploy-tool-build.yml
@@ -47,3 +47,4 @@ jobs:
       with:
         version: v1.31
         working-directory: deploy-tool
+        args: --timeout 5m


### PR DESCRIPTION
The low timeout was causing some builds to fail, this fixes that.