### PR TITLE
 Gracefully drop mismatching packets during batch aggregation

### DIFF
--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -103,6 +103,7 @@ impl<T: Write, W: Write> Write for SidecarWriter<T, W> {
 
 /// This struct represents a key used by this data share processor to sign
 /// batches (ingestion, validation or sum part).
+#[derive(Debug)]
 pub struct BatchSigningKey {
     /// The ECDSA P256 key pair to use when signing batches.
     pub key: EcdsaKeyPair,

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -146,7 +146,10 @@ pub fn generate_ingestion_sample(
                         };
 
                         if drop_packet(count, drop_nth_pha_packet) {
-                            info!("dropping packet #{} from PHA ingestion batch", count);
+                            info!(
+                                "dropping packet #{} {} from PHA ingestion batch",
+                                count, packet_uuid
+                            );
                             pha_dropped_packets.push(packet_uuid);
                         } else {
                             pha_packet.write(&mut pha_packet_writer)?;
@@ -163,8 +166,8 @@ pub fn generate_ingestion_sample(
 
                         if drop_packet(count, drop_nth_facilitator_packet) {
                             info!(
-                                "dropping packet #{} from facilitator ingestion batch",
-                                count
+                                "dropping packet #{} {} from facilitator ingestion batch",
+                                count, packet_uuid
                             );
                             facilitator_dropped_packets.push(packet_uuid);
                         } else {

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -1,11 +1,11 @@
 use crate::{
     batch::{Batch, BatchWriter},
     idl::{IngestionDataSharePacket, IngestionHeader, Packet},
-    transport::Transport,
-    BatchSigningKey,
+    transport::SignableTransport,
 };
 use anyhow::{anyhow, Context, Result};
 use chrono::NaiveDateTime;
+use log::info;
 use prio::{
     client::Client,
     encrypt::{PrivateKey, PublicKey},
@@ -15,22 +15,52 @@ use prio::{
 use rand::{thread_rng, Rng};
 use uuid::Uuid;
 
+/// Configuration for output from sample generation.
+#[derive(Debug)]
+pub struct SampleOutput {
+    /// SignableTransport to which to write the ingestion batch
+    pub transport: SignableTransport,
+    /// Encryption key with which to encrypt ingestion shares
+    pub packet_encryption_key: PrivateKey,
+    /// If this is Some(n), then generate_ingestion_sample will omit every nth
+    /// packet generated from the ingestion batch sent to this output. This is
+    /// intended for testing.
+    pub drop_nth_packet: Option<usize>,
+}
+
+#[derive(Debug)]
+pub struct ReferenceSum {
+    /// The reference sum, covering those packets whose shares appear in both
+    /// PHA and facilitator ingestion batches.
+    pub sum: Vec<Field>,
+    /// The number of contributiosn that went into the reference sum.
+    pub contributions: usize,
+    /// UUIDs of PHA packets that were dropped
+    pub pha_dropped_packets: Vec<Uuid>,
+    /// UUIDs of facilitator packets that were dropped
+    pub facilitator_dropped_packets: Vec<Uuid>,
+}
+
+fn drop_packet(count: usize, drop_nth_packet: Option<usize>) -> bool {
+    match drop_nth_packet {
+        Some(nth) if count % nth == 0 => true,
+        _ => false,
+    }
+}
+
 #[allow(clippy::too_many_arguments)] // Grandfathered in
 pub fn generate_ingestion_sample(
-    pha_transport: &mut dyn Transport,
-    facilitator_transport: &mut dyn Transport,
     batch_uuid: &Uuid,
     aggregation_name: &str,
     date: &NaiveDateTime,
-    pha_key: &PrivateKey,
-    facilitator_key: &PrivateKey,
-    ingestor_signing_key: &BatchSigningKey,
     dim: i32,
     packet_count: usize,
     epsilon: f64,
     batch_start_time: i64,
     batch_end_time: i64,
-) -> Result<Vec<Field>> {
+    pha_output: &mut SampleOutput,
+    facilitator_output: &mut SampleOutput,
+) -> Result<ReferenceSum> {
     if dim <= 0 {
         return Err(anyhow!("dimension must be an integer greater than zero"));
     }
@@ -38,7 +68,7 @@ pub fn generate_ingestion_sample(
     let mut pha_ingestion_batch: BatchWriter<'_, IngestionHeader, IngestionDataSharePacket> =
         BatchWriter::new(
             Batch::new_ingestion(aggregation_name, batch_uuid, date),
-            pha_transport,
+            &mut *pha_output.transport.transport,
         );
     let mut facilitator_ingestion_batch: BatchWriter<
         '_,
@@ -46,7 +76,7 @@ pub fn generate_ingestion_sample(
         IngestionDataSharePacket,
     > = BatchWriter::new(
         Batch::new_ingestion(aggregation_name, batch_uuid, date),
-        facilitator_transport,
+        &mut *facilitator_output.transport.transport,
     );
 
     // Generate random data packets and write into data share packets
@@ -56,12 +86,23 @@ pub fn generate_ingestion_sample(
         // usize is probably bigger than i32 and we have checked that dim is
         // positive so this is safe
         dim as usize,
-        PublicKey::from(pha_key),
-        PublicKey::from(facilitator_key),
+        PublicKey::from(&pha_output.packet_encryption_key),
+        PublicKey::from(&facilitator_output.packet_encryption_key),
     )
     .context("failed to create client (bad dimension parameter?)")?;
 
+    // Borrowing distinct parts of a struct like the SampleOutputs works, but
+    // not under closures: https://github.com/rust-lang/rust/issues/53488
+    // The workaround is to borrow or copy fields outside the closure.
+    let key_copy = pha_output.packet_encryption_key.clone();
+    let facilitator_batch_signing_key_ref = &facilitator_output.transport.batch_signing_key;
+    let drop_nth_pha_packet = pha_output.drop_nth_packet;
+    let drop_nth_facilitator_packet = facilitator_output.drop_nth_packet;
+
     let mut reference_sum = vec![Field::from(0); dim as usize];
+    let mut contributions = 0;
+    let mut pha_dropped_packets = Vec::new();
+    let mut facilitator_dropped_packets = Vec::new();
 
     // We nest the closures here to get both packet writers in one scope
     let pha_packet_file_digest =
@@ -69,16 +110,23 @@ pub fn generate_ingestion_sample(
             let facilitator_packet_file_digest = facilitator_ingestion_batch.packet_file_writer(
                 |mut facilitator_packet_writer| {
                     // We need an instance of a libprio server to pick an r_pit.
-                    let fake_server = Server::new(dim as usize, true, pha_key.clone());
+                    let fake_server = Server::new(dim as usize, true, key_copy);
 
-                    for _ in 0..packet_count {
+                    for count in 0..packet_count {
                         // Generate random bit vector
                         let data = (0..dim)
                             .map(|_| Field::from(thread_rng.gen_range(0, 2)))
                             .collect::<Vec<Field>>();
 
-                        for (r, d) in reference_sum.iter_mut().zip(data.iter()) {
-                            *r += *d
+                        // If we are dropping the packet from either output, do
+                        // not include it in the reference sum
+                        if !drop_packet(count, drop_nth_pha_packet)
+                            && !drop_packet(count, drop_nth_facilitator_packet)
+                        {
+                            for (r, d) in reference_sum.iter_mut().zip(data.iter()) {
+                                *r += *d
+                            }
+                            contributions += 1;
                         }
 
                         let (pha_share, facilitator_share) = client
@@ -97,7 +145,12 @@ pub fn generate_ingestion_sample(
                             device_nonce: None,
                         };
 
-                        pha_packet.write(&mut pha_packet_writer)?;
+                        if drop_packet(count, drop_nth_pha_packet) {
+                            info!("dropping packet #{} from PHA ingestion batch", count);
+                            pha_dropped_packets.push(packet_uuid);
+                        } else {
+                            pha_packet.write(&mut pha_packet_writer)?;
+                        }
 
                         let facilitator_packet = IngestionDataSharePacket {
                             uuid: packet_uuid,
@@ -108,7 +161,15 @@ pub fn generate_ingestion_sample(
                             device_nonce: None,
                         };
 
-                        facilitator_packet.write(&mut facilitator_packet_writer)?;
+                        if drop_packet(count, drop_nth_facilitator_packet) {
+                            info!(
+                                "dropping packet #{} from facilitator ingestion batch",
+                                count
+                            );
+                            facilitator_dropped_packets.push(packet_uuid);
+                        } else {
+                            facilitator_packet.write(&mut facilitator_packet_writer)?;
+                        }
                     }
                     Ok(())
                 },
@@ -127,12 +188,12 @@ pub fn generate_ingestion_sample(
                     batch_end_time,
                     packet_file_digest: facilitator_packet_file_digest.as_ref().to_vec(),
                 },
-                &ingestor_signing_key.key,
+                &facilitator_batch_signing_key_ref.key,
             )?;
 
             facilitator_ingestion_batch.put_signature(
                 &facilitator_header_signature,
-                &ingestor_signing_key.identifier,
+                &facilitator_batch_signing_key_ref.identifier,
             )
         })?;
 
@@ -149,11 +210,19 @@ pub fn generate_ingestion_sample(
             batch_end_time,
             packet_file_digest: pha_packet_file_digest.as_ref().to_vec(),
         },
-        &ingestor_signing_key.key,
+        &pha_output.transport.batch_signing_key.key,
     )?;
-    pha_ingestion_batch.put_signature(&pha_header_signature, &ingestor_signing_key.identifier)?;
+    pha_ingestion_batch.put_signature(
+        &pha_header_signature,
+        &pha_output.transport.batch_signing_key.identifier,
+    )?;
     println!("done");
-    Ok(reference_sum)
+    Ok(ReferenceSum {
+        sum: reference_sum,
+        contributions,
+        pha_dropped_packets,
+        facilitator_dropped_packets,
+    })
 }
 
 #[cfg(test)]
@@ -165,7 +234,7 @@ mod tests {
             default_ingestor_private_key, DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY,
             DEFAULT_PHA_ECIES_PRIVATE_KEY,
         },
-        transport::LocalFileTransport,
+        transport::{LocalFileTransport, Transport},
     };
     use chrono::NaiveDate;
 
@@ -174,29 +243,48 @@ mod tests {
     fn write_sample() {
         let tempdir = tempfile::TempDir::new().unwrap();
         let batch_uuid = Uuid::new_v4();
-        let mut pha_transport = LocalFileTransport::new(tempdir.path().to_path_buf().join("pha"));
-        let mut facilitator_transport =
-            LocalFileTransport::new(tempdir.path().to_path_buf().join("pha"));
+
+        let mut pha_output = SampleOutput {
+            transport: SignableTransport {
+                transport: Box::new(LocalFileTransport::new(
+                    tempdir.path().to_path_buf().join("pha"),
+                )),
+                batch_signing_key: default_ingestor_private_key(),
+            },
+            packet_encryption_key: PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap(),
+            drop_nth_packet: None,
+        };
+        let mut facilitator_output = SampleOutput {
+            transport: SignableTransport {
+                transport: Box::new(LocalFileTransport::new(
+                    tempdir.path().to_path_buf().join("facilitator"),
+                )),
+                batch_signing_key: default_ingestor_private_key(),
+            },
+            packet_encryption_key: PrivateKey::from_base64(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY)
+                .unwrap(),
+            drop_nth_packet: None,
+        };
 
         let res = generate_ingestion_sample(
-            &mut pha_transport,
-            &mut facilitator_transport,
             &batch_uuid,
             "fake-aggregation",
             &NaiveDate::from_ymd(2009, 2, 13).and_hms(23, 31, 0),
-            &PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap(),
-            &PrivateKey::from_base64(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY).unwrap(),
-            &default_ingestor_private_key(),
             10,
             10,
             0.11,
             100,
             100,
+            &mut pha_output,
+            &mut facilitator_output,
         );
         assert!(res.is_ok(), "error writing sample data {:?}", res.err());
         let expected_path = format!("fake-aggregation/2009/02/13/23/31/{}.batch", batch_uuid);
 
-        let transports = &mut [pha_transport, facilitator_transport];
+        let transports = &mut [
+            LocalFileTransport::new(tempdir.path().to_path_buf().join("pha")),
+            LocalFileTransport::new(tempdir.path().to_path_buf().join("facilitator")),
+        ];
         for transport in transports {
             let reader = transport.get(&expected_path);
             assert!(res.is_ok(), "error reading header back {:?}", res.err());

--- a/facilitator/src/test_utils.rs
+++ b/facilitator/src/test_utils.rs
@@ -1,4 +1,5 @@
 use crate::BatchSigningKey;
+use log::LevelFilter;
 use ring::signature::{
     EcdsaKeyPair, KeyPair, UnparsedPublicKey, ECDSA_P256_SHA256_ASN1,
     ECDSA_P256_SHA256_ASN1_SIGNING,
@@ -111,4 +112,15 @@ pub fn default_pha_signing_public_key() -> UnparsedPublicKey<Vec<u8>> {
             .as_ref()
             .to_vec(),
     )
+}
+
+// Disappointingly there's no builtin way to run a setup or init function
+// before all tests in Rust, so per env_logger's advice we call init() at
+// the top of any test we want logs from.
+// https://docs.rs/env_logger/0.8.2/env_logger/#capturing-logs-in-tests
+pub fn log_init() {
+    let _ = env_logger::builder()
+        .filter_level(LevelFilter::Info)
+        .is_test(true)
+        .try_init();
 }

--- a/facilitator/src/transport.rs
+++ b/facilitator/src/transport.rs
@@ -4,9 +4,11 @@ mod s3;
 
 use crate::{manifest::BatchSigningPublicKeys, BatchSigningKey};
 use anyhow::Result;
+use derivative::Derivative;
 use prio::encrypt::PrivateKey;
 use std::{
     boxed::Box,
+    fmt::Debug,
     io::{Read, Write},
 };
 
@@ -16,16 +18,21 @@ pub use s3::S3Transport;
 
 /// A transport along with the public keys that can be used to verify signatures
 /// on the batches read from the transport.
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct VerifiableTransport {
     pub transport: Box<dyn Transport>,
+    #[derivative(Debug = "ignore")]
     pub batch_signing_public_keys: BatchSigningPublicKeys,
 }
 
+#[derive(Debug)]
 pub struct VerifiableAndDecryptableTransport {
     pub transport: VerifiableTransport,
     pub packet_decryption_keys: Vec<PrivateKey>,
 }
 
+#[derive(Debug)]
 pub struct SignableTransport {
     pub transport: Box<dyn Transport>,
     pub batch_signing_key: BatchSigningKey,
@@ -57,7 +64,7 @@ impl<T: TransportWriter + ?Sized> TransportWriter for Box<T> {
 
 /// A transport moves object in and out of some data store, such as a cloud
 /// object store like Amazon S3, or local files, or buffers in memory.
-pub trait Transport {
+pub trait Transport: Debug {
     /// Returns an std::io::Read instance from which the contents of the value
     /// of the provided key may be read.
     fn get(&mut self, key: &str) -> Result<Box<dyn Read>>;

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -138,7 +138,7 @@ impl OauthTokenProvider {
         };
         Ok(OauthTokenProvider {
             default_service_account_key_file: key_file,
-            account_to_impersonate: account_to_impersonate,
+            account_to_impersonate,
             default_account_token: None,
             impersonated_account_token: None,
         })
@@ -312,6 +312,7 @@ impl OauthTokenProvider {
 /// struct can either use the default service account from the metadata service,
 /// or can impersonate another GCP service account if one is provided to
 /// GCSTransport::new.
+#[derive(Debug)]
 pub struct GCSTransport {
     path: GCSPath,
     oauth_token_provider: OauthTokenProvider,

--- a/facilitator/src/transport/local.rs
+++ b/facilitator/src/transport/local.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 /// A transport implementation backed by the local filesystem.
+#[derive(Debug)]
 pub struct LocalFileTransport {
     directory: PathBuf,
 }

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -84,10 +84,13 @@ where
 }
 
 /// Implementation of Transport that reads and writes objects from Amazon S3.
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct S3Transport {
     path: S3Path,
     iam_role: Option<String>,
     // client_provider allows injection of mock S3Client for testing purposes
+    #[derivative(Debug = "ignore")]
     client_provider: ClientProvider,
 }
 

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -465,24 +465,13 @@ impl TransportWriter for MultipartUploadWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use log::LevelFilter;
+    use crate::test_utils::log_init;
     use rusoto_core::{request::HttpDispatchError, signature::SignedRequest};
     use rusoto_mock::{
         MockCredentialsProvider, MockRequestDispatcher, MultipleMockRequestDispatcher,
     };
     use rusoto_s3::CreateMultipartUploadError;
     use std::io::Read;
-
-    // Disappointingly there's no builtin way to run a setup or init function
-    // before all tests in Rust, so per env_logger's advice we call init() at
-    // the top of any test we want logs from.
-    // https://docs.rs/env_logger/0.8.2/env_logger/#capturing-logs-in-tests
-    fn init() {
-        let _ = env_logger::builder()
-            .filter_level(LevelFilter::Info)
-            .is_test(true)
-            .try_init();
-    }
 
     // Rusoto provides us the ability to create mock clients and play canned
     // responses to API requests. Besides that, we want to verify that we get
@@ -585,7 +574,7 @@ mod tests {
 
     #[test]
     fn multipart_upload_create_fails() {
-        init();
+        log_init();
         let err = MultipartUploadWriter::new(
             String::from(TEST_BUCKET),
             String::from(TEST_KEY),
@@ -607,7 +596,7 @@ mod tests {
 
     #[test]
     fn multipart_upload_create_no_upload_id() {
-        init();
+        log_init();
         // Response body format from
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html
         MultipartUploadWriter::new(
@@ -633,7 +622,7 @@ mod tests {
 
     #[test]
     fn multipart_upload() {
-        init();
+        log_init();
         // Response body format from
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html
         let mut writer =
@@ -736,7 +725,7 @@ mod tests {
 
     #[test]
     fn roundtrip_s3_transport() {
-        init();
+        log_init();
         let s3_path = S3Path {
             region: Region::UsWest2,
             bucket: TEST_BUCKET.into(),

--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -2,26 +2,39 @@ use chrono::NaiveDateTime;
 use facilitator::{
     aggregation::BatchAggregator,
     batch::{Batch, BatchReader},
-    idl::{IngestionDataSharePacket, SumPart},
+    idl::{InvalidPacket, Packet, SumPart},
     intake::BatchIntaker,
     sample::{generate_ingestion_sample, SampleOutput},
     test_utils::{
         default_facilitator_signing_private_key, default_facilitator_signing_public_key,
         default_ingestor_private_key, default_ingestor_public_key, default_pha_signing_private_key,
-        default_pha_signing_public_key, DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY,
+        default_pha_signing_public_key, log_init, DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY,
         DEFAULT_PHA_ECIES_PRIVATE_KEY,
     },
     transport::{
         LocalFileTransport, SignableTransport, VerifiableAndDecryptableTransport,
         VerifiableTransport,
     },
+    Error,
 };
 use prio::{encrypt::PrivateKey, util::reconstruct_shares};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 #[test]
 fn end_to_end() {
+    end_to_end_test(None, None)
+}
+
+#[test]
+fn inconsistent_ingestion_batches() {
+    // Have sample generation drop every third and every fourth packet from the
+    // PHA and facilitator ingestion batches, respectively.
+    end_to_end_test(Some(3), Some(4))
+}
+
+fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usize>) {
+    log_init();
     let pha_tempdir = tempfile::TempDir::new().unwrap();
     let pha_copy_tempdir = tempfile::TempDir::new().unwrap();
     let facilitator_tempdir = tempfile::TempDir::new().unwrap();
@@ -48,7 +61,7 @@ fn end_to_end() {
             batch_signing_key: default_ingestor_private_key(),
         },
         packet_encryption_key: PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap(),
-        drop_nth_packet: None,
+        drop_nth_packet: drop_nth_pha,
     };
 
     let mut facilitator_output = SampleOutput {
@@ -60,7 +73,7 @@ fn end_to_end() {
         },
         packet_encryption_key: PrivateKey::from_base64(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY)
             .unwrap(),
-        drop_nth_packet: None,
+        drop_nth_packet: drop_nth_facilitator,
     };
 
     let batch_1_reference_sum = generate_ingestion_sample(
@@ -112,7 +125,7 @@ fn end_to_end() {
             transport: Box::new(LocalFileTransport::new(
                 facilitator_tempdir.path().to_path_buf(),
             )),
-            batch_signing_public_keys: ingestor_pub_keys.clone(),
+            batch_signing_public_keys: ingestor_pub_keys,
         },
         packet_decryption_keys: vec![
             PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap(),
@@ -263,7 +276,7 @@ fn end_to_end() {
     .generate_sum_part(&batch_ids_and_dates)
     .unwrap();
 
-    let mut pha_aggregation_batch_reader: BatchReader<'_, SumPart, IngestionDataSharePacket> =
+    let mut pha_aggregation_batch_reader: BatchReader<'_, SumPart, InvalidPacket> =
         BatchReader::new(
             Batch::new_sum(
                 instance_name,
@@ -275,45 +288,36 @@ fn end_to_end() {
             &mut *pha_aggregation_transport.transport,
         );
     let pha_sum_part = pha_aggregation_batch_reader.header(&pha_pub_keys).unwrap();
-    assert_eq!(pha_sum_part.total_individual_clients, 30);
+    assert_eq!(
+        pha_sum_part.total_individual_clients,
+        batch_1_reference_sum.contributions as i64 + batch_2_reference_sum.contributions as i64
+    );
     let pha_sum_fields = pha_sum_part.sum().unwrap();
 
-    let pha_invalid_packet_reader = pha_aggregation_batch_reader.packet_file_reader(&pha_sum_part);
-    assert!(
-        pha_invalid_packet_reader.is_err(),
-        "should get no invalid packet reader when all packets were OK"
-    );
-
-    let mut facilitator_aggregation_batch_reader: BatchReader<
-        '_,
-        SumPart,
-        IngestionDataSharePacket,
-    > = BatchReader::new(
-        Batch::new_sum(
-            instance_name,
-            &aggregation_name,
-            &start_date,
-            &end_date,
-            false,
-        ),
-        &mut *facilitator_aggregation_transport.transport,
-    );
+    let mut facilitator_aggregation_batch_reader: BatchReader<'_, SumPart, InvalidPacket> =
+        BatchReader::new(
+            Batch::new_sum(
+                instance_name,
+                &aggregation_name,
+                &start_date,
+                &end_date,
+                false,
+            ),
+            &mut *facilitator_aggregation_transport.transport,
+        );
     let facilitator_sum_part = facilitator_aggregation_batch_reader
         .header(&facilitator_pub_keys)
         .unwrap();
-    assert_eq!(facilitator_sum_part.total_individual_clients, 30);
-    let facilitator_sum_fields = facilitator_sum_part.sum().unwrap();
-
-    let facilitator_invalid_packet_reader =
-        facilitator_aggregation_batch_reader.packet_file_reader(&facilitator_sum_part);
-    assert!(
-        facilitator_invalid_packet_reader.is_err(),
-        "should get no invalid packet reader when all packets were OK"
+    assert_eq!(
+        facilitator_sum_part.total_individual_clients,
+        batch_1_reference_sum.contributions as i64 + batch_2_reference_sum.contributions as i64
     );
+    let facilitator_sum_fields = facilitator_sum_part.sum().unwrap();
 
     let reconstructed = reconstruct_shares(&facilitator_sum_fields, &pha_sum_fields).unwrap();
 
-    let reference_sum = reconstruct_shares(&batch_1_reference_sum, &batch_2_reference_sum).unwrap();
+    let reference_sum =
+        reconstruct_shares(&batch_1_reference_sum.sum, &batch_2_reference_sum.sum).unwrap();
     assert_eq!(
         reconstructed, reference_sum,
         "reconstructed shares do not match original data.\npha sum: {:?}\n
@@ -327,4 +331,47 @@ fn end_to_end() {
         \tfacilitator clients: {}\n\tpha clients: {}",
         facilitator_sum_part.total_individual_clients, pha_sum_part.total_individual_clients
     );
+
+    check_invalid_packets(
+        &batch_1_reference_sum.facilitator_dropped_packets,
+        &batch_2_reference_sum.facilitator_dropped_packets,
+        &mut pha_aggregation_batch_reader,
+        &pha_sum_part,
+    );
+
+    check_invalid_packets(
+        &batch_1_reference_sum.pha_dropped_packets,
+        &batch_2_reference_sum.pha_dropped_packets,
+        &mut facilitator_aggregation_batch_reader,
+        &facilitator_sum_part,
+    );
+}
+
+fn check_invalid_packets(
+    peer_dropped_packets_1: &[Uuid],
+    peer_dropped_packets_2: &[Uuid],
+    batch_reader: &mut BatchReader<'_, SumPart, InvalidPacket>,
+    sum_part_header: &SumPart,
+) {
+    if !peer_dropped_packets_1.is_empty() || !peer_dropped_packets_2.is_empty() {
+        // Check the packets that were marked invalid by either data share
+        // processor against the ones dropped from the other's ingestion batches
+        let mut dropped_packets = HashSet::new();
+        for dropped in peer_dropped_packets_1 {
+            dropped_packets.insert(dropped);
+        }
+        for dropped in peer_dropped_packets_2 {
+            dropped_packets.insert(dropped);
+        }
+        let mut invalid_packet_reader = batch_reader.packet_file_reader(sum_part_header).unwrap();
+        loop {
+            match InvalidPacket::read(&mut invalid_packet_reader) {
+                Ok(packet) => assert!(dropped_packets.contains(&packet.uuid)),
+                Err(Error::EofError) => break,
+                Err(err) => assert!(false, "error reading invalid packet {}", err),
+            }
+        }
+    } else {
+        assert!(batch_reader.packet_file_reader(sum_part_header).is_err());
+    }
 }

--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -4,7 +4,7 @@ use facilitator::{
     batch::{Batch, BatchReader},
     idl::{IngestionDataSharePacket, SumPart},
     intake::BatchIntaker,
-    sample::generate_ingestion_sample,
+    sample::{generate_ingestion_sample, SampleOutput},
     test_utils::{
         default_facilitator_signing_private_key, default_facilitator_signing_public_key,
         default_ingestor_private_key, default_ingestor_public_key, default_pha_signing_private_key,
@@ -42,37 +42,52 @@ fn end_to_end() {
         default_ingestor_public_key(),
     );
 
+    let mut pha_output = SampleOutput {
+        transport: SignableTransport {
+            transport: Box::new(LocalFileTransport::new(pha_tempdir.path().to_path_buf())),
+            batch_signing_key: default_ingestor_private_key(),
+        },
+        packet_encryption_key: PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap(),
+        drop_nth_packet: None,
+    };
+
+    let mut facilitator_output = SampleOutput {
+        transport: SignableTransport {
+            transport: Box::new(LocalFileTransport::new(
+                facilitator_tempdir.path().to_path_buf(),
+            )),
+            batch_signing_key: default_ingestor_private_key(),
+        },
+        packet_encryption_key: PrivateKey::from_base64(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY)
+            .unwrap(),
+        drop_nth_packet: None,
+    };
+
     let batch_1_reference_sum = generate_ingestion_sample(
-        &mut LocalFileTransport::new(pha_tempdir.path().to_path_buf()),
-        &mut LocalFileTransport::new(facilitator_tempdir.path().to_path_buf()),
         &batch_1_uuid,
         &aggregation_name,
         &date,
-        &PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap(),
-        &PrivateKey::from_base64(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY).unwrap(),
-        &default_ingestor_private_key(),
         10,
         16,
         0.11,
         100,
         100,
+        &mut pha_output,
+        &mut facilitator_output,
     )
     .unwrap();
 
     let batch_2_reference_sum = generate_ingestion_sample(
-        &mut LocalFileTransport::new(pha_tempdir.path().to_path_buf()),
-        &mut LocalFileTransport::new(facilitator_tempdir.path().to_path_buf()),
         &batch_2_uuid,
         &aggregation_name,
         &date,
-        &PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap(),
-        &PrivateKey::from_base64(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY).unwrap(),
-        &default_ingestor_private_key(),
         10,
         14,
         0.11,
         100,
         100,
+        &mut pha_output,
+        &mut facilitator_output,
     )
     .unwrap();
 


### PR DESCRIPTION
This PR resolves #118. The first commit enhances the sample generation so it can drop every nth packet from the PHA batch and every mth from the facilitator batch, as well as recording expected sums and dropped packet UUIDs. The second commit reimplements aggregation such that we no longer discard whole batches if any individual validation packet is missing.