### PR TITLE
workflow-manager: set ImagePullPolicy=IfNotPresent

### DIFF
--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -370,7 +370,7 @@ func launchAggregationJobs(ctx context.Context, batchesByID aggregationMap, inte
 								Args:            args,
 								Name:            "facile-container",
 								Image:           *facilitatorImage,
-								ImagePullPolicy: "Always",
+								ImagePullPolicy: "IfNotPresent",
 								VolumeMounts:    volumeMounts,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
@@ -512,7 +512,7 @@ func startIntakeJob(
 							Args:            args,
 							Name:            "facile-container",
 							Image:           *facilitatorImage,
-							ImagePullPolicy: "Always",
+							ImagePullPolicy: "IfNotPresent",
 							VolumeMounts:    volumeMounts,
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{


### PR DESCRIPTION
During development and testing, we forced the ImagePullPolicy to Always
in an effort to avoid the risk of stale images. In production, we don't
need to fetch an image from DockerHub every single time we spawn the
facilitator.