### PR TITLE
prod-us: add ta-ta locality for testing

### DIFF
--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -2,7 +2,7 @@ environment     = "prod-us"
 gcp_region      = "us-west1"
 gcp_project     = "prio-prod-us"
 machine_type    = "e2-standard-8"
-localities      = ["aq-aq"]
+localities      = ["aq-aq", "ta-ta"]
 aws_region      = "us-west-1"
 manifest_domain = "isrg-prio.org"
 managed_dns_zone = {
@@ -13,7 +13,7 @@ ingestors = {
   apple  = "exposure-notification.apple.com/manifest"
   g-enpa = "storage.googleapis.com/prio-manifests"
 }
-peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+peer_share_processor_manifest_base_url = "test-en-analytics.cancer.gov"
 portal_server_manifest_base_url        = "manifest.enpa-pha.io"
 is_first                               = false
 use_aws                                = false


### PR DESCRIPTION
Adds a new test/fake locality for integration testing with peer
production and pre-production deloyments. Updates peer manifest endpoint
to point at NCI test deployment.