### PR TITLE
terraform: Explicitly require providers & use non-beta google by default

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -118,6 +118,41 @@ terraform {
   backend "gcs" {}
 
   required_version = ">= 0.13.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.16.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.49.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.49.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 1.3.2"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = "~> 2.0.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 1.13.3"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0.0"
+    }
+  }
 }
 
 data "terraform_remote_state" "state" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -125,11 +125,13 @@ terraform {
       version = "~> 3.16.0"
     }
     google = {
-      source  = "hashicorp/google"
+      source = "hashicorp/google"
+      # Ensure that this matches the google-beta provider version below.
       version = "~> 3.49.0"
     }
     google-beta = {
-      source  = "hashicorp/google-beta"
+      source = "hashicorp/google-beta"
+      # Ensure that this matches the non-beta google provider version above.
       version = "~> 3.49.0"
     }
     helm = {
@@ -167,12 +169,7 @@ data "terraform_remote_state" "state" {
 
 data "google_client_config" "current" {}
 
-provider "google-beta" {
-  # We use the google-beta provider so that we can use configuration fields that
-  # aren't in the GA google provider. Google resources must explicitly opt into
-  # this provider with `provider = google-beta` or they will not inherit values
-  # appropriately.
-  # https://www.terraform.io/docs/providers/google/guides/provider_versions.html
+provider "google" {
   # This will use "Application Default Credentials". Run `gcloud auth
   # application-default login` to generate them.
   # https://www.terraform.io/docs/providers/google/guides/provider_reference.html#credentials
@@ -180,21 +177,23 @@ provider "google-beta" {
   project = var.gcp_project
 }
 
+provider "google-beta" {
+  # Duplicate settings from the non-beta provider
+  region  = var.gcp_region
+  project = var.gcp_project
+}
+
 # Activate some services which the deployment will require.
 resource "google_project_service" "compute" {
-  provider = google-beta
-  service  = "compute.googleapis.com"
+  service = "compute.googleapis.com"
 }
 
 resource "google_project_service" "container" {
-  provider = google-beta
-  service  = "container.googleapis.com"
+  service = "container.googleapis.com"
 }
 
 resource "google_project_service" "kms" {
-  provider = google-beta
-  project  = var.gcp_project
-  service  = "cloudkms.googleapis.com"
+  service = "cloudkms.googleapis.com"
 }
 
 provider "aws" {
@@ -358,7 +357,6 @@ module "data_share_processors" {
 # to permit writes from this GCP service account, whose email the portal
 # operator discovers in our global manifest.
 resource "google_service_account" "sum_part_bucket_writer" {
-  provider     = google-beta
   account_id   = "prio-${var.environment}-sum-writer"
   display_name = "prio-${var.environment}-sum-part-bucket-writer"
 }
@@ -366,7 +364,6 @@ resource "google_service_account" "sum_part_bucket_writer" {
 # Permit the service accounts for all the data share processors to request Oauth
 # tokens allowing them to impersonate the sum part bucket writer.
 resource "google_service_account_iam_binding" "data_share_processors_to_sum_part_bucket_writer_token_creator" {
-  provider           = google-beta
   service_account_id = google_service_account.sum_part_bucket_writer.name
   role               = "roles/iam.serviceAccountTokenCreator"
   members            = [for v in module.data_share_processors : "serviceAccount:${v.service_account_email}"]

--- a/terraform/modules/account_mapping/account_mapping.tf
+++ b/terraform/modules/account_mapping/account_mapping.tf
@@ -37,7 +37,6 @@ resource "random_string" "account_id" {
 
 # We first create a GCP service account.
 resource "google_service_account" "account" {
-  provider = google-beta
   # The Account ID must be unique across the whole GCP project, and not just the
   # namespace. It must also be fewer than 30 characters, so we can't concatenate
   # environment and PHA name to get something unique. Instead, we generate a
@@ -69,7 +68,6 @@ locals {
 
 # Allows the Kubernetes service account to impersonate the GCP service account.
 resource "google_service_account_iam_binding" "binding" {
-  provider           = google-beta
   service_account_id = google_service_account.account.name
   role               = "roles/iam.workloadIdentityUser"
   members = [

--- a/terraform/modules/cloud_storage_gcp/bucket/bucket.tf
+++ b/terraform/modules/cloud_storage_gcp/bucket/bucket.tf
@@ -19,7 +19,6 @@ variable "bucket_writer" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  provider = google-beta
   name     = var.name
   location = var.gcp_region
   # Force deletion of bucket contents on bucket destroy. Bucket contents would
@@ -44,18 +43,16 @@ resource "google_storage_bucket" "bucket" {
 }
 
 resource "google_storage_bucket_iam_binding" "bucket_writer" {
-  provider = google-beta
-  bucket   = google_storage_bucket.bucket.name
-  role     = "roles/storage.objectCreator"
+  bucket = google_storage_bucket.bucket.name
+  role   = "roles/storage.objectCreator"
   members = [
     "serviceAccount:${var.bucket_writer}"
   ]
 }
 
 resource "google_storage_bucket_iam_binding" "bucket_reader" {
-  provider = google-beta
-  bucket   = google_storage_bucket.bucket.name
-  role     = "roles/storage.objectViewer"
+  bucket = google_storage_bucket.bucket.name
+  role   = "roles/storage.objectViewer"
   members = [
     "serviceAccount:${var.bucket_reader}"
   ]

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -273,7 +273,6 @@ POLICY
 # share processor, enabling us to cryptographically destroy one instance's
 # storage without disrupting any others.
 resource "google_kms_crypto_key" "bucket_encryption" {
-  provider = google-beta
   name     = "${local.resource_prefix}-bucket-encryption-key"
   key_ring = var.kms_keyring
   purpose  = "ENCRYPT_DECRYPT"
@@ -284,9 +283,7 @@ resource "google_kms_crypto_key" "bucket_encryption" {
 
 # Permit the GCS service account to use the KMS key
 # https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_project_service_account
-data "google_storage_project_service_account" "gcs_account" {
-  provider = google-beta
-}
+data "google_storage_project_service_account" "gcs_account" {}
 
 resource "google_kms_crypto_key_iam_binding" "bucket_encryption_key" {
   crypto_key_id = google_kms_crypto_key.bucket_encryption.id

--- a/terraform/modules/fake_server_resources/fake_server_resources.tf
+++ b/terraform/modules/fake_server_resources/fake_server_resources.tf
@@ -22,7 +22,6 @@ variable "ingestors" {
 # sum parts, as well as a correctly formed global manifest advertising that
 # bucket's name.
 resource "google_storage_bucket" "sum_part_output" {
-  provider = google-beta
   name     = "prio-${var.environment}-sum-part-output"
   location = var.gcp_region
   # Force deletion of bucket contents on bucket destroy. Bucket contents would
@@ -49,7 +48,6 @@ resource "google_storage_bucket_iam_binding" "write_sum_parts" {
 # resource's name field must match the portal_server_manifest_base_url value in
 # this env's .tfvars!
 resource "google_storage_bucket_object" "portal_server_global_manifest" {
-  provider     = google-beta
   name         = "portal-server/global-manifest.json"
   bucket       = var.manifest_bucket
   content_type = "application/json"
@@ -66,7 +64,6 @@ resource "google_storage_bucket_object" "portal_server_global_manifest" {
 # public keys that match what the sample_maker will use.
 resource "google_storage_bucket_object" "ingestor_global_manifests" {
   for_each     = var.ingestors
-  provider     = google-beta
   name         = "${each.key}/global-manifest.json"
   bucket       = var.manifest_bucket
   content_type = "application/json"

--- a/terraform/modules/gke/network.tf
+++ b/terraform/modules/gke/network.tf
@@ -51,10 +51,9 @@ module "subnets" {
 }
 
 resource "google_compute_subnetwork" "subnet" {
-  provider = google-beta
-  name     = "${var.resource_prefix}-${var.gcp_region}-instances"
-  region   = var.gcp_region
-  network  = var.network
+  name    = "${var.resource_prefix}-${var.gcp_region}-instances"
+  region  = var.gcp_region
+  network = var.network
 
   ip_cidr_range = module.subnets.network_cidr_blocks["vm_instances"]
   # We'll let other resources automatically add the secondary address ranges
@@ -68,17 +67,15 @@ resource "google_compute_subnetwork" "subnet" {
 # We don't actually use any routing/BGP features of the Router, but one is
 # required in order to configure a NAT gateway below.
 resource "google_compute_router" "router" {
-  provider = google-beta
-  name     = "${var.resource_prefix}-${var.gcp_region}-router"
-  network  = var.network
-  region   = var.gcp_region
+  name    = "${var.resource_prefix}-${var.gcp_region}-router"
+  network = var.network
+  region  = var.gcp_region
 }
 
 # This NAT gateway provides internet access to the Kubernetes cluster
 resource "google_compute_router_nat" "nat" {
-  provider = google-beta
-  name     = "${var.resource_prefix}-${var.gcp_region}-nat"
-  router   = google_compute_router.router.name
+  name   = "${var.resource_prefix}-${var.gcp_region}-nat"
+  router = google_compute_router.router.name
 
   # External IPs will be allocated and released as needed by the NAT according
   # to demand for ports. This can be changed and a pool manually managed if we

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -135,7 +135,6 @@ module "account_mapping" {
 # Allows the Kubernetes service account to request auth tokens for the GCP
 # service account.
 resource "google_service_account_iam_binding" "workflow_manager_token" {
-  provider           = google-beta
   service_account_id = module.account_mapping.google_service_account_name
   role               = "roles/iam.serviceAccountTokenCreator"
   members = [

--- a/terraform/modules/manifest/manifest.tf
+++ b/terraform/modules/manifest/manifest.tf
@@ -20,7 +20,6 @@ data "aws_caller_identity" "current" {}
 # peers can fetch them.
 # https://cloud.google.com/cdn/docs/setting-up-cdn-with-bucket
 resource "google_storage_bucket" "manifests" {
-  provider = google-beta
   name     = "prio-${var.environment}-manifests"
   location = var.gcp_region
   # Force deletion of bucket contents on bucket destroy. Bucket contents would
@@ -50,7 +49,6 @@ resource "google_storage_bucket_iam_binding" "public_read" {
 
 # Puts this data share processor's global manifest into the bucket.
 resource "google_storage_bucket_object" "global_manifest" {
-  provider      = google-beta
   name          = "global-manifest.json"
   bucket        = google_storage_bucket.manifests.name
   content_type  = "application/json"
@@ -70,8 +68,11 @@ locals {
 
 # Now we configure an external HTTPS load balancer backed by the bucket.
 resource "google_compute_managed_ssl_certificate" "manifests" {
+  # Managed SSL certificates are GA but the Terraform provider still restricts
+  # them to the beta variant.
   provider = google-beta
-  name     = "prio-${var.environment}-manifests"
+
+  name = "prio-${var.environment}-manifests"
   managed {
     domains = [local.domain_name]
   }
@@ -80,8 +81,7 @@ resource "google_compute_managed_ssl_certificate" "manifests" {
 # We expect a managed DNS zone in which we can create subdomains for a given
 # env's manifest endpoint to already exist, outside of this Terraform module.
 data "google_dns_managed_zone" "manifests" {
-  provider = google-beta
-  name     = var.managed_dns_zone.name
+  name = var.managed_dns_zone.name
   # The managed zone is not necessarily in the same GCP project as this env, so
   # we pass the project all the way from tfvars to here.
   project = var.managed_dns_zone.gcp_project
@@ -89,7 +89,6 @@ data "google_dns_managed_zone" "manifests" {
 
 # Create an A record from which this env's manifests will be served.
 resource "google_dns_record_set" "manifests" {
-  provider     = google-beta
   project      = var.managed_dns_zone.gcp_project
   name         = local.domain_name
   managed_zone = data.google_dns_managed_zone.manifests.name
@@ -101,32 +100,27 @@ resource "google_dns_record_set" "manifests" {
 # Reserve an external IP address for the load balancer.
 # https://cloud.google.com/cdn/docs/setting-up-cdn-with-bucket#ip-address
 resource "google_compute_global_address" "manifests" {
-  provider = google-beta
-  name     = "prio-${var.environment}-manifests"
+  name = "prio-${var.environment}-manifests"
 }
 
 resource "google_compute_backend_bucket" "manifests" {
-  provider    = google-beta
   name        = "prio-${var.environment}-manifest-backend"
   bucket_name = google_storage_bucket.manifests.name
   enable_cdn  = true
 }
 
 resource "google_compute_url_map" "manifests" {
-  provider        = google-beta
   name            = "prio-${var.environment}-manifests"
   default_service = google_compute_backend_bucket.manifests.id
 }
 
 resource "google_compute_target_https_proxy" "manifests" {
-  provider         = google-beta
   name             = "prio-${var.environment}-manifests"
   url_map          = google_compute_url_map.manifests.id
   ssl_certificates = [google_compute_managed_ssl_certificate.manifests.id]
 }
 
 resource "google_compute_global_forwarding_rule" "manifests" {
-  provider   = google-beta
   name       = "prio-${var.environment}-manifests"
   ip_address = google_compute_global_address.manifests.address
   port_range = "443"

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -8,7 +8,6 @@ locals {
 # A VPC is a global resource in GCP, however, subnets inside it are regional
 # and so are created for each region by the gke module. See gke/network.tf
 resource "google_compute_network" "network" {
-  provider = google-beta
   # Add prefix to support existing multi-env GCP projects
   name = "${var.environment}-network"
   # We will always have to create a subnet for the cluster anyways, so the auto


### PR DESCRIPTION
This adds explicit provider version requirements to the TF file (as recommended by documentation, and also stops TF from nagging every time about how you should add that).

It also changes all GCP resources to use the non-beta google provider. This mean not needing to add `provider = google-beta` to every single resource. For resources requiring the beta provider, that can still be added, and the two providers interoperate seamlessly (no need to `terraform import` or anything of the sort).