### PR TITLE
workflow-manager: use batch ID in intake job name

### DIFF
--- a/workflow-manager/main_test.go
+++ b/workflow-manager/main_test.go
@@ -2,9 +2,45 @@ package main
 
 import "testing"
 
-func TestIdForJobName(t *testing.T) {
+func TestIntakeJobNameForBatchPath(t *testing.T) {
+	var testCases = []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "short-aggregation-name",
+			input:    "kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771",
+			expected: "i-kittens-seen-b8a5579af984460a-2020-10-31-20-29",
+		},
+		{
+			name:     "long-aggregation-name",
+			input:    "a-very-long-aggregation-name-that-will-get-truncated/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771",
+			expected: "i-a-very-long-aggregation-nam-b8a5579af984460a-2020-10-31-20-29",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			batchPath, err := newBatchPath(testCase.input)
+			if err != nil {
+				t.Fatalf("unexpected batch path parse failure: %s", err)
+			}
+
+			jobName := intakeJobNameForBatchPath(batchPath)
+			if jobName != testCase.expected {
+				t.Errorf("expected %q, encountered %q", testCase.expected, jobName)
+			}
+
+			if len(jobName) > 63 {
+				t.Errorf("job name is too long")
+			}
+		})
+	}
+}
+
+func TestAggregationJobNameFragment(t *testing.T) {
 	input := "FooBar%012345678901234567890123456789"
-	id := idForJobName(input)
+	id := aggregationJobNameFragment(input, 30)
 	expected := "foobar-01234567890123456789012"
 	if id != expected {
 		t.Errorf("expected id %q, got %q", expected, id)


### PR DESCRIPTION
Intake Kubernetes jobs must incorporate the batch UUID name or
workflow-manager will not schedule jobs if more than one batch arrives
with the same timestamp.

Resolves #231