### PR TITLE
deal with non-singleton ingestors

### DIFF
--- a/facilitator/src/config.rs
+++ b/facilitator/src/config.rs
@@ -168,6 +168,7 @@ impl<'de> Deserialize<'de> for StoragePath {
 #[derive(Clone, Debug, PartialEq)]
 pub enum ManifestKind {
     IngestorGlobal,
+    IngestorSpecific,
     DataShareProcessorGlobal,
     DataShareProcessorSpecific,
     PortalServerGlobal,
@@ -179,6 +180,7 @@ impl FromStr for ManifestKind {
     fn from_str(s: &str) -> Result<ManifestKind> {
         match s {
             "ingestor-global" => Ok(ManifestKind::IngestorGlobal),
+            "ingestor-specific" => Ok(ManifestKind::IngestorSpecific),
             "data-share-processor-global" => Ok(ManifestKind::DataShareProcessorGlobal),
             "data-share-processor-specific" => Ok(ManifestKind::DataShareProcessorSpecific),
             "portal-global" => Ok(ManifestKind::PortalServerGlobal),
@@ -191,6 +193,7 @@ impl Display for ManifestKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             ManifestKind::IngestorGlobal => write!(f, "ingestor-global"),
+            ManifestKind::IngestorSpecific => write!(f, "ingestor-specific"),
             ManifestKind::DataShareProcessorGlobal => write!(f, "data-share-processor-global"),
             ManifestKind::DataShareProcessorSpecific => write!(f, "data-share-processor-specific"),
             ManifestKind::PortalServerGlobal => write!(f, "portal-global"),

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -183,10 +183,11 @@ struct IngestionServerIdentity {
     gcp_service_account_email: String,
 }
 
-/// Represents an ingestion server's global manifest.
+/// Represents an ingestion server's manifest. This could be a global manifest
+/// or a locality-specific manifest.
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
-pub struct IngestionServerGlobalManifest {
+pub struct IngestionServerManifest {
     /// Format version of the manifest. Versions besides the currently supported
     /// one are rejected.
     format: u32,
@@ -199,19 +200,36 @@ pub struct IngestionServerGlobalManifest {
     batch_signing_public_keys: HashMap<String, BatchSigningPublicKey>,
 }
 
-impl IngestionServerGlobalManifest {
+impl IngestionServerManifest {
     /// Loads the global manifest relative to the provided base path and returns
-    /// it. Returns an error if the manifest could not be loaded or parsed.
-    pub fn from_https(base_path: &str) -> Result<Self> {
-        let manifest_url = format!("{}/global-manifest.json", base_path);
-        IngestionServerGlobalManifest::from_slice(fetch_manifest(&manifest_url)?.as_bytes())
+    /// it. First tries to load a global manifest, then falls back to a specific
+    /// manifest for the specified locality. Returns an error if no manifest
+    /// could be found at either location, or if either was unparseable.
+    pub fn from_https(base_path: &str, locality: Option<&str>) -> Result<Self> {
+        IngestionServerManifest::from_http(base_path, locality, fetch_manifest)
+    }
+
+    fn from_http(
+        base_path: &str,
+        locality: Option<&str>,
+        fetcher: ManifestFetcher,
+    ) -> Result<Self> {
+        match fetcher(&format!("{}/global-manifest.json", base_path)) {
+            Ok(body) => IngestionServerManifest::from_slice(body.as_bytes()),
+            Err(err) => match locality {
+                Some(locality) => IngestionServerManifest::from_slice(
+                    fetcher(&format!("{}/{}-manifest.json", base_path, locality))?.as_bytes(),
+                ),
+                None => Err(err),
+            },
+        }
     }
 
     /// Loads the manifest from the provided String. Returns an error if
     /// the manifest could not be parsed.
     pub fn from_slice(json: &[u8]) -> Result<Self> {
         let manifest: Self =
-            serde_json::from_slice(json).context("failed to decode JSON global manifest")?;
+            serde_json::from_slice(json).context("failed to decode JSON manifest")?;
         if manifest.format != 1 {
             return Err(anyhow!("unsupported manifest format {}", manifest.format));
         }
@@ -296,7 +314,12 @@ impl PortalServerGlobalManifest {
     }
 }
 
-/// Obtains a manifest file from the provided URL
+/// A function that fetches a manifest from the provided URL, returning the
+/// manifest body as a String on success.
+type ManifestFetcher = fn(&str) -> Result<String>;
+
+/// Obtains a manifest file from the provided URL, returning an error if the URL
+/// is not https or if a problem occurs during the transfer.
 fn fetch_manifest(manifest_url: &str) -> Result<String> {
     if !manifest_url.starts_with("https://") {
         return Err(anyhow!("Manifest must be fetched over HTTPS"));
@@ -696,7 +719,7 @@ mod tests {
     }
 
     #[test]
-    fn load_ingestor_global_manifest() {
+    fn load_ingestor_manifest() {
         let manifest_with_aws_identity = r#"
 {
     "format": 1,
@@ -734,8 +757,7 @@ mod tests {
             "#;
 
         let manifest =
-            IngestionServerGlobalManifest::from_slice(manifest_with_aws_identity.as_bytes())
-                .unwrap();
+            IngestionServerManifest::from_slice(manifest_with_aws_identity.as_bytes()).unwrap();
         assert_eq!(
             manifest.server_identity.aws_iam_entity,
             Some("arn:aws:iam::338276578713:role/ingestor-1-role".to_owned())
@@ -753,8 +775,7 @@ mod tests {
         assert!(batch_signing_public_keys.get("nosuchkey").is_none());
 
         let manifest =
-            IngestionServerGlobalManifest::from_slice(manifest_with_gcp_identity.as_bytes())
-                .unwrap();
+            IngestionServerManifest::from_slice(manifest_with_gcp_identity.as_bytes()).unwrap();
         assert_eq!(manifest.server_identity.aws_iam_entity, None);
         assert_eq!(
             manifest.server_identity.gcp_service_account_email,
@@ -824,7 +845,7 @@ mod tests {
         ];
 
         for invalid_manifest in &invalid_manifests {
-            IngestionServerGlobalManifest::from_slice(invalid_manifest.as_bytes()).unwrap_err();
+            IngestionServerManifest::from_slice(invalid_manifest.as_bytes()).unwrap_err();
         }
     }
 
@@ -904,5 +925,135 @@ mod tests {
         for invalid_manifest in &invalid_manifests {
             PortalServerGlobalManifest::from_slice(invalid_manifest.as_bytes()).unwrap_err();
         }
+    }
+
+    use mockito::mock;
+
+    #[test]
+    fn ingestor_global_manifest() {
+        let mocked_get = mock("GET", "/global-manifest.json")
+            .with_status(200)
+            .with_body(r#"
+{
+    "format": 1,
+    "server-identity": {
+        "aws-iam-entity": "arn:aws:iam::338276578713:role/ingestor-1-role",
+        "gcp-service-account-id": "12345678901234567890",
+        "gcp-service-account-email": "foo@bar.com"
+    },
+    "batch-signing-public-keys": {
+        "key-identifier-1": {
+            "public-key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/8OzWHOvmin1KeaiMWFQXfNwS9uZ\n839EjwMff1VB4dnurW38FRP+Z0KxIdvvrPsGMWdPXoTASRAPEHHqpWlTlg==\n-----END PUBLIC KEY-----\n",
+            "expiration": "2021-01-15T18:53:20Z"
+        }
+    }
+}
+            "#)
+            .expect(1)
+            .create();
+
+        IngestionServerManifest::from_http(&mockito::server_url(), None, http::get_url).unwrap();
+
+        mocked_get.assert();
+    }
+
+    #[test]
+    fn unparseable_ingestor_global_manifest() {
+        let mocked_get = mock("GET", "/global-manifest.json")
+            .with_status(200)
+            .with_body("invalid manifest")
+            .expect(1)
+            .create();
+
+        IngestionServerManifest::from_http(&mockito::server_url(), None, http::get_url)
+            .unwrap_err();
+
+        mocked_get.assert();
+    }
+
+    #[test]
+    fn ingestor_specific_manifest_fallback() {
+        let mocked_global_get = mock("GET", "/global-manifest.json")
+            .with_status(404)
+            .expect(1)
+            .create();
+
+        let mocked_specific_get = mock("GET", "/instance-name-manifest.json")
+        .with_status(200)
+        .with_body(r#"
+{
+    "format": 1,
+    "server-identity": {
+        "aws-iam-entity": "arn:aws:iam::338276578713:role/ingestor-1-role",
+        "gcp-service-account-id": "12345678901234567890",
+        "gcp-service-account-email": "foo@bar.com"
+    },
+    "batch-signing-public-keys": {
+        "key-identifier-1": {
+            "public-key": "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/8OzWHOvmin1KeaiMWFQXfNwS9uZ\n839EjwMff1VB4dnurW38FRP+Z0KxIdvvrPsGMWdPXoTASRAPEHHqpWlTlg==\n-----END PUBLIC KEY-----\n",
+            "expiration": "2021-01-15T18:53:20Z"
+        }
+    }
+}
+            "#)
+            .expect(1)
+            .create();
+
+        IngestionServerManifest::from_http(
+            &mockito::server_url(),
+            Some("instance-name"),
+            http::get_url,
+        )
+        .unwrap();
+
+        mocked_global_get.assert();
+        mocked_specific_get.assert();
+    }
+
+    #[test]
+    fn unparseable_ingestor_specific_manifest() {
+        let mocked_global_get = mock("GET", "/global-manifest.json")
+            .with_status(404)
+            .expect(1)
+            .create();
+
+        let mocked_specific_get = mock("GET", "/instance-name-manifest.json")
+            .with_status(200)
+            .with_body("invalid manifest")
+            .expect(1)
+            .create();
+
+        IngestionServerManifest::from_http(
+            &mockito::server_url(),
+            Some("instance-name"),
+            http::get_url,
+        )
+        .unwrap_err();
+
+        mocked_global_get.assert();
+        mocked_specific_get.assert();
+    }
+
+    #[test]
+    fn missing_ingestor_specific_manifest() {
+        let mocked_global_get = mock("GET", "/global-manifest.json")
+            .with_status(404)
+            .expect(1)
+            .create();
+
+        let mocked_specific_get = mock("GET", "/instance-name-manifest.json")
+            .with_status(404)
+            .expect(1)
+            .create();
+
+        IngestionServerManifest::from_http(
+            &mockito::server_url(),
+            Some("instance-name"),
+            http::get_url,
+        )
+        .unwrap_err();
+
+        mocked_global_get.assert();
+        mocked_specific_get.assert();
     }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -205,17 +205,7 @@ module "gke" {
   ]
 }
 
-# For each peer data share processor, we will receive ingestion batches from two
-# ingestion servers. We create a distinct data share processor instance for each
-# (peer, ingestor) pair.
-# First, we fetch the ingestor global manifests, which yields a map of ingestor
-# name => HTTP content.
-data "http" "ingestor_global_manifests" {
-  for_each = var.ingestors
-  url      = "https://${each.value}/global-manifest.json"
-}
-
-# Then we fetch the single global manifest for all the peer share processors.
+# We fetch the single global manifest for all the peer share processors.
 data "http" "peer_share_processor_global_manifest" {
   url = "https://${var.peer_share_processor_manifest_base_url}/global-manifest.json"
 }
@@ -256,8 +246,13 @@ resource "kubernetes_secret" "ingestion_packet_decryption_keys" {
   }
 }
 
-# Now, we take the set product of localities x ingestor names to
-# get the config values for all the data share processors we need to create.
+# We will receive ingestion batches from multiple ingestion servers for each
+# locality. We create a distinct data share processor for each (locality,
+# ingestor) pair. e.g., "us-pa-apple" processes data for Pennsylvanians received
+# from Apple's server, and "us-az-g-enpa" processes data for Arizonans received
+# from Google's server.
+# We take the set product of localities x ingestor names to get the config
+# values for all the data share processors we need to create.
 locals {
   locality_ingestor_pairs = {
     for pair in setproduct(toset(var.localities), keys(var.ingestors)) :
@@ -265,7 +260,6 @@ locals {
       ingestor                                = pair[1]
       kubernetes_namespace                    = kubernetes_namespace.namespaces[pair[0]].metadata[0].name
       packet_decryption_key_kubernetes_secret = kubernetes_secret.ingestion_packet_decryption_keys[pair[0]].metadata[0].name
-      ingestor_gcp_service_account_email      = jsondecode(data.http.ingestor_global_manifests[pair[1]].body).server-identity.gcp-service-account-id
       ingestor_manifest_base_url              = var.ingestors[pair[1]]
     }
   }
@@ -302,7 +296,6 @@ module "data_share_processors" {
   manifest_bucket                                = module.manifest.bucket
   kubernetes_namespace                           = each.value.kubernetes_namespace
   certificate_domain                             = "${var.environment}.certificates.${var.manifest_domain}"
-  ingestor_gcp_service_account_email             = each.value.ingestor_gcp_service_account_email
   ingestor_manifest_base_url                     = each.value.ingestor_manifest_base_url
   packet_decryption_key_kubernetes_secret        = each.value.packet_decryption_key_kubernetes_secret
   peer_share_processor_aws_account_id            = local.peer_share_processor_server_identity.aws-account-id

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -46,10 +46,6 @@ variable "ingestor_manifest_base_url" {
   type = string
 }
 
-variable "ingestor_gcp_service_account_email" {
-  type = string
-}
-
 variable "peer_share_processor_aws_account_id" {
   type = string
 }
@@ -96,7 +92,44 @@ variable "kms_keyring" {
   type = string
 }
 
+# We need the ingestion server's manifest so that we can discover the GCP
+# service account it will use to upload ingestion batches. Some ingestors
+# (Apple) are singletons, and advertise a single global manifest which contains
+# the single GCP SA used by that server to send ingestion batches. Others
+# (Google) operate a distinct instance per locality, using a distinct GCP SA for
+# each. We first check for a global manifest, and fall back to a specific
+# manifest if it cannot be found. A Terraform data.http block would cause the
+# entire plan or apply to fail if the specified URL can't be loaded, so we use
+# this data.external block to check the HTTP status.
+data "external" "global_manifest_http_status" {
+  program = [
+    "curl",
+    "--silent",
+    "--output", "/dev/null",
+    # Terraform insists that the output of the program be JSON so that it can be
+    # parsed into a Terraform map.
+    "--write-out", "{ \"http_code\": \"%%{http_code}\" }",
+    "https://${var.ingestor_manifest_base_url}/global-manifest.json"
+  ]
+}
+
+data "http" "ingestor_global_manifest" {
+  count = local.ingestor_global_manifest_exists ? 1 : 0
+  url   = "https://${var.ingestor_manifest_base_url}/global-manifest.json"
+}
+
+data "http" "ingestor_specific_manifest" {
+  count = local.ingestor_global_manifest_exists ? 0 : 1
+  url   = "https://${var.ingestor_manifest_base_url}/${var.data_share_processor_name}-manifest.json"
+}
+
 locals {
+  ingestor_global_manifest_exists = data.external.global_manifest_http_status.result.http_code == "200"
+  ingestor_gcp_service_account_email = local.ingestor_global_manifest_exists ? (
+    jsondecode(data.http.ingestor_global_manifest[0].body).server-identity.gcp-service-account-email
+    ) : (
+    jsondecode(data.http.ingestor_specific_manifest[0].body).server-identity.gcp-service-account-email
+  )
   resource_prefix         = "prio-${var.environment}-${var.data_share_processor_name}"
   is_env_with_ingestor    = lookup(var.test_peer_environment, "env_with_ingestor", "") == var.environment
   is_env_without_ingestor = lookup(var.test_peer_environment, "env_without_ingestor", "") == var.environment
@@ -159,7 +192,7 @@ locals {
     {
       # Ingestors always act as a GCP service account, to which we grant write
       # permissions.
-      ingestion_bucket_writer = var.ingestor_gcp_service_account_email
+      ingestion_bucket_writer = local.ingestor_gcp_service_account_email
       # No special auth is needed to read from the ingestion bucket in GCS
       ingestion_bucket_reader = module.kubernetes.service_account_email
       # The identity that GKE jobs should assume or impersonate to access the


### PR DESCRIPTION
Google will have one ingestion server per locality, using distinct batch
signing keys and GCP service accounts. We now will check for the
ingestor global manifest, and if it cannot be found, will fall back to a
specific manifest at a path "<instance-name>-manifest.json", i.e.,
"us-co-g-enpa-manifest.json". If there is a global manifest but it is
not a valid manifest, we still error out.

resolves #107