### PR TITLE
terraform: configure Prometheus provider

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,7 +16,7 @@ We use the [AWS Terraform provider](https://registry.terraform.io/providers/hash
 
 We currently use the profile `leuswest2` in terraform (this value is defined in `main.tf`). In order for terraform to recognize your credentials, you will need to configure it with `aws configure --profile leuswest2`.
 
-Once you have helm installed, add the "stable" repository:
+`helm` is not required for creating or maintaining a cluster, but it's still useful to have configured. Once you have helm installed, add the "stable" repository:
 
 ```
 helm repo add stable https://charts.helm.sh/stable

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -368,7 +368,17 @@ output "use_test_pha_decryption_key" {
   value = lookup(var.test_peer_environment, "env_without_ingestor", "") == var.environment
 }
 
+provider "helm" {
+  kubernetes {
+    host                   = module.gke.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.gke.certificate_authority_data)
+    token                  = data.google_client_config.current.access_token
+    load_config_file       = false
+  }
+}
+
 resource "helm_release" "prometheus" {
-  name  = "prometheus"
-  chart = "stable/prometheus"
+  name       = "prometheus"
+  chart      = "prometheus"
+  repository = "https://charts.helm.sh/stable"
 }


### PR DESCRIPTION
Make sure the Prometheus provider uses credentials for the Kubernetes
cluster managed by Terraform, and not ambient credentials from ~/.kube,
which may not be for the right cluster. Additionally, we now set the
repository from which to pull the Prometheus chart so that operators
don't need to `helm add stable` outside of Terraform before deploying.