### PR TITLE
Add the env for United States production

### DIFF
--- a/terraform/modules/gke/gke.tf
+++ b/terraform/modules/gke/gke.tf
@@ -84,10 +84,10 @@ resource "google_container_node_pool" "worker_nodes" {
   name               = "${var.resource_prefix}-node-pool"
   location           = var.gcp_region
   cluster            = google_container_cluster.cluster.name
-  initial_node_count = 1
+  initial_node_count = 3
   autoscaling {
-    min_node_count = 1
-    max_node_count = 3
+    min_node_count = 2
+    max_node_count = 5
   }
   node_config {
     disk_size_gb = "25"

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -1,0 +1,21 @@
+environment     = "prod-us"
+gcp_region      = "us-west1"
+gcp_project     = "prio-prod-us"
+machine_type    = "e2-standard-8"
+localities      = []
+aws_region      = "us-west-1"
+manifest_domain = "isrg-prio.org"
+managed_dns_zone = {
+  name        = "manifests"
+  gcp_project = "prio-bringup-290620"
+}
+ingestors = {
+  apple  = "exposure-notification.apple.com/manifest"
+  g-enpa = "www.gstatic.com/prio-manifests"
+}
+peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+is_first                               = false
+use_aws                                = false
+aggregation_period                     = "8h"
+aggregation_grace_period               = "4h"


### PR DESCRIPTION
 - add prod-us.tfvars, with correct production manifest URLs for MITRE,
   Apple and NCI. Google hasn't yet confirmed their manifest endpoint
   but we can bootstrap the env without the final value in place yet.
   Per prior agreement, we set aggregation period to 8h and grace period
   to 4h. We don't yet have any localities configured.
 - make the worker node pools bigger in hopes of not running out of
   compute capacity.