### PR TITLE
terraform: force worker pool size to 12

### DIFF
--- a/terraform/modules/gke/gke.tf
+++ b/terraform/modules/gke/gke.tf
@@ -84,9 +84,9 @@ resource "google_container_node_pool" "worker_nodes" {
   name               = "${var.resource_prefix}-node-pool"
   location           = var.gcp_region
   cluster            = google_container_cluster.cluster.name
-  initial_node_count = 3
+  initial_node_count = 4
   autoscaling {
-    min_node_count = 2
+    min_node_count = 4
     max_node_count = 5
   }
   node_config {


### PR DESCRIPTION
We encountered a problem where GCP implicitly limits clusters with fewer
than 10 nodes to 10,000 jobs per namespace, a limit we ran up against
once we started receiving batches from Connecticut. This change forces
the node pool to create at least 4 VMs in each of three zones, bumping
our cluster size high enough that our job limit is now 50,000.