### PR TITLE
facilitator: jsha review feedback from #265

### DIFF
--- a/facilitator/src/aggregation.rs
+++ b/facilitator/src/aggregation.rs
@@ -226,10 +226,10 @@ impl<'a> BatchAggregator<'a> {
         // iterate over the ingestion packets. For each ingestion packet, if we
         // have the corresponding validation packets and the proofs are good, we
         // accumulate. Otherwise we drop the packet and move on.
-        let peer_validation_packets = validation_packet_map(
+        let peer_validation_packets: HashMap<Uuid, ValidationPacket> = validation_packet_map(
             &mut peer_validation_batch.packet_file_reader(&peer_validation_header)?,
         )?;
-        let own_validation_packets = validation_packet_map(
+        let own_validation_packets: HashMap<Uuid, ValidationPacket> = validation_packet_map(
             &mut own_validation_batch.packet_file_reader(&own_validation_header)?,
         )?;
 
@@ -255,22 +255,24 @@ impl<'a> BatchAggregator<'a> {
 
             // Make sure we have own validation and peer validation packets
             // matching the ingestion packet.
-            let peer_validation_packet = match get_validation_packet(
+            let peer_validation_packet = get_validation_packet(
                 &ingestion_packet.uuid,
                 &peer_validation_packets,
                 "peer",
                 invalid_uuids,
-            ) {
+            );
+            let peer_validation_packet: &ValidationPacket = match peer_validation_packet {
                 Some(p) => p,
                 None => continue,
             };
 
-            let own_validation_packet = match get_validation_packet(
+            let own_validation_packet = get_validation_packet(
                 &ingestion_packet.uuid,
                 &own_validation_packets,
                 "own",
                 invalid_uuids,
-            ) {
+            );
+            let own_validation_packet: &ValidationPacket = match own_validation_packet {
                 Some(p) => p,
                 None => continue,
             };

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -645,17 +645,18 @@ fn main() -> Result<(), anyhow::Error> {
 fn generate_sample(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
     let peer_output_path = StoragePath::from_str(sub_matches.value_of("peer-output").unwrap())?;
     let peer_identity = sub_matches.value_of("peer-identity");
+    let packet_encryption_key = PrivateKey::from_base64(
+        sub_matches
+            .value_of("facilitator-ecies-private-key")
+            .unwrap(),
+    )
+    .unwrap();
     let mut peer_transport = SampleOutput {
         transport: SignableTransport {
             transport: transport_for_path(peer_output_path, peer_identity, sub_matches)?,
             batch_signing_key: batch_signing_key_from_arg(sub_matches)?,
         },
-        packet_encryption_key: PrivateKey::from_base64(
-            sub_matches
-                .value_of("facilitator-ecies-private-key")
-                .unwrap(),
-        )
-        .unwrap(),
+        packet_encryption_key,
         drop_nth_packet: None,
     };
 

--- a/facilitator/src/idl.rs
+++ b/facilitator/src/idl.rs
@@ -7,7 +7,6 @@ use avro_rs::{
 use prio::{finite_field::Field, server::VerificationMessage};
 use serde::{Deserialize, Serialize};
 use std::{
-    cmp::{Ord, Ordering, PartialOrd},
     convert::TryFrom,
     io::{Read, Write},
     num::TryFromIntError,
@@ -48,6 +47,8 @@ pub trait Packet: Sized {
     /// schema returned from Packet::schema.
     fn write<W: Write>(&self, writer: &mut Writer<W>) -> Result<(), Error>;
 
+    /// Implementations of Packet should return their Avro schemas as strings
+    /// from this method.
     fn schema_raw() -> &'static str;
 
     /// Creates an avro_rs::Schema from the packet schema. For constructing the
@@ -513,18 +514,6 @@ impl Packet for IngestionDataSharePacket {
     }
 }
 
-impl Ord for IngestionDataSharePacket {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.uuid.cmp(&other.uuid)
-    }
-}
-
-impl PartialOrd for IngestionDataSharePacket {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
 /// The header on a Prio validation (sometimes referred to as verification)
 /// batch.
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -753,18 +742,6 @@ impl Packet for ValidationPacket {
         })?;
 
         Ok(())
-    }
-}
-
-impl Ord for ValidationPacket {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.uuid.cmp(&other.uuid)
-    }
-}
-
-impl PartialOrd for ValidationPacket {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
     }
 }
 
@@ -1021,17 +998,6 @@ impl Header for SumPart {
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct InvalidPacket {
     pub uuid: Uuid,
-}
-impl Ord for InvalidPacket {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.uuid.cmp(&other.uuid)
-    }
-}
-
-impl PartialOrd for InvalidPacket {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
 }
 
 impl Packet for InvalidPacket {

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -33,7 +33,7 @@ pub struct ReferenceSum {
     /// The reference sum, covering those packets whose shares appear in both
     /// PHA and facilitator ingestion batches.
     pub sum: Vec<Field>,
-    /// The number of contributiosn that went into the reference sum.
+    /// The number of contributions that went into the reference sum.
     pub contributions: usize,
     /// UUIDs of PHA packets that were dropped
     pub pha_dropped_packets: Vec<Uuid>,


### PR DESCRIPTION
We short circuited jsha's review on #265 in order to accelerate release
of production code to our partners. This PR addresses those comments.

 - use type annotations to make code more obvious
 - remove nested expressions in `match` statements
 - remove unused `Ord` and `PartialOrd` implementations from idl.rs
 - fix typo in sample.rs