### PR TITLE
Terraform: don't create specific manifests

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -65,6 +65,8 @@ After the successful `apply-bootstrap` you may need to wait several minutes for 
     ENV=with-ingestor make apply
     ENV=without-ingestor make apply
 
+In your test setup, you might want to exercise reading and writing data to AWS S3 buckets, to simulate interacting with a peer data share processor that runs in AWS. Add `use_aws = true` to the `.tfvars` file for the environment you specified as `env_without_ingestor` and that env's ingestion and peer validation buckets will be created in S3.
+
 ## kubectl configuration
 
 When instantiating a new GKE cluster, you will want to merge its configuration into your local `~/.kube/config` so that you can use `kubectl` for cluster management. After a successful `apply`, Terraform will emit a `gcloud` invocation that will update your local config file. More generally, `gcloud container clusters get-credentials <YOUR CLUSTER NAME> --region <GCP REGION>"` will do the trick.

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -342,21 +342,6 @@ module "bucket" {
   gcp_region    = var.gcp_region
 }
 
-resource "google_storage_bucket_object" "specific_manifest" {
-  provider      = google-beta
-  name          = "${var.data_share_processor_name}-manifest.json"
-  bucket        = var.manifest_bucket
-  content_type  = "application/json"
-  cache_control = "no-cache"
-  content = jsonencode({
-    format                     = 1
-    ingestion-bucket           = local.ingestion_bucket_url
-    peer-validation-bucket     = local.peer_validation_bucket_url
-    batch-signing-public-keys  = {}
-    packet-encryption-key-csrs = {}
-  })
-}
-
 module "kubernetes" {
   source                                  = "../../modules/kubernetes/"
   data_share_processor_name               = var.data_share_processor_name


### PR DESCRIPTION
Creating specific manifests from Terraform was causing TF to destroy
manifests containing valid keys on each `make apply`. This also adds
a useful tip to the Terraform README.