### PR TITLE
terraform: typo in bucket_access_identities

### DIFF
--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -207,7 +207,7 @@ locals {
       remote_validation_bucket_writer = aws_iam_role.bucket_role.arn
       # We permit the peer's GCP service account to write their validations to
       # our bucket
-      local_peer_validation_bucket_writer = var.peer_share_processor_gcp_service_account_email
+      peer_validation_bucket_writer = var.peer_share_processor_gcp_service_account_email
       # No special auth is needed to read from the validation bucket in GCS
       peer_validation_bucket_reader = module.kubernetes.service_account_email
       # The identity that GKE jobs should assume or impersonate to access the


### PR DESCRIPTION
I noticed a bug in the construction of the bucket_access_identities map
in the case where we're not creating a paired test env.