### PR TITLE
facilitator: retry AWS S3 requests

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -323,7 +323,7 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
 
 fn main() -> Result<(), anyhow::Error> {
     use log::info;
-    env_logger::init();
+    env_logger::builder().format_timestamp_millis().init();
 
     let args: Vec<String> = std::env::args().collect();
     info!(


### PR DESCRIPTION
During Narnia testing, we encountered cases where we failed to upload
validation batches to S3 because the ingestion batches were _just_ big
enough so that roughly ten seconds would elapse between the
CreateMultipartUpload call and the first UploadPart. We had previously
set the Hyper connection pool idle timeout to 10 seconds to avoid having
S3 close connections on us after 20 seconds, so sometimes we would lose
the race with Hyper and have uploads spuriously fail. Our fix is to
detect the case where the txn fails due to the connection getting closed
(which manifests as RusotoError::HttpDispatch) and try up to two more
times in that case. We don't retry in the face of other errors to avoid
abusing Amazon API endpoints.

Example of the error encountered:

HttpDispatch(HttpDispatchError { message: "Error during dispatch: connection closed before message completed" })