### PR TITLE
workflow-manager: request 1.0 CPU for facilitator

### DIFF
--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -375,11 +375,11 @@ func launchAggregationJobs(ctx context.Context, batchesByID aggregationMap, inte
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										corev1.ResourceMemory: resource.MustParse("500Mi"),
-										corev1.ResourceCPU:    resource.MustParse("0.5"),
+										corev1.ResourceCPU:    resource.MustParse("1.0"),
 									},
 									Limits: corev1.ResourceList{
 										corev1.ResourceMemory: resource.MustParse("550Mi"),
-										corev1.ResourceCPU:    resource.MustParse("0.7"),
+										corev1.ResourceCPU:    resource.MustParse("1.5"),
 									},
 								},
 								EnvFrom: []corev1.EnvFromSource{
@@ -517,11 +517,11 @@ func startIntakeJob(
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("500Mi"),
-									corev1.ResourceCPU:    resource.MustParse("0.5"),
+									corev1.ResourceCPU:    resource.MustParse("1.0"),
 								},
 								Limits: corev1.ResourceList{
 									corev1.ResourceMemory: resource.MustParse("550Mi"),
-									corev1.ResourceCPU:    resource.MustParse("0.7"),
+									corev1.ResourceCPU:    resource.MustParse("1.5"),
 								},
 							},
 							EnvFrom: []corev1.EnvFromSource{


### PR DESCRIPTION
facilitator jobs, whether intake-batch or aggregate, are
single-threaded, and during testing with large batches (> 100 MB
ingestion batches), I observed that `intake-batch` jobs quickly reach
~0.7 CPUs (which is the maximum currently allowed by the jobs
workflow-manager creates) and stay there until they are done. By raising
the CPU request/limit from 0.5/0.7 to 1.0/1.5, we should achieve a
speedup of 0.3 / 0.7 = ~43%. Individual jobs are not going to use any
more than 1.0 CPU because there's no multithreading within an individual
`facilitator` job, so the 1.5 maximum is just a healthy margin of error.
I haven't observed extraordinary memory usage, meaning the 500 MB memory
request we currently have will suffice, provided we don't see ingestion
batches larger than that.