### PR TITLE
terraform: pin prod-us to 0.5.0 images

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -120,6 +120,21 @@ variable "pushgateway" {
   description = "The location of a pushgateway in host:port form. Set to prometheus-pushgateway.default:9091 to enable metrics"
 }
 
+variable "container_registry" {
+  type    = string
+  default = "letsencrypt"
+}
+
+variable "workflow_manager_version" {
+  type    = string
+  default = "latest"
+}
+
+variable "facilitator_version" {
+  type    = string
+  default = "latest"
+}
+
 terraform {
   backend "gcs" {}
 
@@ -350,6 +365,9 @@ module "data_share_processors" {
   aggregation_grace_period                       = var.aggregation_grace_period
   kms_keyring                                    = module.gke.kms_keyring
   pushgateway                                    = var.pushgateway
+  workflow_manager_version                       = var.workflow_manager_version
+  facilitator_version                            = var.facilitator_version
+  container_registry                             = var.container_registry
 }
 
 # The portal owns two sum part buckets (one for each data share processor) and

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -96,6 +96,18 @@ variable "pushgateway" {
   type = string
 }
 
+variable "container_registry" {
+  type = string
+}
+
+variable "workflow_manager_version" {
+  type = string
+}
+
+variable "facilitator_version" {
+  type = string
+}
+
 # We need the ingestion server's manifest so that we can discover the GCP
 # service account it will use to upload ingestion batches. Some ingestors
 # (Apple) are singletons, and advertise a single global manifest which contains
@@ -404,6 +416,9 @@ module "kubernetes" {
   aggregation_period                      = var.aggregation_period
   aggregation_grace_period                = var.aggregation_grace_period
   pushgateway                             = var.pushgateway
+  container_registry                      = var.container_registry
+  workflow_manager_version                = var.workflow_manager_version
+  facilitator_version                     = var.facilitator_version
 }
 
 output "data_share_processor_name" {

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -11,8 +11,7 @@ variable "environment" {
 }
 
 variable "container_registry" {
-  type    = string
-  default = "letsencrypt"
+  type = string
 }
 
 variable "workflow_manager_image" {
@@ -21,8 +20,7 @@ variable "workflow_manager_image" {
 }
 
 variable "workflow_manager_version" {
-  type    = string
-  default = "latest"
+  type = string
 }
 
 variable "facilitator_image" {
@@ -31,8 +29,7 @@ variable "facilitator_image" {
 }
 
 variable "facilitator_version" {
-  type    = string
-  default = "latest"
+  type = string
 }
 
 variable "gcp_project" {

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -19,3 +19,5 @@ is_first                               = false
 use_aws                                = false
 aggregation_period                     = "8h"
 aggregation_grace_period               = "4h"
+workflow_manager_version               = "0.5.0"
+facilitator_version                    = "0.5.0"


### PR DESCRIPTION
We pin the prod-us deployment of the application to version 0.5.0 of
`prio-workflow-manager` and `prio-facilitator`. This commit also plumbs
arguments for container image versions and image repository all the way
from kubernetes.tf to main.tf.