### PR TITLE
s3: try WebIdentityProvider before instance metadata

### DIFF
--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -920,10 +920,10 @@ async fn chain_provider_credentials(
     if let Ok(creds) = provider.container_provider.credentials().await {
         return Ok(creds);
     }
-    if let Ok(creds) = provider.instance_metadata_provider.credentials().await {
+    if let Ok(creds) = provider.webidp_provider.credentials().await {
         return Ok(creds);
     }
-    if let Ok(creds) = provider.webidp_provider.credentials().await {
+    if let Ok(creds) = provider.instance_metadata_provider.credentials().await {
         return Ok(creds);
     }
     Err(CredentialsError::new(


### PR DESCRIPTION
We observed that every single S3 transaction being done by NCI's
facilitator containers was taking at least 30 seconds, which led me to
suspect a timeout somewhere. I think I was able to reproduce the problem
by moving my ~/.aws/ directory aside and running facilitator locally.
Sure enough, it takes 30 seconds for Rusoto to give up on connecting to
169.254.169.254 (the AWS instance metadata endpoint). The crude fix here
is to check the web identity provider before instance metadata.