### PR TITLE
GCS object lifecycle and encryption

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -314,8 +314,7 @@ module "data_share_processors" {
   is_first                                       = var.is_first
   aggregation_period                             = var.aggregation_period
   aggregation_grace_period                       = var.aggregation_grace_period
-
-  depends_on = [module.gke]
+  kms_keyring                                    = module.gke.kms_keyring
 }
 
 # The portal owns two sum part buckets (one for each data share processor) and

--- a/terraform/modules/cloud_storage_gcp/bucket/bucket.tf
+++ b/terraform/modules/cloud_storage_gcp/bucket/bucket.tf
@@ -1,0 +1,62 @@
+variable "name" {
+  type = string
+}
+
+variable "gcp_region" {
+  type = string
+}
+
+variable "kms_key" {
+  type = string
+}
+
+variable "bucket_reader" {
+  type = string
+}
+
+variable "bucket_writer" {
+  type = string
+}
+
+resource "google_storage_bucket" "bucket" {
+  provider = google-beta
+  name     = var.name
+  location = var.gcp_region
+  # Force deletion of bucket contents on bucket destroy. Bucket contents would
+  # be re-created by a subsequent deploy so no reason to keep them around.
+  force_destroy               = true
+  uniform_bucket_level_access = true
+  # Automatically purge data after 7 days
+  # https://cloud.google.com/storage/docs/lifecycle
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      age = 7
+    }
+  }
+  # Encrypt bucket contents at rest using KMS key
+  # https://cloud.google.com/storage/docs/encryption/customer-managed-keys
+  encryption {
+    default_kms_key_name = var.kms_key
+  }
+}
+
+resource "google_storage_bucket_iam_binding" "bucket_writer" {
+  provider = google-beta
+  bucket   = google_storage_bucket.bucket.name
+  role     = "roles/storage.objectCreator"
+  members = [
+    "serviceAccount:${var.bucket_writer}"
+  ]
+}
+
+resource "google_storage_bucket_iam_binding" "bucket_reader" {
+  provider = google-beta
+  bucket   = google_storage_bucket.bucket.name
+  role     = "roles/storage.objectViewer"
+  members = [
+    "serviceAccount:${var.bucket_reader}"
+  ]
+}

--- a/terraform/modules/cloud_storage_gcp/cloud_storage_gcp.tf
+++ b/terraform/modules/cloud_storage_gcp/cloud_storage_gcp.tf
@@ -26,63 +26,32 @@ variable "peer_validation_bucket_reader" {
   type = string
 }
 
-# The ingestion bucket for this data share processor, to which ingestors write
-# ingestion batches.
-resource "google_storage_bucket" "ingestion_bucket" {
-  provider                    = google-beta
-  name                        = var.ingestion_bucket_name
-  location                    = var.gcp_region
-  force_destroy               = true
-  uniform_bucket_level_access = true
+variable "kms_key" {
+  type = string
 }
 
-# Permit the ingestion server to write to the ingestion bucket. It is assumed
-# that the ingestion server advertises a GCP service account email.
-resource "google_storage_bucket_iam_binding" "ingestion_bucket_writer" {
-  bucket = google_storage_bucket.ingestion_bucket.name
-  role   = "roles/storage.objectCreator"
-  members = [
-    "serviceAccount:${var.ingestion_bucket_writer}"
-  ]
+locals {
+  bucket_parameters = {
+    ingestion = {
+      name   = var.ingestion_bucket_name
+      writer = var.ingestion_bucket_writer
+      reader = var.ingestion_bucket_reader
+    }
+    local_peer_validation = {
+      name   = var.peer_validation_bucket_name
+      writer = var.peer_validation_bucket_writer
+      reader = var.ingestion_bucket_reader
+    }
+  }
 }
 
-# Permit our own data share processor's workflow manager and facilitators to
-# read content from the ingestion bucket.
-resource "google_storage_bucket_iam_binding" "ingestion_bucket_reader" {
-  bucket = google_storage_bucket.ingestion_bucket.name
-  role   = "roles/storage.objectViewer"
-  members = [
-    "serviceAccount:${var.ingestion_bucket_reader}"
-  ]
-}
+module "bucket" {
+  for_each = toset(["ingestion", "local_peer_validation"])
+  source   = "./bucket"
 
-# The peer validation bucket for this data share processor, to which peer data
-# share processors write validation batches.
-resource "google_storage_bucket" "peer_validation_bucket" {
-  provider                    = google-beta
-  name                        = var.peer_validation_bucket_name
-  location                    = var.gcp_region
-  force_destroy               = true
-  uniform_bucket_level_access = true
-}
-
-# Permit the peer data share processors to write to the ingestion bucket. It is
-# assumed that all peer DSPs will impersonate a single GCP SA whose email is
-# advertised from the peer DSP global manifest.
-resource "google_storage_bucket_iam_binding" "peer_validation_bucket_writer" {
-  bucket = google_storage_bucket.peer_validation_bucket.name
-  role   = "roles/storage.objectCreator"
-  members = [
-    "serviceAccount:${var.peer_validation_bucket_writer}"
-  ]
-}
-
-# Permit our own data share processor's workflow manager and facilitators to
-# read content from the peer validation bucket.
-resource "google_storage_bucket_iam_binding" "peer_validation_bucket_reader" {
-  bucket = google_storage_bucket.peer_validation_bucket.name
-  role   = "roles/storage.objectViewer"
-  members = [
-    "serviceAccount:${var.peer_validation_bucket_reader}"
-  ]
+  name          = local.bucket_parameters[each.value].name
+  bucket_reader = local.bucket_parameters[each.value].reader
+  bucket_writer = local.bucket_parameters[each.value].writer
+  kms_key       = var.kms_key
+  gcp_region    = var.gcp_region
 }

--- a/terraform/modules/gke/gke.tf
+++ b/terraform/modules/gke/gke.tf
@@ -161,3 +161,7 @@ output "cluster_endpoint" {
 output "certificate_authority_data" {
   value = google_container_cluster.cluster.master_auth.0.cluster_ca_certificate
 }
+
+output "kms_keyring" {
+  value = google_kms_key_ring.keyring.id
+}


### PR DESCRIPTION
Refactors creation of GCS buckets into a module which does two
additional things:
  - enables object lifecycle to automatically delete bucket contents
    after 7 days
  - enables encryption at rest with a per-data share processor KMS key

Resolves #38, #46