### PR TITLE
publisher/subscriber task model

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -610,6 +610,7 @@ dependencies = [
  "rusoto_core",
  "rusoto_mock",
  "rusoto_s3",
+ "rusoto_sqs",
  "rusoto_sts",
  "serde",
  "serde_json",
@@ -1817,6 +1818,20 @@ dependencies = [
  "sha2",
  "time 0.2.22",
  "tokio",
+]
+
+[[package]]
+name = "rusoto_sqs"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcd228a1b4ce3f3a40541ee8cef526ff3702b58a4779fb05c31e739174efda5e"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core",
+ "serde_urlencoded",
+ "xml-rs",
 ]
 
 [[package]]

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -25,6 +25,7 @@ regex = "1.4"
 ring = { version = "0.16.15", features = ["std"] }
 rusoto_core = { version = "0.45.0", default_features = false, features = ["rustls"] }
 rusoto_s3 = { version = "0.45.0", default_features = false, features = ["rustls"] }
+rusoto_sqs = { version = "0.45.0", default_features = false, features = ["rustls"] }
 rusoto_sts = { version = "0.45.0", default_features = false, features = ["rustls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -1,0 +1,160 @@
+use anyhow::Result;
+use rusoto_core::{
+    credential::EnvironmentProvider,
+    credential::{
+        AutoRefreshingProvider, AwsCredentials, ContainerProvider, CredentialsError,
+        InstanceMetadataProvider, ProfileProvider, ProvideAwsCredentials,
+    },
+};
+use rusoto_sts::WebIdentityProvider;
+use std::{boxed::Box, time::Duration};
+use tokio::runtime::{Builder, Runtime};
+
+/// Constructs a basic runtime suitable for use in our single threaded context
+pub(crate) fn basic_runtime() -> Result<Runtime> {
+    Ok(Builder::new().basic_scheduler().enable_all().build()?)
+}
+
+// ------------- Everything below here was copied from rusoto/credential/src/lib.rs in the rusoto repo ---------------------------
+// -------------------------------------------------------------------------------------------------------------------------------
+
+/// Wraps a `ChainProvider` in an `AutoRefreshingProvider`.
+///
+/// The underlying `ChainProvider` checks multiple sources for credentials, and the `AutoRefreshingProvider`
+/// refreshes the credentials automatically when they expire.
+///
+/// # Warning
+///
+/// This provider allows the [`credential_process`][credential_process] option in the AWS config
+/// file (`~/.aws/config`), a method of sourcing credentials from an external process. This can
+/// potentially be dangerous, so proceed with caution. Other credential providers should be
+/// preferred if at all possible. If using this option, you should make sure that the config file
+/// is as locked down as possible using security best practices for your operating system.
+///
+/// [credential_process]: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
+#[derive(Clone)]
+pub struct DefaultCredentialsProvider(AutoRefreshingProvider<ChainProvider>);
+
+impl DefaultCredentialsProvider {
+    /// Creates a new thread-safe `DefaultCredentialsProvider`.
+    pub fn new() -> Result<DefaultCredentialsProvider, CredentialsError> {
+        let inner = AutoRefreshingProvider::new(ChainProvider::new())?;
+        Ok(DefaultCredentialsProvider(inner))
+    }
+}
+
+#[async_trait]
+impl ProvideAwsCredentials for DefaultCredentialsProvider {
+    async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+        self.0.credentials().await
+    }
+}
+
+/// Provides AWS credentials from multiple possible sources using a priority order.
+///
+/// The following sources are checked in order for credentials when calling `credentials`:
+///
+/// 1. Environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
+/// 2. `credential_process` command in the AWS config file, usually located at `~/.aws/config`.
+/// 3. AWS credentials file. Usually located at `~/.aws/credentials`.
+/// 4. IAM instance profile. Will only work if running on an EC2 instance with an instance profile/role.
+///
+/// If the sources are exhausted without finding credentials, an error is returned.
+///
+/// The provider has a default timeout of 30 seconds. While it should work well for most setups,
+/// you can change the timeout using the `set_timeout` method.
+///
+/// # Example
+///
+///
+/// # Warning
+///
+/// This provider allows the [`credential_process`][credential_process] option in the AWS config
+/// file (`~/.aws/config`), a method of sourcing credentials from an external process. This can
+/// potentially be dangerous, so proceed with caution. Other credential providers should be
+/// preferred if at all possible. If using this option, you should make sure that the config file
+/// is as locked down as possible using security best practices for your operating system.
+///
+/// [credential_process]: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
+#[derive(Debug, Clone)]
+pub struct ChainProvider {
+    environment_provider: EnvironmentProvider,
+    instance_metadata_provider: InstanceMetadataProvider,
+    container_provider: ContainerProvider,
+    profile_provider: Option<ProfileProvider>,
+    webidp_provider: WebIdentityProvider,
+}
+
+impl ChainProvider {
+    /// Set the timeout on the provider to the specified duration.
+    #[allow(dead_code)]
+    pub fn set_timeout(&mut self, duration: Duration) {
+        self.instance_metadata_provider.set_timeout(duration);
+        self.container_provider.set_timeout(duration);
+    }
+}
+
+async fn chain_provider_credentials(
+    provider: ChainProvider,
+) -> Result<AwsCredentials, CredentialsError> {
+    if let Ok(creds) = provider.environment_provider.credentials().await {
+        return Ok(creds);
+    }
+    if let Some(ref profile_provider) = provider.profile_provider {
+        if let Ok(creds) = profile_provider.credentials().await {
+            return Ok(creds);
+        }
+    }
+    if let Ok(creds) = provider.container_provider.credentials().await {
+        return Ok(creds);
+    }
+    if let Ok(creds) = provider.webidp_provider.credentials().await {
+        return Ok(creds);
+    }
+    if let Ok(creds) = provider.instance_metadata_provider.credentials().await {
+        return Ok(creds);
+    }
+    Err(CredentialsError::new(
+        "Couldn't find AWS credentials in environment, credentials file, or IAM role.",
+    ))
+}
+
+use async_trait::async_trait;
+
+#[async_trait]
+impl ProvideAwsCredentials for ChainProvider {
+    async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
+        chain_provider_credentials(self.clone()).await
+    }
+}
+
+impl ChainProvider {
+    /// Create a new `ChainProvider` using a `ProfileProvider` with the default settings.
+    pub fn new() -> ChainProvider {
+        ChainProvider {
+            environment_provider: EnvironmentProvider::default(),
+            profile_provider: ProfileProvider::new().ok(),
+            instance_metadata_provider: InstanceMetadataProvider::new(),
+            container_provider: ContainerProvider::new(),
+            webidp_provider: WebIdentityProvider::from_k8s_env(),
+        }
+    }
+
+    /// Create a new `ChainProvider` using the provided `ProfileProvider`.
+    #[allow(dead_code)]
+    pub fn with_profile_provider(profile_provider: ProfileProvider) -> ChainProvider {
+        ChainProvider {
+            environment_provider: EnvironmentProvider::default(),
+            profile_provider: Some(profile_provider),
+            instance_metadata_provider: InstanceMetadataProvider::new(),
+            container_provider: ContainerProvider::new(),
+            webidp_provider: WebIdentityProvider::from_k8s_env(),
+        }
+    }
+}
+
+impl Default for ChainProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -835,7 +835,7 @@ fn intake_batch_worker(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
 
     loop {
         if let Some(task_handle) = queue.dequeue()? {
-            info!("dequeued task: {:?}", task_handle);
+            info!("dequeued task: {}", task_handle);
             intake_started.inc();
             let result = intake_batch(
                 &task_handle.task.aggregation_id,
@@ -850,7 +850,7 @@ fn intake_batch_worker(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
                     queue.acknowledge_task(task_handle)?;
                 }
                 Err(err) => {
-                    error!("error while processing task {:?}: {:?}", task_handle, err);
+                    error!("error while processing task {}: {:?}", task_handle, err);
                     intake_finished.with_label_values(&["error"]).inc();
                     queue.nacknowledge_task(task_handle)?;
                 }
@@ -1040,7 +1040,7 @@ fn aggregate_worker(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
 
     loop {
         if let Some(task_handle) = queue.dequeue()? {
-            info!("dequeued task: {:?}", task_handle);
+            info!("dequeued task: {}", task_handle);
             aggregation_started.inc();
 
             let batches: Vec<(&str, &str)> = task_handle
@@ -1063,7 +1063,7 @@ fn aggregate_worker(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
                     queue.acknowledge_task(task_handle)?;
                 }
                 Err(err) => {
-                    error!("error while processing task {:?}: {:?}", task_handle, err);
+                    error!("error while processing task {}: {:?}", task_handle, err);
                     aggregation_finished.with_label_values(&["error"]).inc();
                     queue.nacknowledge_task(task_handle)?;
                 }

--- a/facilitator/src/config.rs
+++ b/facilitator/src/config.rs
@@ -201,6 +201,33 @@ impl Display for ManifestKind {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum TaskQueueKind {
+    GcpPubSub,
+    AwsSqs,
+}
+
+impl FromStr for TaskQueueKind {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<TaskQueueKind> {
+        match s {
+            "gcp-pubsub" => Ok(TaskQueueKind::GcpPubSub),
+            "aws-sqs" => Ok(TaskQueueKind::AwsSqs),
+            _ => Err(anyhow!(format!("unrecognized task queue kind {}", s))),
+        }
+    }
+}
+
+impl Display for TaskQueueKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            TaskQueueKind::GcpPubSub => write!(f, "gcp-pubsub"),
+            TaskQueueKind::AwsSqs => write!(f, "aws-sqs"),
+        }
+    }
+}
+
 /// Represents a simple duration specified in terms of whole hours, minutes and seconds. Mostly used
 /// for user input in flags or config files. For computations it should usually be converted to a
 /// [`chrono::Duration`] using [`to_duration`](DayDuration::to_duration).

--- a/facilitator/src/gcp_oauth.rs
+++ b/facilitator/src/gcp_oauth.rs
@@ -1,0 +1,296 @@
+use anyhow::{anyhow, Context, Result};
+use chrono::{prelude::Utc, DateTime, Duration};
+use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
+use serde::{Deserialize, Serialize};
+use std::{fmt, io::Read};
+use ureq::Response;
+
+use crate::http::{send_json_request, JsonRequestParameters};
+
+const DEFAULT_OAUTH_TOKEN_URL: &str =
+    "http://metadata.google.internal:80/computeMetadata/v1/instance/service-accounts/default/token";
+
+/// Represents the claims encoded into JWTs when using a service account key
+/// file to authenticate as the default GCP service account.
+#[derive(Debug, Serialize, Deserialize)]
+struct Claims {
+    iss: String,
+    scope: String,
+    aud: String,
+    iat: i64,
+    exp: i64,
+}
+
+/// A wrapper around an Oauth token and its expiration date.
+struct OauthToken {
+    token: String,
+    expiration: DateTime<Utc>,
+}
+
+impl OauthToken {
+    /// Returns true if the token is expired.
+    fn expired(&self) -> bool {
+        Utc::now() >= self.expiration
+    }
+}
+
+/// Represents the response from a GET request to the GKE metadata service's
+/// service account token endpoint, or to oauth2.googleapis.com.token.
+/// https://developers.google.com/identity/protocols/oauth2/service-account
+#[derive(Deserialize, PartialEq)]
+struct OauthTokenResponse {
+    access_token: String,
+    expires_in: i64,
+    token_type: String,
+}
+
+/// Represents the response from a POST request to the GCP IAM service's
+/// generateAccessToken endpoint.
+/// https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
+#[derive(Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct GenerateAccessTokenResponse {
+    access_token: String,
+    expire_time: DateTime<Utc>,
+}
+
+/// This is the subset of a GCP service account key file that we need to parse
+/// to construct a signed JWT.
+#[derive(Debug, Deserialize, PartialEq)]
+struct ServiceAccountKeyFile {
+    /// The PEM-armored base64 encoding of the ASN.1 encoding of the account's
+    /// RSA private key.
+    private_key: String,
+    /// The private key ID.
+    private_key_id: String,
+    /// The service account's email address.
+    client_email: String,
+    /// The URL from which OAuth tokens should be requested.
+    token_uri: String,
+}
+
+/// OauthTokenProvider manages a default service account Oauth token (i.e. the
+/// one for a GCP service account mapped to a Kubernetes service account, or the
+/// one found in a JSON key file) and an Oauth token used to impersonate another
+/// service account.
+pub(crate) struct OauthTokenProvider {
+    /// The Oauth scope for which tokens should be requested.
+    scope: String,
+    /// The parsed key file for the default GCP service account. If present,
+    /// this will be used to obtain the default account OAuth token. If absent,
+    /// the GKE metadata service is consulted.
+    default_service_account_key_file: Option<ServiceAccountKeyFile>,
+    /// Holds the service account email to impersonate, if one was provided to
+    /// OauthTokenProvider::new.
+    account_to_impersonate: Option<String>,
+    /// This field is None after instantiation and is Some after the first
+    /// successful request for a token for the default service account, though
+    /// the contained token may be expired.
+    default_account_token: Option<OauthToken>,
+    /// This field is None after instantiation and is Some after the first
+    /// successful request for a token for the impersonated service account,
+    /// though the contained token may be expired. This will always be None if
+    /// account_to_impersonate is None.
+    impersonated_account_token: Option<OauthToken>,
+}
+
+impl fmt::Debug for OauthTokenProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OauthTokenProvider")
+            .field("account_to_impersonate", &self.account_to_impersonate)
+            .field(
+                "default_service_account_key_file",
+                &self
+                    .default_service_account_key_file
+                    .as_ref()
+                    .map(|key_file| key_file.client_email.clone()),
+            )
+            .field(
+                "default_account_token",
+                &self.default_account_token.as_ref().map(|_| "redacted"),
+            )
+            .field(
+                "impersonated_account_token",
+                &self.default_account_token.as_ref().map(|_| "redacted"),
+            )
+            .finish()
+    }
+}
+
+impl OauthTokenProvider {
+    /// Creates a token provider which can impersonate the specified service
+    /// account.
+    pub(crate) fn new(
+        scope: &str,
+        account_to_impersonate: Option<String>,
+        key_file_reader: Option<Box<dyn Read>>,
+    ) -> Result<OauthTokenProvider> {
+        let key_file: Option<ServiceAccountKeyFile> = match key_file_reader {
+            Some(reader) => {
+                serde_json::from_reader(reader).context("failed to deserialize JSON key file")?
+            }
+            None => None,
+        };
+        Ok(OauthTokenProvider {
+            scope: scope.to_owned(),
+            default_service_account_key_file: key_file,
+            account_to_impersonate,
+            default_account_token: None,
+            impersonated_account_token: None,
+        })
+    }
+
+    /// Returns the Oauth token to use with GCP API in an Authorization header,
+    /// fetching it or renewing it if necessary. If a service account to
+    /// impersonate was provided, the default service account is used to
+    /// authenticate to the GCP IAM API to retrieve an Oauth token. If no
+    /// impersonation is taking place, provides the default service account
+    /// Oauth token.
+    pub(crate) fn ensure_oauth_token(&mut self) -> Result<String> {
+        match self.account_to_impersonate {
+            Some(_) => self.ensure_impersonated_service_account_oauth_token(),
+            None => self.ensure_default_account_token(),
+        }
+    }
+
+    /// Returns the current OAuth token for the default service account, if it
+    /// is valid. Otherwise obtains and returns a new one.
+    /// The returned value is an owned reference because the token owned by this
+    /// struct could change while the caller is still holding the returned token
+    fn ensure_default_account_token(&mut self) -> Result<String> {
+        if let Some(token) = &self.default_account_token {
+            if !token.expired() {
+                return Ok(token.token.clone());
+            }
+        }
+
+        let http_response = match &self.default_service_account_key_file {
+            Some(key_file) => self.account_token_with_key_file(&key_file)?,
+            None => OauthTokenProvider::account_token_from_gke_metadata_service(),
+        };
+        if http_response.error() {
+            return Err(anyhow!(
+                "failed to query GKE metadata service: {:?}",
+                http_response
+            ));
+        }
+
+        let response = http_response
+            .into_json_deserialize::<OauthTokenResponse>()
+            .context("failed to deserialize response from GKE metadata service")?;
+
+        if response.token_type != "Bearer" {
+            return Err(anyhow!("unexpected token type {}", response.token_type));
+        }
+
+        self.default_account_token = Some(OauthToken {
+            token: response.access_token.clone(),
+            expiration: Utc::now() + Duration::seconds(response.expires_in),
+        });
+
+        Ok(response.access_token)
+    }
+
+    /// Fetches default account token from GKE metadata service. Returns the
+    /// ureq::Response, whose body will be an OauthTokenResponse if the HTTP
+    /// call was successful, but may be an error.
+    fn account_token_from_gke_metadata_service() -> Response {
+        ureq::get(DEFAULT_OAUTH_TOKEN_URL)
+            .set("Metadata-Flavor", "Google")
+            // By default, ureq will wait forever to connect or read.
+            .timeout_connect(10_000) // ten seconds
+            .timeout_read(10_000) // ten seconds
+            .call()
+    }
+
+    /// Fetches the default account token from Google OAuth API using a JWT
+    /// constructed from the parameters in the provided key file. If the JWT is
+    /// successfully constructed, returns the ureq::Response whose body will be
+    /// an OauthTokenResponse if the HTTP call was successful, but may be an
+    /// error.
+    fn account_token_with_key_file(&self, key_file: &ServiceAccountKeyFile) -> Result<Response> {
+        // We construct the JWT per Google documentation:
+        // https://developers.google.com/identity/protocols/oauth2/service-account#authorizingrequests
+        let mut header = Header::new(Algorithm::RS256);
+        header.kid = Some(key_file.private_key_id.to_owned());
+
+        // The iat and exp fields in a JWT are in seconds since UNIX epoch.
+        let now = Utc::now().timestamp();
+        let claims = Claims {
+            iss: key_file.client_email.to_owned(),
+            scope: self.scope.to_owned(),
+            aud: key_file.token_uri.to_owned(),
+            iat: now,
+            exp: now + 3600, // token expires in one hour
+        };
+
+        let encoding_key = EncodingKey::from_rsa_pem(key_file.private_key.as_bytes())
+            .context("failed to parse PEM RSA key")?;
+
+        let token =
+            encode(&header, &claims, &encoding_key).context("failed to construct and sign JWT")?;
+
+        let request_body = format!(
+            "grant_type={}&assertion={}",
+            urlencoding::encode("urn:ietf:params:oauth:grant-type:jwt-bearer"),
+            token
+        );
+
+        Ok(ureq::post(&key_file.token_uri)
+            .set("Content-Type", "application/x-www-form-urlencoded")
+            // By default, ureq will wait forever to connect or read.
+            .timeout_connect(10_000) // ten seconds
+            .timeout_read(10_000) // ten seconds
+            .send_string(&request_body))
+    }
+
+    /// Returns the current OAuth token for the impersonated service account, if
+    /// it is valid. Otherwise obtains and returns a new one.
+    fn ensure_impersonated_service_account_oauth_token(&mut self) -> Result<String> {
+        if self.account_to_impersonate.is_none() {
+            return Err(anyhow!("no service account to impersonate was provided"));
+        }
+
+        if let Some(token) = &self.impersonated_account_token {
+            if !token.expired() {
+                return Ok(token.token.clone());
+            }
+        }
+
+        let service_account_to_impersonate = self.account_to_impersonate.clone().unwrap();
+        // API reference:
+        // https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
+        let request_url = format!("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}:generateAccessToken",
+            service_account_to_impersonate);
+        let request = ureq::post(&request_url)
+            .set(
+                "Authorization",
+                &format!("Bearer {}", self.ensure_default_account_token()?),
+            )
+            .build();
+        let http_response = send_json_request(JsonRequestParameters {
+            request: request,
+            body: ureq::json!({
+                "scope": [self.scope]
+            }),
+            ..Default::default()
+        })?;
+        if http_response.error() {
+            return Err(anyhow!(
+                "failed to get Oauth token to impersonate service account {}: {:?}",
+                service_account_to_impersonate,
+                http_response
+            ));
+        }
+
+        let response = http_response
+            .into_json_deserialize::<GenerateAccessTokenResponse>()
+            .context("failed to deserialize response from IAM API")?;
+        self.impersonated_account_token = Some(OauthToken {
+            token: response.access_token.clone(),
+            expiration: response.expire_time,
+        });
+
+        Ok(response.access_token)
+    }
+}

--- a/facilitator/src/http.rs
+++ b/facilitator/src/http.rs
@@ -1,4 +1,47 @@
 use anyhow::{anyhow, Context, Result};
+use ureq::{Request, Response, SerdeValue};
+
+use crate::gcp_oauth::OauthTokenProvider;
+
+/// Struct containing parameters for send_json_request
+#[derive(Debug, Default)]
+pub(crate) struct JsonRequestParameters<'a> {
+    /// The ureq::Request to be sent
+    pub request: Request,
+    /// If this field is set, the request with be sent with an "Authorization"
+    /// header containing a bearer token obtained from the OauthTokenProvider.
+    /// If unset, the request is sent unauthenticated.
+    pub token_provider: Option<&'a mut OauthTokenProvider>,
+    /// Timeout in milliseconds for connections. If unset, a default timeout of
+    /// 10 seconds is applied.
+    pub connect_timeout_millis: Option<u64>,
+    /// Timeout in milliseconds for reads. If unset, a default timeout of 10
+    /// seconds is applied.
+    pub read_timeout_millis: Option<u64>,
+    /// The JSON body to be sent in the request, constructed with ureq::json!
+    pub body: SerdeValue,
+}
+
+/// Send the provided request with the provided JSON body. See
+/// JsonRequestParameters for more details.
+pub(crate) fn send_json_request(mut parameters: JsonRequestParameters) -> Result<Response> {
+    let authenticated_request = match &mut parameters.token_provider {
+        Some(token_provider) => parameters.request.set(
+            "Authorization",
+            &format!("Bearer {}", token_provider.ensure_oauth_token()?),
+        ),
+        None => &mut parameters.request,
+    };
+    let connect_timeout_millis = parameters.connect_timeout_millis.unwrap_or(10_000);
+    let read_timeout_millis = parameters.read_timeout_millis.unwrap_or(10_000);
+
+    Ok(authenticated_request
+        // By default, ureq will wait forever to connect or read.
+        .timeout_connect(connect_timeout_millis)
+        .timeout_read(read_timeout_millis)
+        .set("Content-Type", "application/json")
+        .send_json(parameters.body))
+}
 
 pub(crate) fn get_url(url: &str) -> Result<String> {
     let resp = ureq::get(url)

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -3,13 +3,16 @@ use ring::{digest, signature::EcdsaKeyPair};
 use std::io::Write;
 
 pub mod aggregation;
+mod aws_credentials;
 pub mod batch;
 pub mod config;
+mod gcp_oauth;
 pub mod http;
 pub mod idl;
 pub mod intake;
 pub mod manifest;
 pub mod sample;
+pub mod task;
 pub mod test_utils;
 pub mod transport;
 mod workflow;

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -3,7 +3,6 @@ use crate::http;
 use anyhow::{anyhow, Context, Result};
 use ring::signature::{UnparsedPublicKey, ECDSA_P256_SHA256_ASN1};
 use serde::Deserialize;
-
 use std::{collections::HashMap, str::FromStr};
 
 // See discussion in SpecificManifest::batch_signing_public_key

--- a/facilitator/src/task.rs
+++ b/facilitator/src/task.rs
@@ -1,0 +1,118 @@
+mod pubsub;
+mod sqs;
+
+use anyhow::Result;
+use serde::Deserialize;
+use std::{
+    fmt,
+    fmt::{Debug, Display},
+};
+
+pub use pubsub::GcpPubSubTaskQueue;
+pub use sqs::AwsSqsTaskQueue;
+
+/// A queue of tasks to be executed
+pub trait TaskQueue<T: Task>: Debug {
+    /// Get a task to execute. If a task to run is found, returns Ok(Some(T)).
+    /// If a task is successfully checked for but there is no work available,
+    /// returns Ok(None). Returns Err(e) if something goes wrong.
+    /// Once the task has been successfully completed, the TaskHandle should be
+    /// passed to acknowledge_task to permanently remove the task. If
+    /// acknowledge_task is never called, the task will eventually be
+    /// re-delivered via dequeue().
+    fn dequeue(&mut self) -> Result<Option<TaskHandle<T>>>;
+
+    /// Signal to the task queue that the task has been handled and should be
+    /// removed from the queue.
+    fn acknowledge_task(&mut self, handle: TaskHandle<T>) -> Result<()>;
+
+    /// Signal to the task queue that the task was not handled and should be
+    /// retried later.
+    fn nacknowledge_task(&mut self, handle: TaskHandle<T>) -> Result<()>;
+}
+
+/// Represents a task that can be assigned to a worker
+pub trait Task: Debug + Display + Sized + serde::de::DeserializeOwned {}
+
+/// Represents an intake batch task to be executed
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct IntakeBatchTask {
+    /// The identifier for the aggregation
+    pub aggregation_id: String,
+    /// The identifier of the batch, typically a UUID
+    pub batch_id: String,
+    /// The UTC timestamp on the batch, with minute precision, formatted like
+    /// "2006/01/02/15/04"
+    pub date: String,
+}
+
+impl Task for IntakeBatchTask {}
+
+impl Display for IntakeBatchTask {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "aggregation ID: {}\nbatch ID: {}\ndate: {}",
+            self.aggregation_id, self.batch_id, self.date
+        )
+    }
+}
+
+/// Represents an aggregation task to be executed
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct AggregationTask {
+    /// The identifier for the aggregation
+    pub aggregation_id: String,
+    /// The start of the range of time covered by the aggregation in UTC, with
+    /// minute precision, formatted like "2006/01/02/15/04"
+    pub aggregation_start: String,
+    /// The end of the range of time covered by the aggregation in UTC, with
+    /// minute precision, formatted like "2006/01/02/15/04"
+    pub aggregation_end: String,
+    // The list of batches aggregated by this task
+    pub batches: Vec<Batch>,
+}
+
+impl Task for AggregationTask {}
+
+impl Display for AggregationTask {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "aggregation ID: {}\naggregation start: {}\naggregation end: {}\nnumber of batches: {}",
+            self.aggregation_id,
+            self.aggregation_start,
+            self.aggregation_end,
+            self.batches.len()
+        )
+    }
+}
+
+/// Represents a batch included in an aggregation
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct Batch {
+    /// The identifier of the batch. Typically a UUID.
+    pub id: String,
+    /// The timestamp on the batch, in UTC, with minute precision, formatted
+    /// like "2006/01/02/15/04".
+    pub time: String,
+}
+
+/// A TaskHandle wraps a Task along with whatever metadata is needed by a
+/// TaskQueue implementation
+#[derive(Debug)]
+pub struct TaskHandle<T: Task> {
+    /// The acknowledgment ID for the task
+    acknowledgment_id: String,
+    /// The task
+    pub task: T,
+}
+
+impl<T: Task> Display for TaskHandle<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ack ID: {}\ntask: {}", self.acknowledgment_id, self.task)
+    }
+}

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -127,8 +127,6 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
             ));
         }
 
-        info!("dequeued message {:?}", received_messages.get(0));
-
         if received_messages.len() == 0 {
             return Ok(None);
         }

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -1,0 +1,219 @@
+use crate::{
+    config::Identity,
+    gcp_oauth::OauthTokenProvider,
+    http::{send_json_request, JsonRequestParameters},
+    task::{Task, TaskHandle, TaskQueue},
+};
+use anyhow::{anyhow, Context, Result};
+use log::info;
+use serde::Deserialize;
+use std::{io::Cursor, marker::PhantomData};
+
+const PUBSUB_API_BASE_URL: &str = "https://pubsub.googleapis.com";
+
+/// Represents the response to a subscription.pull request. See API doc for
+/// discussion of fields.
+/// https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/pull#response-body
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct PullResponse {
+    received_messages: Option<Vec<ReceivedMessage>>,
+}
+
+/// Represents a message received from a PubSub topic subscription. See API doc
+/// for discussion of fields.
+/// https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/pull#receivedmessage
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct ReceivedMessage {
+    ack_id: String,
+    message: GcpPubSubMessage,
+}
+
+/// The portion of a PubSubMessage that we are interested in. See API doc for
+/// discussion of fields. Note that not all fields of a PubSubMessage are
+/// parsed here, only the ones used by this application.
+/// https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct GcpPubSubMessage {
+    data: String,
+    message_id: String,
+    publish_time: String,
+}
+
+/// A task queue backed by Google Cloud PubSub
+#[derive(Debug)]
+pub struct GcpPubSubTaskQueue<T: Task> {
+    pubsub_api_endpoint: String,
+    gcp_project_id: String,
+    subscription_id: String,
+    oauth_token_provider: OauthTokenProvider,
+    phantom_task: PhantomData<*const T>,
+}
+
+impl<T: Task> GcpPubSubTaskQueue<T> {
+    pub fn new(
+        pubsub_api_endpoint: Option<&str>,
+        gcp_project_id: &str,
+        subscription_id: &str,
+        identity: Identity,
+    ) -> Result<GcpPubSubTaskQueue<T>> {
+        Ok(GcpPubSubTaskQueue {
+            pubsub_api_endpoint: pubsub_api_endpoint
+                .unwrap_or(PUBSUB_API_BASE_URL)
+                .to_owned(),
+            gcp_project_id: gcp_project_id.to_string(),
+            subscription_id: subscription_id.to_string(),
+            oauth_token_provider: OauthTokenProvider::new(
+                // This token is used to access PubSub API
+                // https://developers.google.com/identity/protocols/oauth2/scopes
+                "https://www.googleapis.com/auth/pubsub",
+                identity.map(|x| x.to_string()),
+                None, // GCP key file; never used
+            )?,
+            phantom_task: PhantomData,
+        })
+    }
+}
+
+impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
+    fn dequeue(&mut self) -> Result<Option<TaskHandle<T>>> {
+        info!(
+            "pull task from {}/{} as {:?}",
+            self.gcp_project_id, self.subscription_id, self.oauth_token_provider
+        );
+
+        // API reference: https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/pull
+        let url = format!(
+            "{}/v1/projects/{}/subscriptions/{}:pull",
+            self.pubsub_api_endpoint, self.gcp_project_id, self.subscription_id
+        );
+
+        let http_response = send_json_request(JsonRequestParameters {
+            request: ureq::post(&url),
+            token_provider: Some(&mut self.oauth_token_provider),
+            // Empirically, if there are no messages available in the
+            // subscription, the PubSub API will wait about 90 seconds to send
+            // an HTTP 200 with an empty JSON body. We set higher timeouts than
+            // usual to allow for this.
+            connect_timeout_millis: Some(180_000), // three minutes
+            read_timeout_millis: Some(180_000),    // three minutes
+            body: ureq::json!({
+                // Dequeue one task at a time
+                "maxMessages": 1
+            }),
+        })?;
+        if http_response.error() {
+            return Err(anyhow!(
+                "failed to pull messages from PubSub topic: {:?}",
+                http_response
+            ));
+        }
+
+        let response = http_response
+            .into_json_deserialize::<PullResponse>()
+            .context("failed to deserialize response from PubSub API")?;
+
+        let received_messages = match response.received_messages {
+            Some(ref messages) => messages,
+            None => return Ok(None),
+        };
+
+        if received_messages.len() > 1 {
+            return Err(anyhow!(
+                "unexpected number of messages in PubSub API response: {:?}",
+                response
+            ));
+        }
+
+        info!("dequeued message {:?}", received_messages.get(0));
+
+        if received_messages.len() == 0 {
+            return Ok(None);
+        }
+
+        // The JSON task is encoded as Base64 in the pubsub message
+        let task_json = base64::decode(&received_messages[0].message.data)
+            .context("failed to decode PubSub message")?;
+
+        let task: T = serde_json::from_reader(Cursor::new(&task_json))
+            .context(format!("failed to decode task {:?} from JSON", task_json))?;
+
+        let handle = TaskHandle {
+            task: task,
+            acknowledgment_id: received_messages[0].ack_id.clone(),
+        };
+
+        Ok(Some(handle))
+    }
+
+    fn acknowledge_task(&mut self, handle: TaskHandle<T>) -> Result<()> {
+        info!(
+            "acknowledging task {} in topic {}/{} as {:?}",
+            handle.acknowledgment_id,
+            self.gcp_project_id,
+            self.subscription_id,
+            self.oauth_token_provider
+        );
+
+        // API reference: https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/acknowledge
+        let url = format!(
+            "{}/v1/projects/{}/subscriptions/{}:acknowledge",
+            self.pubsub_api_endpoint, self.gcp_project_id, self.subscription_id
+        );
+
+        let http_response = send_json_request(JsonRequestParameters {
+            request: ureq::post(&url),
+            token_provider: Some(&mut self.oauth_token_provider),
+            body: ureq::json!({
+                "ackIds": [handle.acknowledgment_id]
+            }),
+            ..Default::default()
+        })?;
+        if http_response.error() {
+            return Err(anyhow!(
+                "failed to acknowledge task {:?}: {:?}",
+                handle,
+                http_response
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn nacknowledge_task(&mut self, handle: TaskHandle<T>) -> Result<()> {
+        info!(
+            "nacknowledging task {} in topic {}/{} as {:?}",
+            handle.acknowledgment_id,
+            self.gcp_project_id,
+            self.subscription_id,
+            self.oauth_token_provider,
+        );
+
+        // API reference: https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
+        let url = format!(
+            "{}/v1/projects/{}/subscriptions/{}:modifyAckDeadline",
+            self.pubsub_api_endpoint, self.gcp_project_id, self.subscription_id
+        );
+
+        let http_response = send_json_request(JsonRequestParameters {
+            request: ureq::post(&url),
+            token_provider: Some(&mut self.oauth_token_provider),
+            body: ureq::json!({
+                "ackIds": [handle.acknowledgment_id],
+                "ackDeadlineSeconds": 0,
+            }),
+            ..Default::default()
+        })?;
+        if http_response.error() {
+            return Err(anyhow!(
+                "failed to nacknowledge task {:?}: {:?}",
+                handle,
+                http_response
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/facilitator/src/task/sqs.rs
+++ b/facilitator/src/task/sqs.rs
@@ -1,0 +1,143 @@
+use anyhow::{anyhow, Context, Result};
+use derivative::Derivative;
+use log::info;
+use rusoto_core::Region;
+use rusoto_sqs::{
+    ChangeMessageVisibilityRequest, DeleteMessageRequest, ReceiveMessageRequest, Sqs, SqsClient,
+};
+use std::{marker::PhantomData, str::FromStr};
+use tokio::runtime::Runtime;
+
+use crate::{
+    aws_credentials::{basic_runtime, DefaultCredentialsProvider},
+    task::{Task, TaskHandle, TaskQueue},
+};
+
+/// A task queue backed by AWS SQS
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct AwsSqsTaskQueue<T: Task> {
+    #[derivative(Debug = "ignore")]
+    client: SqsClient,
+    queue_url: String,
+    runtime: Runtime,
+    phantom_task: PhantomData<*const T>,
+}
+
+impl<T: Task> AwsSqsTaskQueue<T> {
+    pub fn new(region: &str, queue_url: &str) -> Result<AwsSqsTaskQueue<T>> {
+        let region = Region::from_str(region).context("invalid AWS region")?;
+        let runtime = basic_runtime()?;
+
+        // Credentials for authenticating to AWS are automatically
+        // sourced from environment variables or ~/.aws/credentials.
+        // https://github.com/rusoto/rusoto/blob/master/AWS-CREDENTIALS.md
+        let credentials_provider =
+            DefaultCredentialsProvider::new().context("failed to create credentials provider")?;
+
+        let http_client = rusoto_core::HttpClient::new().context("failed to create HTTP client")?;
+
+        Ok(AwsSqsTaskQueue {
+            client: SqsClient::new_with(http_client, credentials_provider, region),
+            queue_url: queue_url.to_owned(),
+            runtime: runtime,
+            phantom_task: PhantomData,
+        })
+    }
+}
+
+impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
+    fn dequeue(&mut self) -> Result<Option<TaskHandle<T>>> {
+        info!("pull task from {}", self.queue_url);
+
+        let request = ReceiveMessageRequest {
+            // Dequeue one task at a time
+            max_number_of_messages: Some(1),
+            queue_url: self.queue_url.clone(),
+            // Long polling. SQS allows us to wait up to 20 seconds.
+            // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling
+            wait_time_seconds: Some(20),
+            // Visibility timeout configures how long SQS will wait for message
+            // deletion by this client before making a message visible again to
+            // other queue consumers. We set it to 600s = 10 minutes.
+            visibility_timeout: Some(600),
+            ..Default::default()
+        };
+
+        let response = self
+            .runtime
+            .block_on(self.client.receive_message(request))
+            .context("failed to dequeue message from SQS")?;
+
+        let received_messages = match response.messages {
+            Some(ref messages) => messages,
+            None => return Ok(None),
+        };
+
+        if received_messages.len() == 0 {
+            return Ok(None);
+        }
+
+        if received_messages.len() > 1 {
+            return Err(anyhow!(
+                "unexpected number of messages in SQS response: {:?}",
+                response
+            ));
+        }
+
+        let body = match &received_messages[0].body {
+            Some(body) => body,
+            None => return Err(anyhow!("no body in SQS message")),
+        };
+        let receipt_handle = match &received_messages[0].receipt_handle {
+            Some(handle) => handle,
+            None => return Err(anyhow!("no receipt handle in SQS message")),
+        };
+
+        let task = serde_json::from_reader(body.as_bytes())
+            .context(format!("failed to decode JSON task {:?}", body))?;
+
+        Ok(Some(TaskHandle {
+            task: task,
+            acknowledgment_id: receipt_handle.to_owned(),
+        }))
+    }
+
+    fn acknowledge_task(&mut self, task: TaskHandle<T>) -> Result<()> {
+        info!(
+            "acknowledging task {} in queue {}",
+            task.acknowledgment_id, self.queue_url
+        );
+
+        let request = DeleteMessageRequest {
+            queue_url: self.queue_url.clone(),
+            receipt_handle: task.acknowledgment_id.clone(),
+        };
+
+        Ok(self
+            .runtime
+            .block_on(self.client.delete_message(request))
+            .context("failed to delete/acknowledge message in SQS")?)
+    }
+
+    fn nacknowledge_task(&mut self, task: TaskHandle<T>) -> Result<()> {
+        // In SQS, messages are nacked by changing the message visibility
+        // timeout to 0
+        // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html#terminating-message-visibility-timeout
+        info!(
+            "nacknowledging task {} in queue {}",
+            task.acknowledgment_id, self.queue_url
+        );
+
+        let request = ChangeMessageVisibilityRequest {
+            queue_url: self.queue_url.clone(),
+            receipt_handle: task.acknowledgment_id.clone(),
+            visibility_timeout: 0,
+        };
+
+        Ok(self
+            .runtime
+            .block_on(self.client.change_message_visibility(request))
+            .context("failed to change message visibility/nacknowledge message in SQS")?)
+    }
+}

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -1,311 +1,17 @@
 use crate::{
     config::{GCSPath, Identity},
+    gcp_oauth::OauthTokenProvider,
     transport::{Transport, TransportWriter},
     Error,
 };
 use anyhow::{anyhow, Context, Result};
-use chrono::{prelude::Utc, DateTime, Duration};
-use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use log::info;
-use serde::{Deserialize, Serialize};
 use std::{
-    fmt, io,
+    io,
     io::{Read, Write},
 };
-use ureq::Response;
 
 const STORAGE_API_BASE_URL: &str = "https://storage.googleapis.com";
-const DEFAULT_OAUTH_TOKEN_URL: &str =
-    "http://metadata.google.internal:80/computeMetadata/v1/instance/service-accounts/default/token";
-
-/// Represents the claims encoded into JWTs when using a service account key
-/// file to authenticate as the default GCP service account.
-#[derive(Debug, Serialize, Deserialize)]
-struct Claims {
-    iss: String,
-    scope: String,
-    aud: String,
-    iat: i64,
-    exp: i64,
-}
-
-/// A wrapper around an Oauth token and its expiration date.
-struct OauthToken {
-    token: String,
-    expiration: DateTime<Utc>,
-}
-
-impl OauthToken {
-    /// Returns true if the token is expired.
-    fn expired(&self) -> bool {
-        Utc::now() >= self.expiration
-    }
-}
-
-/// Represents the response from a GET request to the GKE metadata service's
-/// service account token endpoint, or to oauth2.googleapis.com.token.
-/// https://developers.google.com/identity/protocols/oauth2/service-account
-#[derive(Deserialize, PartialEq)]
-struct OauthTokenResponse {
-    access_token: String,
-    expires_in: i64,
-    token_type: String,
-}
-
-/// Represents the response from a POST request to the GCP IAM service's
-/// generateAccessToken endpoint.
-/// https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
-#[derive(Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-struct GenerateAccessTokenResponse {
-    access_token: String,
-    expire_time: DateTime<Utc>,
-}
-
-/// This is the subset of a GCP service account key file that we need to parse
-/// to construct a signed JWT.
-#[derive(Debug, Deserialize, PartialEq)]
-struct ServiceAccountKeyFile {
-    /// The PEM-armored base64 encoding of the ASN.1 encoding of the account's
-    /// RSA private key.
-    private_key: String,
-    /// The private key ID.
-    private_key_id: String,
-    /// The service account's email address.
-    client_email: String,
-    /// The URL from which OAuth tokens should be requested.
-    token_uri: String,
-}
-
-/// OauthTokenProvider manages a default service account Oauth token (i.e. the
-/// one for a GCP service account mapped to a Kubernetes service account, or the
-/// one found in a JSON key file) and an Oauth token used to impersonate another
-/// service account.
-struct OauthTokenProvider {
-    /// The parsed key file for the default GCP service account. If present,
-    /// this will be used to obtain the default account OAuth token. If absent,
-    /// the GKE metadata service is consulted.
-    default_service_account_key_file: Option<ServiceAccountKeyFile>,
-    /// Holds the service account email to impersonate, if one was provided to
-    /// OauthTokenProvider::new.
-    account_to_impersonate: Option<String>,
-    /// This field is None after instantiation and is Some after the first
-    /// successful request for a token for the default service account, though
-    /// the contained token may be expired.
-    default_account_token: Option<OauthToken>,
-    /// This field is None after instantiation and is Some after the first
-    /// successful request for a token for the impersonated service account,
-    /// though the contained token may be expired. This will always be None if
-    /// account_to_impersonate is None.
-    impersonated_account_token: Option<OauthToken>,
-}
-
-impl fmt::Debug for OauthTokenProvider {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("OauthTokenProvider")
-            .field("account_to_impersonate", &self.account_to_impersonate)
-            .field(
-                "default_service_account_key_file",
-                &self
-                    .default_service_account_key_file
-                    .as_ref()
-                    .map(|key_file| key_file.client_email.clone()),
-            )
-            .field(
-                "default_account_token",
-                &self.default_account_token.as_ref().map(|_| "redacted"),
-            )
-            .field(
-                "impersonated_account_token",
-                &self.default_account_token.as_ref().map(|_| "redacted"),
-            )
-            .finish()
-    }
-}
-
-impl OauthTokenProvider {
-    /// Creates a token provider which can impersonate the specified service
-    /// account.
-    fn new(
-        account_to_impersonate: Option<String>,
-        key_file_reader: Option<Box<dyn Read>>,
-    ) -> Result<OauthTokenProvider> {
-        let key_file: Option<ServiceAccountKeyFile> = match key_file_reader {
-            Some(reader) => {
-                serde_json::from_reader(reader).context("failed to deserialize JSON key file")?
-            }
-            None => None,
-        };
-        Ok(OauthTokenProvider {
-            default_service_account_key_file: key_file,
-            account_to_impersonate,
-            default_account_token: None,
-            impersonated_account_token: None,
-        })
-    }
-
-    /// Returns the Oauth token to use with GCS storage API in an Authorization
-    /// header, fetching it or renewing it if necessary. If a service account to
-    /// impersonate was provided, the default service account is used to
-    /// authenticate to the GCP IAM API to retrieve an Oauth token. If no
-    /// impersonation is taking place, provides the default service account
-    /// Oauth token.
-    fn ensure_storage_access_oauth_token(&mut self) -> Result<String> {
-        match self.account_to_impersonate {
-            Some(_) => self.ensure_impersonated_service_account_oauth_token(),
-            None => self.ensure_default_account_token(),
-        }
-    }
-
-    /// Returns the current OAuth token for the default service account, if it
-    /// is valid. Otherwise obtains and returns a new one.
-    /// The returned value is an owned reference because the token owned by this
-    /// struct could change while the caller is still holding the returned token
-    fn ensure_default_account_token(&mut self) -> Result<String> {
-        if let Some(token) = &self.default_account_token {
-            if !token.expired() {
-                return Ok(token.token.clone());
-            }
-        }
-
-        let http_response = match &self.default_service_account_key_file {
-            Some(key_file) => OauthTokenProvider::account_token_with_key_file(&key_file)?,
-            None => OauthTokenProvider::account_token_from_gke_metadata_service(),
-        };
-        if http_response.error() {
-            return Err(anyhow!(
-                "failed to query GKE metadata service: {:?}",
-                http_response
-            ));
-        }
-
-        let response = http_response
-            .into_json_deserialize::<OauthTokenResponse>()
-            .context("failed to deserialize response from GKE metadata service")?;
-
-        if response.token_type != "Bearer" {
-            return Err(anyhow!("unexpected token type {}", response.token_type));
-        }
-
-        self.default_account_token = Some(OauthToken {
-            token: response.access_token.clone(),
-            expiration: Utc::now() + Duration::seconds(response.expires_in),
-        });
-
-        Ok(response.access_token)
-    }
-
-    /// Fetches default account token from GKE metadata service. Returns the
-    /// ureq::Response, whose body will be an OauthTokenResponse if the HTTP
-    /// call was successful, but may be an error.
-    fn account_token_from_gke_metadata_service() -> Response {
-        ureq::get(DEFAULT_OAUTH_TOKEN_URL)
-            .set("Metadata-Flavor", "Google")
-            // By default, ureq will wait forever to connect or read.
-            .timeout_connect(10_000) // ten seconds
-            .timeout_read(10_000) // ten seconds
-            .call()
-    }
-
-    /// Fetches the default account token from Google OAuth API using a JWT
-    /// constructed from the parameters in the provided key file. If the JWT is
-    /// successfully constructed, returns the ureq::Response whose body will be
-    /// an OauthTokenResponse if the HTTP call was successful, but may be an
-    /// error.
-    fn account_token_with_key_file(key_file: &ServiceAccountKeyFile) -> Result<Response> {
-        // We construct the JWT per Google documentation:
-        // https://developers.google.com/identity/protocols/oauth2/service-account#authorizingrequests
-        let mut header = Header::new(Algorithm::RS256);
-        header.kid = Some(key_file.private_key_id.to_owned());
-
-        // The iat and exp fields in a JWT are in seconds since UNIX epoch.
-        let now = Utc::now().timestamp();
-        let claims = Claims {
-            iss: key_file.client_email.to_owned(),
-            // This token is used to access GCS storage
-            // https://developers.google.com/identity/protocols/oauth2/scopes#storage
-            scope: "https://www.googleapis.com/auth/devstorage.read_write".to_owned(),
-            aud: key_file.token_uri.to_owned(),
-            iat: now,
-            exp: now + 3600, // token expires in one hour
-        };
-
-        let encoding_key = EncodingKey::from_rsa_pem(key_file.private_key.as_bytes())
-            .context("failed to parse PEM RSA key")?;
-
-        let token =
-            encode(&header, &claims, &encoding_key).context("failed to construct and sign JWT")?;
-
-        let request_body = format!(
-            "grant_type={}&assertion={}",
-            urlencoding::encode("urn:ietf:params:oauth:grant-type:jwt-bearer"),
-            token
-        );
-
-        Ok(ureq::post(&key_file.token_uri)
-            .set("Content-Type", "application/x-www-form-urlencoded")
-            // By default, ureq will wait forever to connect or read.
-            .timeout_connect(10_000) // ten seconds
-            .timeout_read(10_000) // ten seconds
-            .send_string(&request_body))
-    }
-
-    /// Returns the current OAuth token for the impersonated service account, if
-    /// it is valid. Otherwise obtains and returns a new one.
-    fn ensure_impersonated_service_account_oauth_token(&mut self) -> Result<String> {
-        if self.account_to_impersonate.is_none() {
-            return Err(anyhow!("no service account to impersonate was provided"));
-        }
-
-        if let Some(token) = &self.impersonated_account_token {
-            if !token.expired() {
-                return Ok(token.token.clone());
-            }
-        }
-
-        let service_account_to_impersonate = self.account_to_impersonate.clone().unwrap();
-        // API reference:
-        // https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
-        let request_url = format!("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}:generateAccessToken",
-            service_account_to_impersonate);
-        let auth = format!("Bearer {}", self.ensure_default_account_token()?);
-        let http_response = ureq::post(&request_url)
-            // By default, ureq will wait forever to connect or read.
-            .timeout_connect(10_000) // ten seconds
-            .timeout_read(10_000) // ten seconds
-            .set("Authorization", &auth)
-            .set("Content-Type", "application/json")
-            // At the moment, these tokens are only used to read and write from
-            // GCS buckets, so we request an appropriate scope. We could further
-            // narrow this to a devstorage.read token if we knew what it was
-            // going to be used for, but that would require this object to
-            // manage two impersonation tokens which is more work than I want to
-            // do right now.
-            // https://cloud.google.com/storage/docs/authentication#oauth-scopes
-            .send_json(ureq::json!({
-                "scope": [
-                    "https://www.googleapis.com/auth/devstorage.read_write"
-                ]
-            }));
-        if http_response.error() {
-            return Err(anyhow!(
-                "failed to get Oauth token to impersonate service account {}: {:?}",
-                service_account_to_impersonate,
-                http_response
-            ));
-        }
-
-        let response = http_response
-            .into_json_deserialize::<GenerateAccessTokenResponse>()
-            .context("failed to deserialize response from IAM API")?;
-        self.impersonated_account_token = Some(OauthToken {
-            token: response.access_token.clone(),
-            expiration: response.expire_time,
-        });
-
-        Ok(response.access_token)
-    }
-}
 
 /// GCSTransport manages reading and writing from GCS buckets, with
 /// authenticatiom to the API by Oauth token in an Authorization header. This
@@ -332,6 +38,9 @@ impl GCSTransport {
         Ok(GCSTransport {
             path: path.ensure_directory_prefix(),
             oauth_token_provider: OauthTokenProvider::new(
+                // This token is used to access GCS storage
+                // https://developers.google.com/identity/protocols/oauth2/scopes#storage
+                "https://www.googleapis.com/auth/devstorage.read_write",
                 identity.map(|x| x.to_string()),
                 key_file_reader,
             )?,
@@ -363,11 +72,7 @@ impl Transport for GCSTransport {
             .query("alt", "media")
             .set(
                 "Authorization",
-                &format!(
-                    "Bearer {}",
-                    self.oauth_token_provider
-                        .ensure_storage_access_oauth_token()?
-                ),
+                &format!("Bearer {}", self.oauth_token_provider.ensure_oauth_token()?),
             )
             // By default, ureq will wait forever to connect or read
             .timeout_connect(10_000) // ten seconds
@@ -393,9 +98,7 @@ impl Transport for GCSTransport {
         // expiring during the lifetime of that object, and so obtain a token
         // here instead of passing the token provider into the
         // StreamingTransferWriter.
-        let oauth_token = self
-            .oauth_token_provider
-            .ensure_storage_access_oauth_token()?;
+        let oauth_token = self.oauth_token_provider.ensure_oauth_token()?;
         let writer = StreamingTransferWriter::new(
             self.path.bucket.to_owned(),
             [&self.path.key, key].concat(),

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -1,4 +1,5 @@
 use crate::{
+    aws_credentials::{basic_runtime, DefaultCredentialsProvider},
     config::{Identity, S3Path},
     transport::{Transport, TransportWriter},
     Error,
@@ -8,11 +9,7 @@ use derivative::Derivative;
 use hyper_rustls::HttpsConnector;
 use log::info;
 use rusoto_core::{
-    credential::EnvironmentProvider,
-    credential::{
-        AutoRefreshingProvider, AwsCredentials, ContainerProvider, CredentialsError,
-        InstanceMetadataProvider, ProfileProvider, ProvideAwsCredentials, Secret, Variable,
-    },
+    credential::{AutoRefreshingProvider, CredentialsError, Secret, Variable},
     ByteStream, Region, RusotoError, RusotoResult,
 };
 use rusoto_s3::{
@@ -30,7 +27,7 @@ use std::{
 };
 use tokio::{
     io::{AsyncRead, AsyncReadExt},
-    runtime::{Builder, Runtime},
+    runtime::Runtime,
 };
 
 // We use workload identity to map GCP service accounts to Kubernetes service
@@ -50,11 +47,6 @@ const MAX_ATTEMPT_COUNT: i32 = 3;
 
 /// ClientProvider allows mocking out a client for testing.
 type ClientProvider = Box<dyn Fn(&Region, Option<String>) -> Result<S3Client>>;
-
-/// Constructs a basic runtime suitable for use in our single threaded context
-fn basic_runtime() -> Result<Runtime> {
-    Ok(Builder::new().basic_scheduler().enable_all().build()?)
-}
 
 /// Calls the provided closure, retrying up to MAX_ATTEMPT_COUNT times if it
 /// fails with RusotoError::HttpDispatch, which indicates a problem sending the
@@ -816,149 +808,5 @@ mod tests {
         writer.write_all(b"fake-content").unwrap();
         writer.complete_upload().unwrap();
         writer.cancel_upload().unwrap();
-    }
-}
-
-// ------------- Everything below here was copied from rusoto/credential/src/lib.rs in the rusoto repo ---------------------------
-// -------------------------------------------------------------------------------------------------------------------------------
-
-/// Wraps a `ChainProvider` in an `AutoRefreshingProvider`.
-///
-/// The underlying `ChainProvider` checks multiple sources for credentials, and the `AutoRefreshingProvider`
-/// refreshes the credentials automatically when they expire.
-///
-/// # Warning
-///
-/// This provider allows the [`credential_process`][credential_process] option in the AWS config
-/// file (`~/.aws/config`), a method of sourcing credentials from an external process. This can
-/// potentially be dangerous, so proceed with caution. Other credential providers should be
-/// preferred if at all possible. If using this option, you should make sure that the config file
-/// is as locked down as possible using security best practices for your operating system.
-///
-/// [credential_process]: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
-#[derive(Clone)]
-pub struct DefaultCredentialsProvider(AutoRefreshingProvider<ChainProvider>);
-
-impl DefaultCredentialsProvider {
-    /// Creates a new thread-safe `DefaultCredentialsProvider`.
-    pub fn new() -> Result<DefaultCredentialsProvider, CredentialsError> {
-        let inner = AutoRefreshingProvider::new(ChainProvider::new())?;
-        Ok(DefaultCredentialsProvider(inner))
-    }
-}
-
-#[async_trait]
-impl ProvideAwsCredentials for DefaultCredentialsProvider {
-    async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
-        self.0.credentials().await
-    }
-}
-
-/// Provides AWS credentials from multiple possible sources using a priority order.
-///
-/// The following sources are checked in order for credentials when calling `credentials`:
-///
-/// 1. Environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-/// 2. `credential_process` command in the AWS config file, usually located at `~/.aws/config`.
-/// 3. AWS credentials file. Usually located at `~/.aws/credentials`.
-/// 4. IAM instance profile. Will only work if running on an EC2 instance with an instance profile/role.
-///
-/// If the sources are exhausted without finding credentials, an error is returned.
-///
-/// The provider has a default timeout of 30 seconds. While it should work well for most setups,
-/// you can change the timeout using the `set_timeout` method.
-///
-/// # Example
-///
-///
-/// # Warning
-///
-/// This provider allows the [`credential_process`][credential_process] option in the AWS config
-/// file (`~/.aws/config`), a method of sourcing credentials from an external process. This can
-/// potentially be dangerous, so proceed with caution. Other credential providers should be
-/// preferred if at all possible. If using this option, you should make sure that the config file
-/// is as locked down as possible using security best practices for your operating system.
-///
-/// [credential_process]: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
-#[derive(Debug, Clone)]
-pub struct ChainProvider {
-    environment_provider: EnvironmentProvider,
-    instance_metadata_provider: InstanceMetadataProvider,
-    container_provider: ContainerProvider,
-    profile_provider: Option<ProfileProvider>,
-    webidp_provider: WebIdentityProvider,
-}
-
-impl ChainProvider {
-    /// Set the timeout on the provider to the specified duration.
-    #[allow(dead_code)]
-    pub fn set_timeout(&mut self, duration: Duration) {
-        self.instance_metadata_provider.set_timeout(duration);
-        self.container_provider.set_timeout(duration);
-    }
-}
-
-async fn chain_provider_credentials(
-    provider: ChainProvider,
-) -> Result<AwsCredentials, CredentialsError> {
-    if let Ok(creds) = provider.environment_provider.credentials().await {
-        return Ok(creds);
-    }
-    if let Some(ref profile_provider) = provider.profile_provider {
-        if let Ok(creds) = profile_provider.credentials().await {
-            return Ok(creds);
-        }
-    }
-    if let Ok(creds) = provider.container_provider.credentials().await {
-        return Ok(creds);
-    }
-    if let Ok(creds) = provider.webidp_provider.credentials().await {
-        return Ok(creds);
-    }
-    if let Ok(creds) = provider.instance_metadata_provider.credentials().await {
-        return Ok(creds);
-    }
-    Err(CredentialsError::new(
-        "Couldn't find AWS credentials in environment, credentials file, or IAM role.",
-    ))
-}
-
-use async_trait::async_trait;
-
-#[async_trait]
-impl ProvideAwsCredentials for ChainProvider {
-    async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
-        chain_provider_credentials(self.clone()).await
-    }
-}
-
-impl ChainProvider {
-    /// Create a new `ChainProvider` using a `ProfileProvider` with the default settings.
-    pub fn new() -> ChainProvider {
-        ChainProvider {
-            environment_provider: EnvironmentProvider::default(),
-            profile_provider: ProfileProvider::new().ok(),
-            instance_metadata_provider: InstanceMetadataProvider::new(),
-            container_provider: ContainerProvider::new(),
-            webidp_provider: WebIdentityProvider::from_k8s_env(),
-        }
-    }
-
-    /// Create a new `ChainProvider` using the provided `ProfileProvider`.
-    #[allow(dead_code)]
-    pub fn with_profile_provider(profile_provider: ProfileProvider) -> ChainProvider {
-        ChainProvider {
-            environment_provider: EnvironmentProvider::default(),
-            profile_provider: Some(profile_provider),
-            instance_metadata_provider: InstanceMetadataProvider::new(),
-            container_provider: ContainerProvider::new(),
-            webidp_provider: WebIdentityProvider::from_k8s_env(),
-        }
-    }
-}
-
-impl Default for ChainProvider {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/terraform/modules/cloud_storage_aws/cloud_storage_aws.tf
+++ b/terraform/modules/cloud_storage_aws/cloud_storage_aws.tf
@@ -33,7 +33,14 @@ resource "aws_s3_bucket" "ingestion_bucket" {
   bucket = var.ingestion_bucket_name
   # Force deletion of bucket contents on bucket destroy.
   force_destroy = true
-  policy        = <<POLICY
+  # Delete objects 7 days after creation
+  lifecycle_rule {
+    enabled = true
+    expiration {
+      days = 7
+    }
+  }
+  policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -82,7 +89,14 @@ resource "aws_s3_bucket" "peer_validation_bucket" {
   bucket = var.peer_validation_bucket_name
   # Force deletion of bucket contents on bucket destroy.
   force_destroy = true
-  policy        = <<POLICY
+  # Delete objects 7 days after creation
+  lifecycle_rule {
+    enabled = true
+    expiration {
+      days = 7
+    }
+  }
+  policy = <<POLICY
 {
   "Version": "2012-10-17",
   "Statement": [

--- a/terraform/modules/fake_server_resources/fake_server_resources.tf
+++ b/terraform/modules/fake_server_resources/fake_server_resources.tf
@@ -15,7 +15,7 @@ variable "sum_part_bucket_writer_email" {
 }
 
 variable "ingestors" {
-  type = map(string)
+  type = list(string)
 }
 
 # For our purposes, a fake portal server is simply a bucket where we can write
@@ -63,7 +63,7 @@ resource "google_storage_bucket_object" "portal_server_global_manifest" {
 # Constructs global manifests for this env's ingestion servers, populated with
 # public keys that match what the sample_maker will use.
 resource "google_storage_bucket_object" "ingestor_global_manifests" {
-  for_each     = var.ingestors
+  for_each     = toset(var.ingestors)
   name         = "${each.key}/global-manifest.json"
   bucket       = var.manifest_bucket
   content_type = "application/json"

--- a/terraform/modules/gke/gke.tf
+++ b/terraform/modules/gke/gke.tf
@@ -84,9 +84,9 @@ resource "google_container_node_pool" "worker_nodes" {
   name               = "${var.resource_prefix}-node-pool"
   location           = var.gcp_region
   cluster            = google_container_cluster.cluster.name
-  initial_node_count = 3
+  initial_node_count = 4
   autoscaling {
-    min_node_count = 2
+    min_node_count = 4
     max_node_count = 5
   }
   node_config {

--- a/terraform/modules/gke/gke.tf
+++ b/terraform/modules/gke/gke.tf
@@ -84,9 +84,9 @@ resource "google_container_node_pool" "worker_nodes" {
   name               = "${var.resource_prefix}-node-pool"
   location           = var.gcp_region
   cluster            = google_container_cluster.cluster.name
-  initial_node_count = 4
+  initial_node_count = 3
   autoscaling {
-    min_node_count = 4
+    min_node_count = 2
     max_node_count = 5
   }
   node_config {

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -278,6 +278,10 @@ resource "kubernetes_cron_job" "workflow_manager" {
                 "--aggregate-config-map", kubernetes_config_map.aggregate_job_config_map.metadata[0].name,
                 "--facilitator-image", "${var.container_registry}/${var.facilitator_image}:${var.facilitator_version}",
                 "--push-gateway", var.pushgateway,
+                "--task-queue-kind", "gcp-pubsub",
+                "--intake-tasks-topic", var.intake_tasks_queue,
+                "--aggregate-tasks-topic", var.aggregate_tasks_queue,
+                "--gcp-project-id", data.google_project.project.project_id,
               ]
             }
             # If we use any other restart policy, then when the job is finally
@@ -395,7 +399,7 @@ resource "kubernetes_role" "workflow_manager_role" {
     // Note: Some of these permissions will probably wind up not being needed.
     // Starting with a moderately generous demonstration set.
     resources = ["namespaces", "pods", "jobs"]
-    verbs     = ["get", "list", "watch", "create"]
+    verbs     = ["get", "list", "watch", "delete"]
   }
 }
 

--- a/terraform/modules/pubsub/pubsub.tf
+++ b/terraform/modules/pubsub/pubsub.tf
@@ -1,0 +1,84 @@
+variable "environment" {
+  type = string
+}
+
+variable "data_share_processor_name" {
+  type = string
+}
+
+variable "publisher_service_account" {
+  type = string
+}
+
+variable "subscriber_service_account" {
+  type = string
+}
+
+variable "task" {
+  type = string
+}
+
+data "google_project" "project" {}
+
+locals {
+  # GCP PubSub creates a service account for each project used to move
+  # undeliverable messages from subscriptons to a dead letter topic
+  # https://cloud.google.com/pubsub/docs/dead-letter-topics#granting_forwarding_permissions
+  pubsub_service_account = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+resource "google_pubsub_topic" "task" {
+  name = "${var.environment}-${var.data_share_processor_name}-${var.task}"
+}
+
+resource "google_pubsub_topic_iam_binding" "task" {
+  topic = google_pubsub_topic.task.name
+  role  = "roles/pubsub.publisher"
+  members = [
+    "serviceAccount:${var.publisher_service_account}"
+  ]
+}
+
+# We create a single subscription for the topic that all facilitator instances
+# will dequeue tasks from. If we had multiple subscriptions, then each would see
+# all the messages sent to the topic.
+resource "google_pubsub_subscription" "task" {
+  name                 = "${var.environment}-${var.data_share_processor_name}-${var.task}"
+  topic                = google_pubsub_topic.task.name
+  ack_deadline_seconds = 600
+  # We never want the subscription to expire
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription#expiration_policy
+  expiration_policy {
+    ttl = ""
+  }
+  dead_letter_policy {
+    dead_letter_topic     = google_pubsub_topic.dead_letter.id
+    max_delivery_attempts = 5
+  }
+}
+
+resource "google_pubsub_subscription_iam_binding" "task" {
+  subscription = google_pubsub_subscription.task.name
+  role         = "roles/pubsub.subscriber"
+  members = [
+    "serviceAccount:${var.subscriber_service_account}",
+    local.pubsub_service_account
+  ]
+}
+
+# Dead letter topic to which undeliverable intake batch messages are sent
+resource "google_pubsub_topic" "dead_letter" {
+  name = "${google_pubsub_topic.task.name}-dead-letter"
+}
+
+resource "google_pubsub_topic_iam_binding" "dead_letter" {
+  topic = google_pubsub_topic.dead_letter.name
+  role  = "roles/pubsub.publisher"
+  members = [
+    local.pubsub_service_account
+  ]
+}
+
+output "queue" {
+  value = google_pubsub_topic.task.name
+}

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -10,8 +10,22 @@ managed_dns_zone = {
   gcp_project = "prio-bringup-290620"
 }
 ingestors = {
-  apple  = "exposure-notification.apple.com/manifest"
-  g-enpa = "storage.googleapis.com/prio-manifests"
+  apple = {
+    manifest_base_url = "exposure-notification.apple.com/manifest"
+    localities = {
+      us-ct = {
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
+      }
+    }
+  }
+  g-enpa = {
+    manifest_base_url = "storage.googleapis.com/prio-manifests"
+    us-ct = {
+      intake_worker_count    = 1
+      aggregate_worker_count = 1
+    }
+  }
 }
 peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
 portal_server_manifest_base_url        = "manifest.enpa-pha.io"

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -1,0 +1,31 @@
+environment     = "staging-facil"
+gcp_region      = "us-west1"
+gcp_project     = "prio-staging-300104"
+machine_type    = "e2-standard-8"
+localities      = ["narnia", "gondor", "asgard"]
+aws_region      = "us-west-1"
+manifest_domain = "isrg-prio.org"
+managed_dns_zone = {
+  name        = "manifests"
+  gcp_project = "prio-bringup-290620"
+}
+ingestors = {
+  ingestor-1 = {
+    manifest_base_url          = "storage.googleapis.com/prio-staging-facil-manifests/ingestor-1"
+    intake_batch_replica_count = 1
+  }
+  ingestor-2 = {
+    manifest_base_url          = "storage.googleapis.com/prio-staging-facil-manifests/ingestor-2"
+    intake_batch_replica_count = 1
+  }
+}
+peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
+portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
+test_peer_environment = {
+  env_with_ingestor    = "staging-facil"
+  env_without_ingestor = "staging-pha"
+}
+is_first           = false
+use_aws            = false
+container_registry = "us.gcr.io/prio-staging-300104"
+pushgateway        = "prometheus-pushgateway.monitoring:9091"

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -11,12 +11,38 @@ managed_dns_zone = {
 }
 ingestors = {
   ingestor-1 = {
-    manifest_base_url          = "storage.googleapis.com/prio-staging-facil-manifests/ingestor-1"
-    intake_batch_replica_count = 1
+    manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests/ingestor-1"
+    localities = {
+      narnia = {
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
+      }
+      gondor = {
+        intake_worker_count    = 2
+        aggregate_worker_count = 1
+      }
+      asgard = {
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
+      }
+    }
   }
   ingestor-2 = {
-    manifest_base_url          = "storage.googleapis.com/prio-staging-facil-manifests/ingestor-2"
-    intake_batch_replica_count = 1
+    manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests/ingestor-2"
+    localities = {
+      narnia = {
+        intake_worker_count    = 2
+        aggregate_worker_count = 1
+      }
+      gondor = {
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
+      }
+      asgard = {
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
+      }
+    }
   }
 }
 peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -1,0 +1,31 @@
+environment     = "staging-pha"
+gcp_region      = "us-west1"
+gcp_project     = "prio-staging-300104"
+machine_type    = "e2-standard-8"
+localities      = ["narnia", "gondor", "asgard"]
+aws_region      = "us-west-1"
+manifest_domain = "isrg-prio.org"
+managed_dns_zone = {
+  name        = "manifests"
+  gcp_project = "prio-bringup-290620"
+}
+ingestors = {
+  ingestor-1 = {
+    manifest_base_url          = "storage.googleapis.com/prio-staging-pha-manifests/ingestor-1"
+    intake_batch_replica_count = 1
+  }
+  ingestor-2 = {
+    manifest_base_url          = "storage.googleapis.com/prio-staging-pha-manifests/ingestor-2"
+    intake_batch_replica_count = 1
+  }
+}
+peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
+portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
+test_peer_environment = {
+  env_with_ingestor    = "staging-facil"
+  env_without_ingestor = "staging-pha"
+}
+is_first           = true
+use_aws            = true
+container_registry = "us.gcr.io/prio-staging-300104"
+pushgateway        = "prometheus-pushgateway.monitoring:9091"

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -11,12 +11,38 @@ managed_dns_zone = {
 }
 ingestors = {
   ingestor-1 = {
-    manifest_base_url          = "storage.googleapis.com/prio-staging-pha-manifests/ingestor-1"
-    intake_batch_replica_count = 1
+    manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests/ingestor-1"
+    localities = {
+      narnia = {
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
+      }
+      gondor = {
+        intake_worker_count    = 2
+        aggregate_worker_count = 1
+      }
+      asgard = {
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
+      }
+    }
   }
   ingestor-2 = {
-    manifest_base_url          = "storage.googleapis.com/prio-staging-pha-manifests/ingestor-2"
-    intake_batch_replica_count = 1
+    manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests/ingestor-2"
+    localities = {
+      narnia = {
+        intake_worker_count    = 2
+        aggregate_worker_count = 1
+      }
+      gondor = {
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
+      }
+      asgard = {
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
+      }
+    }
   }
 }
 peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"

--- a/workflow-manager/README.md
+++ b/workflow-manager/README.md
@@ -1,0 +1,39 @@
+# workflow-manager
+
+`workflow-manager` is the publisher portion of the Prio pub/sub architecture. It is responsible for:
+
+- scanning the contents of ingestion, own validation and peer validation buckets and translating the objects it finds into intake and aggregation tasks
+- writing markers to avoid scheduling duplicate tasks
+- reaping Kubernetes jobs left behind by older versions of itself
+
+## Task queues
+
+`workflow-manager` schedules work by sending messages into a queue, which are later consumed by `facilitator` worker instances. We currently support the following message queues:
+
+### [Google PubSub](https://cloud.google.com/pubsub/docs)
+
+Implemented in `GCPPubSubEnqueuer` in `task/task.go`. The model is that each `workflow-manager` instance uses distinct topics for intake and aggregation tasks, so at a higher level, there are distinct PubSub topics for each (locality, ingestor, task) tuple. There is one subscription for each topic, shared among pools of `intake-batch-worker` and `aggregate-worker` instances of `facilitator`. `workflow-manager` assumes that PubSub topics with appropriate names, permissions and subscriptions already exist.
+
+Google provides a [PubSub emulator](https://cloud.google.com/pubsub/docs/emulator) useful for local testing. See the emulator documentation for information getting it set up, then simply set the `PUBSUB_EMULATOR_HOST` environment variable to the emulator's address when running `workflow-manager`.
+
+`workflow-manager` expects the topics to which it writes messages to already have been created in Terraform, and `gcloud` cannot be used to interact with the emulator, so `workflow-manager` takes the `--create-pubsub-topics` flag. When set, `workflow-manager` will create topics with the names provided to the `--intake-tasks-topic` and `--aggregate-tasks-topic` parameters before doing any work.
+
+### [AWS SNS](https://docs.aws.amazon.com/sns/latest/dg/welcome.html) (**EXPERIMENTAL SUPPORT**)
+
+Implemented in `AWSSNSEnqueuer` in `task/task.go`. The model here is that each `workflow-manager` instance uses distinct SNS topics for intake and aggregation tasks, so at a higher level, there are distinct SNS topics for each (locality, ingestor, task) tuple. It is assumed that  There is one SQS queue for each topic, shared among pools of `intake-batch-worker` and `aggregate-worker` instances of `facilitator`. `workflow-manager` assumes that SNS topics and SQS queues with appropriate names, permissions and configurations already exist.
+
+AWS SNS/SQS support is experimental and has not been validated. To use it, invoke `workflow-manager` with `--task-queue-kind=aws-sns`, and provide other `--aws-sns-` parameters as appropriate for your deployment.
+
+### Implementing new task queues
+
+To support new task queues, simply add an implementation of the `task.Enqueuer` interface in `task/task.go`. Then, add the necessary argument handling and initialization logic to `main.go` as directed by the comments there.
+
+## Developing and debugging
+
+`workflow-manager` is intended to run as a Kubernetes cronjob, but it can also be run locally from the command line. It uses cloud platform APIs to access storage buckets and Kubernetes APIs to list and manipulate jobs. If no special arguments are provided, it will use ambient cloud platform credits (i.e., whatever is in `~/.aws` or `~/.config/gcloud`) for the former. For Kubernetes API access, it defaults to using the in cluster client configuration, expecting a Kubernetes service account with appropriate RBAC permissions to be mounted. However you can have it use the credentials configured for `kubectl` by passing `--kube-config-path /path/to/your/.kube/config`. See `kubectl` documentation for more information on `kubeconfig`.
+
+### Dry run mode
+
+If you want to see what `workflow-manager` would do and avoid any side-effects, pass `--dry-run`. No tasks will be scheduled, no objects will be written to cloud storage and no Kubernetes jobs will be deleted. Instead, the operations that would have been performed will be logged.
+
+Note that dry run mode does not guarantee that the logged operations would have succeeded.

--- a/workflow-manager/aws/aws.go
+++ b/workflow-manager/aws/aws.go
@@ -1,0 +1,50 @@
+// Package aws contains utilities related to AWS
+package aws
+
+import (
+	"fmt"
+
+	"github.com/letsencrypt/prio-server/workflow-manager/tokenfetcher"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+)
+
+func webIDP(sess *session.Session, identity string) (*credentials.Credentials, error) {
+	parsed, err := arn.Parse(identity)
+	if err != nil {
+		return nil, err
+	}
+	audience := fmt.Sprintf("sts.amazonaws.com/%s", parsed.AccountID)
+
+	stsSTS := sts.New(sess)
+	roleSessionName := ""
+	roleProvider := stscreds.NewWebIdentityRoleProviderWithToken(
+		stsSTS, identity, roleSessionName, tokenfetcher.NewTokenFetcher(audience))
+
+	return credentials.NewCredentials(roleProvider), nil
+}
+
+// ClientConfig returns a (Session, Config) pair suitable for passing to the
+// New() functions for various AWS services. If identity contains a valid role
+// ARN, the config will use a web identity role provider for that role.
+func ClientConfig(region, identity string) (*session.Session, *aws.Config, error) {
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, nil, fmt.Errorf("making AWS session: %w", err)
+	}
+
+	config := aws.NewConfig().WithRegion(region)
+	if identity != "" {
+		creds, err := webIDP(sess, identity)
+		if err != nil {
+			return nil, nil, err
+		}
+		config = config.WithCredentials(creds)
+	}
+	return sess, config, nil
+}

--- a/workflow-manager/batchpath/batchpath.go
+++ b/workflow-manager/batchpath/batchpath.go
@@ -94,6 +94,10 @@ func (b *BatchPath) isComplete() bool {
 func ReadyBatches(files []string, infix string) (List, error) {
 	batches := make(map[string]*BatchPath)
 	for _, name := range files {
+		// Ignore task marker objects
+		if strings.HasPrefix(name, "task-markers/") {
+			continue
+		}
 		basename := basename(name, infix)
 		b := batches[basename]
 		var err error

--- a/workflow-manager/bucket/bucket.go
+++ b/workflow-manager/bucket/bucket.go
@@ -100,9 +100,7 @@ func (b *Bucket) listFilesS3(ctx context.Context) ([]string, error) {
 	var nextContinuationToken = ""
 	for {
 		input := &s3.ListObjectsV2Input{
-			// We choose a lower number than the default max of 1000 to ensure we exercise the
-			// cursoring case regularly.
-			MaxKeys: aws.Int64(100),
+			MaxKeys: aws.Int64(1000),
 			Bucket:  aws.String(bucket),
 		}
 		if nextContinuationToken != "" {
@@ -139,10 +137,10 @@ func (b *Bucket) listFilesGS(ctx context.Context) ([]string, error) {
 	var output []string
 	it := bkt.Objects(ctx, query)
 
-	// Use the paginated API to list Bucket contents, as otherwise we would only get the first 1,000 objects in the Bucket.
-	// As in the S3 case above, we get 100 results at a time to ensure we exercise the pagination case.
+	// Use the paginated API to list Bucket contents, as otherwise we would only
+	// get the first 1,000 objects in the Bucket.
 	// https://cloud.google.com/storage/docs/json_api/v1/objects/list
-	p := iterator.NewPager(it, 100, "")
+	p := iterator.NewPager(it, 1000, "")
 	var objects []*storage.ObjectAttrs
 	for {
 		// NextPage will append to the objects slice

--- a/workflow-manager/bucket/bucket.go
+++ b/workflow-manager/bucket/bucket.go
@@ -3,20 +3,22 @@ package bucket
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"strings"
 
+	leaws "github.com/letsencrypt/prio-server/workflow-manager/aws"
+
 	"cloud.google.com/go/storage"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	aws_session "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/letsencrypt/prio-server/workflow-manager/tokenfetcher"
 	"google.golang.org/api/iterator"
 )
+
+// TaskMarkerWriter allows writing of a task marker to some storage
+type TaskMarkerWriter interface {
+	WriteTaskMarker(marker string) error
+}
 
 // Bucket represents a general bucket of data
 type Bucket struct {
@@ -25,12 +27,14 @@ type Bucket struct {
 	// bucketName includes the region for S3
 	bucketName string
 	identity   string
+	dryRun     bool
 }
 
-// New creates a new Bucket from a URL and identity
-func New(bucketURL, identity string) (*Bucket, error) {
+// New creates a new Bucket from a URL and identity. If dryRun is true, then any
+// operations with side effects will not actually be performed.
+func New(bucketURL, identity string, dryRun bool) (*Bucket, error) {
 	if bucketURL == "" {
-		log.Fatalf("empty Bucket URL")
+		return nil, fmt.Errorf("empty Bucket URL")
 	}
 	if !strings.HasPrefix(bucketURL, "s3://") && !strings.HasPrefix(bucketURL, "gs://") {
 		return nil, fmt.Errorf("invalid Bucket %q with identity %q", bucketURL, identity)
@@ -39,63 +43,77 @@ func New(bucketURL, identity string) (*Bucket, error) {
 		return nil, fmt.Errorf("workflow-manager doesn't support alternate identities (%s) for gs:// Bucket (%q)",
 			identity, bucketURL)
 	}
+
 	return &Bucket{
 		service:    bucketURL[0:2],
 		bucketName: bucketURL[5:],
 		identity:   identity,
+		dryRun:     dryRun,
 	}, nil
 }
 
 // ListFiles lists the files contained in Bucket
-func (b *Bucket) ListFiles(ctx context.Context) ([]string, error) {
+func (b *Bucket) ListFiles() ([]string, error) {
 	switch b.service {
 	case "s3":
-		return b.listFilesS3(ctx)
+		return b.listFilesS3()
 	case "gs":
-		return b.listFilesGS(ctx)
+		return b.listFilesGS()
 	default:
 		return nil, fmt.Errorf("invalid storage service %q", b.service)
 	}
 }
 
-func webIDP(sess *aws_session.Session, identity string) (*credentials.Credentials, error) {
-	parsed, err := arn.Parse(identity)
+// WriteTaskMarker writes a marker for a scheduled task, which is an object in
+// the bucket whose key is "task-markers/${marker}". This works as a guard
+// against redundant tasks because both Amazon S3 and Google Cloud Storage offer
+// strong read-after-write consistency.
+//
+// https://aws.amazon.com/s3/consistency/
+// https://cloud.google.com/storage/docs/consistency
+func (b *Bucket) WriteTaskMarker(marker string) error {
+	markerObject := fmt.Sprintf("task-markers/%s", marker)
+	switch b.service {
+	case "s3":
+		return b.writeTaskMarkerS3(markerObject)
+	case "gs":
+		return b.writeTaskMarkerGS(markerObject)
+	default:
+		return fmt.Errorf("invalid storage service %q", b.service)
+	}
+}
+
+func parseS3BucketName(bucketName string) (string, string, error) {
+	parts := strings.SplitN(bucketName, "/", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid S3 Bucket name %q", bucketName)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func (b *Bucket) s3Service(region string) (*s3.S3, error) {
+	sess, config, err := leaws.ClientConfig(region, b.identity)
 	if err != nil {
 		return nil, err
 	}
-	audience := fmt.Sprintf("sts.amazonaws.com/%s", parsed.AccountID)
 
-	stsSTS := sts.New(sess)
-	roleSessionName := ""
-	roleProvider := stscreds.NewWebIdentityRoleProviderWithToken(
-		stsSTS, identity, roleSessionName, tokenfetcher.NewTokenFetcher(audience))
-
-	return credentials.NewCredentials(roleProvider), nil
+	return s3.New(sess, config), nil
 }
 
-func (b *Bucket) listFilesS3(ctx context.Context) ([]string, error) {
-	parts := strings.SplitN(b.bucketName, "/", 2)
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid S3 Bucket name %q", b.bucketName)
-	}
-	region := parts[0]
-	bucket := parts[1]
-	sess, err := aws_session.NewSession()
+func (b *Bucket) listFilesS3() ([]string, error) {
+	region, bucket, err := parseS3BucketName(b.bucketName)
 	if err != nil {
-		return nil, fmt.Errorf("making AWS session: %w", err)
+		return nil, err
 	}
 
 	log.Printf("listing files in s3://%s as %q", bucket, b.identity)
-	config := aws.NewConfig().
-		WithRegion(region)
-	if b.identity != "" {
-		creds, err := webIDP(sess, b.identity)
-		if err != nil {
-			return nil, err
-		}
-		config = config.WithCredentials(creds)
+
+	svc, err := b.s3Service(region)
+	if err != nil {
+		return nil, err
 	}
-	svc := s3.New(sess, config)
+
 	var output []string
 	var nextContinuationToken = ""
 	for {
@@ -121,13 +139,55 @@ func (b *Bucket) listFilesS3(ctx context.Context) ([]string, error) {
 	return output, nil
 }
 
-func (b *Bucket) listFilesGS(ctx context.Context) ([]string, error) {
+func (b *Bucket) writeTaskMarkerS3(marker string) error {
+	region, bucket, err := parseS3BucketName(b.bucketName)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("writing task marker to s3://%s/%s as %q", bucket, marker, b.identity)
+
+	if b.dryRun {
+		log.Printf("dry run, skipping marker write")
+		return nil
+	}
+
+	svc, err := b.s3Service(region)
+	if err != nil {
+		return err
+	}
+	input := &s3.PutObjectInput{
+		// Doesn't matter what the file contents are, but use the task name just
+		// in case S3 balks at an empty body
+		Body:   aws.ReadSeekCloser(strings.NewReader(marker)),
+		Bucket: aws.String(bucket),
+		Key:    aws.String(marker),
+	}
+
+	// Deliberately ignore the result, we only care if the write succeeds
+	if _, err := svc.PutObject(input); err != nil {
+		return fmt.Errorf("storage.PutObject: %w", err)
+	}
+
+	return nil
+}
+
+func (b *Bucket) gcsClient() (*storage.Client, error) {
 	if b.identity != "" {
 		return nil, fmt.Errorf("workflow-manager doesn't support non-default identity %q for GS Bucket %q", b.identity, b.bucketName)
 	}
-	client, err := storage.NewClient(ctx)
+	client, err := storage.NewClient(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("storage.newClient: %w", err)
+	}
+
+	return client, nil
+}
+
+func (b *Bucket) listFilesGS() ([]string, error) {
+	client, err := b.gcsClient()
+	if err != nil {
+		return nil, err
 	}
 
 	bkt := client.Bucket(b.bucketName)
@@ -135,7 +195,7 @@ func (b *Bucket) listFilesGS(ctx context.Context) ([]string, error) {
 
 	log.Printf("looking for ready batches in gs://%s as (ambient service account)", b.bucketName)
 	var output []string
-	it := bkt.Objects(ctx, query)
+	it := bkt.Objects(context.Background(), query)
 
 	// Use the paginated API to list Bucket contents, as otherwise we would only
 	// get the first 1,000 objects in the Bucket.
@@ -160,4 +220,38 @@ func (b *Bucket) listFilesGS(ctx context.Context) ([]string, error) {
 	}
 
 	return output, nil
+}
+
+func (b *Bucket) writeTaskMarkerGS(marker string) error {
+	client, err := b.gcsClient()
+	if err != nil {
+		return err
+	}
+
+	bkt := client.Bucket(b.bucketName)
+
+	log.Printf("writing task marker to gs://%s/%s as (ambient service account)",
+		b.bucketName, marker)
+
+	if b.dryRun {
+		log.Printf("dry run, skipping marker write")
+		return nil
+	}
+
+	object := bkt.Object(marker)
+	writer := object.NewWriter(context.Background())
+	_, err = io.WriteString(writer, marker)
+	if err != nil {
+		writer.Close()
+		return fmt.Errorf("failed to write marker to GCS: %w", err)
+	}
+
+	// If writes to GCS fail, we won't find out until we call Close, so we don't
+	// defer in order to check the error
+	// https://godoc.org/cloud.google.com/go/storage#Writer.Write
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("failed to close GCS writer: %w", err)
+	}
+
+	return nil
 }

--- a/workflow-manager/go.mod
+++ b/workflow-manager/go.mod
@@ -3,6 +3,7 @@ module github.com/letsencrypt/prio-server/workflow-manager
 go 1.15
 
 require (
+	cloud.google.com/go/pubsub v1.3.1
 	cloud.google.com/go/storage v1.12.0
 	github.com/aws/aws-sdk-go v1.35.16
 	github.com/prometheus/client_golang v1.8.0

--- a/workflow-manager/go.sum
+++ b/workflow-manager/go.sum
@@ -28,6 +28,7 @@ cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
+cloud.google.com/go/pubsub v1.3.1 h1:ukjixP1wl0LpnZ6LWtZJ0mX5tBmjp1f8Sqer8Z2OMUU=
 cloud.google.com/go/pubsub v1.3.1/go.mod h1:i+ucay31+CNRpDW4Lu78I4xXG+O1r/MAHgjpRVR+TSU=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
@@ -187,6 +188,7 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
@@ -242,6 +244,7 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
@@ -386,6 +389,7 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
@@ -514,6 +518,7 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/workflow-manager/kubernetes/kubernetes.go
+++ b/workflow-manager/kubernetes/kubernetes.go
@@ -1,0 +1,78 @@
+// package kubernetes contains utilities related to Kubernetes Jobs
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type Client struct {
+	client    *kubernetes.Clientset
+	namespace string
+	dryRun    bool
+}
+
+// Client returns a Clientset that uses the credentials that an instance running
+// in the k8s cluster gets automatically, via automount_service_account_token in
+// the Terraform config, or the credentials in the provided kube config file, if
+// it is not empty. If dryRun is true, then any destructive API calls will be
+// made with DryRun: All.
+func NewClient(namespace string, kubeconfigPath string, dryRun bool) (*Client, error) {
+	// BuildConfigFromFlags falls back to rest.InClusterConfig if kubeconfigPath
+	// is empty
+	// https://godoc.org/k8s.io/client-go/tools/clientcmd#BuildConfigFromFlags
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("cluster config: %w", err)
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("clientset: %w", err)
+	}
+
+	return &Client{
+		client:    client,
+		namespace: namespace,
+		dryRun:    dryRun,
+	}, nil
+}
+
+// ListJobs returns a map of Kubernetes jobs in the specified namespace, where
+// the key is the name of the job and the value is the job structure, or an
+// error on failure.
+func (c *Client) ListJobs() (map[string]batchv1.Job, error) {
+	jobs := map[string]batchv1.Job{}
+
+	// The jobs list API is paginated. We request 1000 entries at a time. If
+	// there are more entries, the response will contain a continue token to
+	// provide on subsequent requests.
+	continueToken := ""
+	for {
+		jobsList, err := c.client.BatchV1().Jobs(c.namespace).List(context.Background(), metav1.ListOptions{
+			Limit:    1000,
+			Continue: continueToken,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list jobs in namespace: %w", err)
+		}
+
+		for _, job := range jobsList.Items {
+			jobs[job.Name] = job
+		}
+
+		if jobsList.Continue == "" {
+			break
+		}
+
+		continueToken = jobsList.Continue
+	}
+
+	return jobs, nil
+}

--- a/workflow-manager/main_test.go
+++ b/workflow-manager/main_test.go
@@ -1,8 +1,17 @@
 package main
 
 import (
-	"github.com/letsencrypt/prio-server/workflow-manager/batchpath"
+	"fmt"
+	"reflect"
 	"testing"
+	"time"
+
+	"github.com/letsencrypt/prio-server/workflow-manager/batchpath"
+	"github.com/letsencrypt/prio-server/workflow-manager/task"
+	"github.com/letsencrypt/prio-server/workflow-manager/utils"
+
+	batchv1 "k8s.io/api/batch/v1"
+	_ "k8s.io/api/core/v1"
 )
 
 func TestIntakeJobNameForBatchPath(t *testing.T) {
@@ -47,5 +56,476 @@ func TestAggregationJobNameFragment(t *testing.T) {
 	expected := "foobar-01234567890123456789012"
 	if id != expected {
 		t.Errorf("expected id %q, got %q", expected, id)
+	}
+}
+
+type mockEnqueuer struct {
+	enqueuedTasks []task.Task
+}
+
+func (e *mockEnqueuer) Enqueue(task task.Task, completion func(error)) {
+	e.enqueuedTasks = append(e.enqueuedTasks, task)
+	completion(nil)
+}
+
+func (e *mockEnqueuer) Stop() {}
+
+type mockBucket struct {
+	writtenObjectKeys []string
+}
+
+func (b *mockBucket) WriteTaskMarker(marker string) error {
+	b.writtenObjectKeys = append(b.writtenObjectKeys, fmt.Sprintf("task-markers/%s", marker))
+	return nil
+}
+
+func TestScheduleIntakeTasks(t *testing.T) {
+	batchTime, _ := time.Parse("2006/01/02/15/04", "2020/10/31/20/29")
+	within24Hours, _ := time.Parse("2006/01/02/15/04", "2020/10/31/23/29")
+	tooLate, _ := time.Parse("2006/01/02/15/04", "2020/11/02/20/29")
+	maxAge, _ := time.ParseDuration("24h")
+	aggregationPeriod, _ := time.ParseDuration("8h")
+	gracePeriod, _ := time.ParseDuration("4h")
+	intakeMarker := "task-markers/intake-kittens-seen-2020-10-31-20-29-b8a5579a-f984-460a-a42d-2813cbf57771"
+	existingJob := "i-kittens-seen-b8a5579af984460a-2020-10-31-20-29"
+
+	var testCases = []struct {
+		name               string
+		jobExists          bool
+		taskMarkerExists   bool
+		now                time.Time
+		expectedIntakeTask *task.IntakeBatch
+		expectedTaskMarker string
+	}{
+		{
+			name:               "old-batch-no-job-no-marker",
+			jobExists:          false,
+			taskMarkerExists:   false,
+			now:                tooLate,
+			expectedIntakeTask: nil,
+			expectedTaskMarker: "",
+		},
+		{
+			name:               "old-batch-no-job-has-marker",
+			jobExists:          false,
+			taskMarkerExists:   true,
+			now:                tooLate,
+			expectedIntakeTask: nil,
+			expectedTaskMarker: "",
+		},
+		{
+			name:               "old-batch-has-job-no-marker",
+			jobExists:          true,
+			taskMarkerExists:   false,
+			now:                tooLate,
+			expectedIntakeTask: nil,
+			expectedTaskMarker: "",
+		},
+		{
+			name:               "old-batch-has-job-has-marker",
+			jobExists:          true,
+			taskMarkerExists:   false,
+			now:                tooLate,
+			expectedIntakeTask: nil,
+			expectedTaskMarker: "",
+		},
+		{
+			name:             "current-batch-no-job-no-marker",
+			jobExists:        false,
+			taskMarkerExists: false,
+			now:              within24Hours,
+			expectedIntakeTask: &task.IntakeBatch{
+				AggregationID: "kittens-seen",
+				BatchID:       "b8a5579a-f984-460a-a42d-2813cbf57771",
+				Date:          task.Timestamp(batchTime),
+			},
+			expectedTaskMarker: intakeMarker,
+		},
+		{
+			name:               "current-batch-no-job-has-marker",
+			jobExists:          false,
+			taskMarkerExists:   true,
+			now:                within24Hours,
+			expectedIntakeTask: nil,
+			expectedTaskMarker: "",
+		},
+		{
+			name:               "current-batch-has-job-no-marker",
+			jobExists:          true,
+			taskMarkerExists:   false,
+			now:                within24Hours,
+			expectedIntakeTask: nil,
+			expectedTaskMarker: intakeMarker,
+		},
+		{
+			name:               "current-batch-has-job-has-marker",
+			jobExists:          true,
+			taskMarkerExists:   true,
+			now:                within24Hours,
+			expectedIntakeTask: nil,
+			expectedTaskMarker: "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			clock := utils.ClockWithFixedNow(testCase.now)
+
+			ownValidationFiles := []string{}
+			if testCase.taskMarkerExists {
+				ownValidationFiles = append(ownValidationFiles, intakeMarker)
+			}
+
+			peerValidationFiles := []string{}
+
+			existingJobs := map[string]batchv1.Job{}
+			if testCase.jobExists {
+				existingJobs[existingJob] = batchv1.Job{}
+			}
+
+			intakeTaskEnqueuer := mockEnqueuer{enqueuedTasks: []task.Task{}}
+			aggregateTaskEnqueuer := mockEnqueuer{enqueuedTasks: []task.Task{}}
+			ownValidationBucket := mockBucket{writtenObjectKeys: []string{}}
+
+			scheduleTasks(scheduleTasksConfig{
+				isFirst: false,
+				clock:   clock,
+				intakeFiles: []string{
+					"kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771.batch",
+					"kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771.batch.avro",
+					"kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771.batch.sig",
+				},
+				ownValidationFiles:      ownValidationFiles,
+				peerValidationFiles:     peerValidationFiles,
+				existingJobs:            existingJobs,
+				intakeTaskEnqueuer:      &intakeTaskEnqueuer,
+				aggregationTaskEnqueuer: &aggregateTaskEnqueuer,
+				ownValidationBucket:     &ownValidationBucket,
+				maxAge:                  maxAge,
+				aggregationPeriod:       aggregationPeriod,
+				gracePeriod:             gracePeriod,
+			})
+
+			if testCase.expectedIntakeTask == nil {
+				if len(intakeTaskEnqueuer.enqueuedTasks) != 0 {
+					t.Errorf("unexpected intake tasks scheduled: %q", intakeTaskEnqueuer.enqueuedTasks)
+				}
+			} else {
+				foundExpectedTask := false
+				for _, task := range intakeTaskEnqueuer.enqueuedTasks {
+					if reflect.DeepEqual(task, *testCase.expectedIntakeTask) {
+						foundExpectedTask = true
+						break
+					}
+				}
+				if !foundExpectedTask {
+					t.Errorf("did not find expected intake task %+v among %q", testCase.expectedIntakeTask, intakeTaskEnqueuer.enqueuedTasks)
+				}
+			}
+
+			if len(aggregateTaskEnqueuer.enqueuedTasks) != 0 {
+				t.Errorf("unexpected aggregation tasks scheduled: %q", aggregateTaskEnqueuer.enqueuedTasks)
+			}
+
+			if testCase.expectedTaskMarker == "" {
+				if len(ownValidationBucket.writtenObjectKeys) != 0 {
+					t.Errorf("unexpected task marker written: %q", ownValidationBucket.writtenObjectKeys)
+				}
+			} else {
+				foundExpectedMarker := false
+				for _, object := range ownValidationBucket.writtenObjectKeys {
+					if object == testCase.expectedTaskMarker {
+						foundExpectedMarker = true
+						break
+					}
+				}
+				if !foundExpectedMarker {
+					t.Errorf("did not find expected task marker among %q", ownValidationBucket.writtenObjectKeys)
+				}
+			}
+		})
+	}
+}
+
+func TestScheduleAggregationTasks(t *testing.T) {
+	batchTime, _ := time.Parse("2006/01/02/15/04", "2020/10/31/20/29")
+	aggregationStart, _ := time.Parse("2006/01/02/15/04", "2020/10/31/16/00")
+	aggregationEnd, _ := time.Parse("2006/01/02/15/04", "2020/11/01/00/00")
+	tooSoon, _ := time.Parse("2006/01/02/15/04", "2020/10/31/20/29")
+	tooLate, _ := time.Parse("2006/01/02/15/04", "2020/11/02/20/29")
+	withinWindow, _ := time.Parse("2006/01/02/15/04", "2020/11/01/04/01")
+	maxAge, _ := time.ParseDuration("24h")
+	aggregationPeriod, _ := time.ParseDuration("8h")
+	gracePeriod, _ := time.ParseDuration("4h")
+	aggregationMarker := "task-markers/aggregate-kittens-seen-2020-10-31-16-00-2020-11-01-00-00"
+	existingJob := "a-kittens-seen-2020-10-31-16-00"
+	expectedAggregationTask := &task.Aggregation{
+		AggregationID:    "kittens-seen",
+		AggregationStart: task.Timestamp(aggregationStart),
+		AggregationEnd:   task.Timestamp(aggregationEnd),
+		Batches: []task.Batch{
+			task.Batch{
+				ID:   "b8a5579a-f984-460a-a42d-2813cbf57771",
+				Time: task.Timestamp(batchTime),
+			},
+		},
+	}
+
+	var testCases = []struct {
+		name                    string
+		hasOwnValidation        bool
+		hasPeerValidation       bool
+		jobExists               bool
+		taskMarkerExists        bool
+		now                     time.Time
+		expectedAggregationTask *task.Aggregation
+		expectedTaskMarker      string
+	}{
+		{
+			name:                    "too-soon-no-job-no-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			jobExists:               false,
+			taskMarkerExists:        false,
+			now:                     tooSoon,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+		{
+			name:                    "too-soon-no-job-has-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			jobExists:               false,
+			taskMarkerExists:        true,
+			now:                     tooSoon,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+		{
+			name:                    "too-soon-has-job-no-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			jobExists:               true,
+			taskMarkerExists:        false,
+			now:                     tooSoon,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+		{
+			name:                    "too-soon-has-job-has-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			jobExists:               true,
+			taskMarkerExists:        true,
+			now:                     tooSoon,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+		{
+			name:                    "too-late-no-job-no-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			jobExists:               false,
+			taskMarkerExists:        false,
+			now:                     tooLate,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+		{
+			name:                    "too-late-no-job-has-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			jobExists:               false,
+			taskMarkerExists:        true,
+			now:                     tooLate,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+		{
+			name:                    "too-late-has-job-no-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			jobExists:               true,
+			taskMarkerExists:        false,
+			now:                     tooLate,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+		{
+			name:                    "too-late-has-job-has-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			jobExists:               true,
+			taskMarkerExists:        true,
+			now:                     tooLate,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+		{
+			name:                    "within-window-no-own-no-peer",
+			hasOwnValidation:        false,
+			hasPeerValidation:       false,
+			jobExists:               false,
+			taskMarkerExists:        false,
+			now:                     withinWindow,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+		{
+			name:                    "within-window-no-own-has-peer",
+			hasOwnValidation:        false,
+			hasPeerValidation:       true,
+			jobExists:               false,
+			taskMarkerExists:        false,
+			now:                     withinWindow,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+		{
+			name:                    "within-window-has-own-no-peer",
+			hasOwnValidation:        true,
+			hasPeerValidation:       false,
+			jobExists:               false,
+			taskMarkerExists:        false,
+			now:                     withinWindow,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+		{
+			name:                    "within-window-no-job-no-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			jobExists:               false,
+			taskMarkerExists:        false,
+			now:                     withinWindow,
+			expectedAggregationTask: expectedAggregationTask,
+			expectedTaskMarker:      aggregationMarker,
+		},
+		{
+			name:                    "within-window-no-job-has-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			jobExists:               false,
+			taskMarkerExists:        true,
+			now:                     withinWindow,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+		{
+			name:                    "within-window-has-job-no-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			jobExists:               true,
+			taskMarkerExists:        false,
+			now:                     withinWindow,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      aggregationMarker,
+		},
+		{
+			name:                    "within-window-has-job-has-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			jobExists:               true,
+			taskMarkerExists:        true,
+			now:                     withinWindow,
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			clock := utils.ClockWithFixedNow(testCase.now)
+
+			ownValidationFiles := []string{
+				"task-markers/intake-kittens-seen-2020-10-31-20-29-b8a5579a-f984-460a-a42d-2813cbf57771",
+			}
+			if testCase.hasOwnValidation {
+				ownValidationFiles = append(ownValidationFiles, []string{
+					"kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771.validity_1",
+					"kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771.validity_1.avro",
+					"kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771.validity_1.sig",
+				}...)
+			}
+
+			if testCase.taskMarkerExists {
+				ownValidationFiles = append(ownValidationFiles, aggregationMarker)
+			}
+
+			peerValidationFiles := []string{}
+			if testCase.hasPeerValidation {
+				peerValidationFiles = []string{
+					"kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771.validity_0",
+					"kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771.validity_0.avro",
+					"kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771.validity_0.sig",
+				}
+			}
+
+			existingJobs := map[string]batchv1.Job{}
+			if testCase.jobExists {
+				existingJobs[existingJob] = batchv1.Job{}
+			}
+
+			intakeTaskEnqueuer := mockEnqueuer{enqueuedTasks: []task.Task{}}
+			aggregateTaskEnqueuer := mockEnqueuer{enqueuedTasks: []task.Task{}}
+			ownValidationBucket := mockBucket{writtenObjectKeys: []string{}}
+
+			scheduleTasks(scheduleTasksConfig{
+				isFirst: false,
+				clock:   clock,
+				intakeFiles: []string{
+					"kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771.batch",
+					"kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771.batch.avro",
+					"kittens-seen/2020/10/31/20/29/b8a5579a-f984-460a-a42d-2813cbf57771.batch.sig",
+				},
+				ownValidationFiles:      ownValidationFiles,
+				peerValidationFiles:     peerValidationFiles,
+				existingJobs:            existingJobs,
+				intakeTaskEnqueuer:      &intakeTaskEnqueuer,
+				aggregationTaskEnqueuer: &aggregateTaskEnqueuer,
+				ownValidationBucket:     &ownValidationBucket,
+				maxAge:                  maxAge,
+				aggregationPeriod:       aggregationPeriod,
+				gracePeriod:             gracePeriod,
+			})
+
+			if len(intakeTaskEnqueuer.enqueuedTasks) != 0 {
+				t.Errorf("unexpected intake tasks scheduled: %q", intakeTaskEnqueuer.enqueuedTasks)
+			}
+
+			if testCase.expectedAggregationTask == nil {
+				if len(aggregateTaskEnqueuer.enqueuedTasks) != 0 {
+					t.Errorf("unexpected aggregation tasks scheduled: %q", aggregateTaskEnqueuer.enqueuedTasks)
+				}
+			} else {
+				foundExpectedTask := false
+				for _, task := range aggregateTaskEnqueuer.enqueuedTasks {
+					if reflect.DeepEqual(task, *testCase.expectedAggregationTask) {
+						foundExpectedTask = true
+						break
+					}
+				}
+				if !foundExpectedTask {
+					t.Errorf("did not find expected aggregate task among %q", aggregateTaskEnqueuer.enqueuedTasks)
+				}
+			}
+
+			if testCase.expectedTaskMarker == "" {
+				if len(ownValidationBucket.writtenObjectKeys) != 0 {
+					t.Errorf("unexpected task marker written: %q", ownValidationBucket.writtenObjectKeys)
+				}
+			} else {
+				foundExpectedMarker := false
+				for _, object := range ownValidationBucket.writtenObjectKeys {
+					if object == testCase.expectedTaskMarker {
+						foundExpectedMarker = true
+						break
+					}
+				}
+				if !foundExpectedMarker {
+					t.Errorf("did not find expected task marker among %q", ownValidationBucket.writtenObjectKeys)
+				}
+			}
+		})
 	}
 }

--- a/workflow-manager/task/task.go
+++ b/workflow-manager/task/task.go
@@ -1,0 +1,253 @@
+// package task contains representations of tasks that are sent to facilitator
+// workers by workflow-manager. A _task_ is a work item at the data share
+// processor application layer (i.e., intake of a batch or aggregation of many
+// batches); its name is chosen to distinguish from Kubernetes-level _jobs_.
+package task
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	leaws "github.com/letsencrypt/prio-server/workflow-manager/aws"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sns"
+)
+
+// Timestamp is an alias to time.Time with a custom JSON marshaler that
+// marshals the time to UTC, with minute precision, in the format
+// "2006/01/02/15/04"
+type Timestamp time.Time
+
+func (t Timestamp) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
+}
+
+func (t *Timestamp) stringWithFormat(format string) string {
+	asTime := (*time.Time)(t)
+	return asTime.Format(format)
+}
+
+func (t *Timestamp) String() string {
+	return t.stringWithFormat("2006/01/02/15/04")
+}
+
+// Returns the representation of the timestamp as it should be incorporated into
+// a task marker
+func (t *Timestamp) MarkerString() string {
+	return t.stringWithFormat("2006-01-02-15-04")
+}
+
+// Task is a task that can be enqueued into an Enqueuer
+type Task interface {
+	// Marker returns the name that should be used when writing out a marker for
+	// this task
+	Marker() string
+}
+
+// Aggregation represents an aggregation task
+type Aggregation struct {
+	// AggregationID is the identifier for the aggregation
+	AggregationID string `json:"aggregation-id"`
+	// AggregationStart is the start of the range of time covered by the
+	// aggregation
+	AggregationStart Timestamp `json:"aggregation-start"`
+	// AggregationEnd is the end of the range of time covered by the aggregation
+	AggregationEnd Timestamp `json:"aggregation-end"`
+	// Batches is the list of batch ID date pairs of the batches aggregated by
+	// this task
+	Batches []Batch `json:"batches"`
+}
+
+func (a Aggregation) Marker() string {
+	return fmt.Sprintf(
+		"aggregate-%s-%s-%s",
+		a.AggregationID,
+		a.AggregationStart.MarkerString(),
+		a.AggregationEnd.MarkerString(),
+	)
+}
+
+// Batch represents a batch included in an aggregation task
+type Batch struct {
+	// ID is the batch ID. Typically a UUID.
+	ID string `json:"id"`
+	// Time is the timestamp on the batch
+	Time Timestamp `json:"time"`
+}
+
+type IntakeBatch struct {
+	// AggregationID is the identifier for the aggregaton
+	AggregationID string `json:"aggregation-id"`
+	// BatchID is the identifier of the batch. Typically a UUID.
+	BatchID string `json:"batch-id"`
+	// Date is the timestamp on the batch
+	Date Timestamp `json:"date"`
+}
+
+func (i IntakeBatch) Marker() string {
+	return fmt.Sprintf("intake-%s-%s-%s", i.AggregationID, i.Date.MarkerString(), i.BatchID)
+}
+
+// Enqueuer allows enqueuing tasks.
+type Enqueuer interface {
+	// Enqueue enqueues a task to be executed later. The provided completion
+	// function will be invoked once the task is either successfully enqueued or
+	// some unretryable error has occurred. A call to Stop() will not return
+	// until completion functions passed to any and all calls to Enqueue() have
+	// returned.
+	Enqueue(task Task, completion func(error))
+	// Stop blocks until all tasks passed to Enqueue() have been enqueued in the
+	// underlying system, and all completion functions pased to Enqueue() have
+	// returned, and so it is safe to exit the program without losing any tasks.
+	Stop()
+}
+
+// CreatePubSubTopic creates a PubSub topic with the provided ID, as well as a
+// subscription with the same ID that can later be used by a facilitator.
+// Returns error on failure.
+func CreatePubSubTopic(project string, topicID string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	client, err := pubsub.NewClient(ctx, project)
+	if err != nil {
+		return fmt.Errorf("pubsub.newClient: %w", err)
+	}
+
+	topic, err := client.CreateTopic(ctx, topicID)
+	if err != nil {
+		return fmt.Errorf("pubsub.CreateTopic: %w", err)
+	}
+
+	tenMinutes, _ := time.ParseDuration("10m")
+
+	subscriptionConfig := pubsub.SubscriptionConfig{
+		Topic:            topic,
+		AckDeadline:      tenMinutes,
+		ExpirationPolicy: time.Duration(0), // never expire
+	}
+	if _, err := client.CreateSubscription(ctx, topicID, subscriptionConfig); err != nil {
+		return fmt.Errorf("pubsub.CreateSubscription: %w", err)
+	}
+
+	return nil
+}
+
+// GCPPubSubEnqueuer implements Enqueuer using GCP PubSub
+type GCPPubSubEnqueuer struct {
+	topic     *pubsub.Topic
+	waitGroup sync.WaitGroup
+	dryRun    bool
+}
+
+// NewGCPPubSubEnqueuer creates a task enqueuer for a given project and topic
+// in GCP PubSub. If dryRun is true, no tasks will actually be enqueued. Clients
+// should re-use a single instance as much as possible to enable batching of
+// publish requests.
+func NewGCPPubSubEnqueuer(project string, topicID string, dryRun bool) (*GCPPubSubEnqueuer, error) {
+	client, err := pubsub.NewClient(context.Background(), project)
+	if err != nil {
+		return nil, fmt.Errorf("pubsub.NewClient: %w", err)
+	}
+
+	return &GCPPubSubEnqueuer{
+		topic:  client.Topic(topicID),
+		dryRun: dryRun,
+	}, nil
+}
+
+func (e *GCPPubSubEnqueuer) Enqueue(task Task, completion func(error)) {
+	e.waitGroup.Add(1)
+	go func(task Task) {
+		defer e.waitGroup.Done()
+		jsonTask, err := json.Marshal(task)
+		if err != nil {
+			completion(fmt.Errorf("marshaling task to JSON: %w", err))
+			return
+		}
+
+		if e.dryRun {
+			log.Printf("dry run, not enqueuing task")
+			completion(nil)
+			return
+		}
+
+		// Publish() returns immediately, giving us a handle to the result that we
+		// can block on to see if publishing succeeded. The PubSub client
+		// automatically retries for us, so we just keep the handle so the caller
+		// can do whatever they need to after successful publication and we can
+		// block in Stop() until all tasks have been enqueued
+		res := e.topic.Publish(context.Background(), &pubsub.Message{Data: jsonTask})
+		if _, err := res.Get(context.Background()); err != nil {
+			completion(fmt.Errorf("Failed to publish task %+v: %w", task, err))
+		}
+
+		completion(nil)
+	}(task)
+}
+
+func (e *GCPPubSubEnqueuer) Stop() {
+	e.waitGroup.Wait()
+}
+
+// AWSSNSEnqueuer implements Enqueuer using AWS SNS
+type AWSSNSEnqueuer struct {
+	service   *sns.SNS
+	topicARN  string
+	waitGroup sync.WaitGroup
+	dryRun    bool
+}
+
+func NewAWSSNSEnqueuer(region, identity, topicARN string, dryRun bool) (*AWSSNSEnqueuer, error) {
+	session, config, err := leaws.ClientConfig(region, identity)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AWSSNSEnqueuer{
+		service:  sns.New(session, config),
+		topicARN: topicARN,
+		dryRun:   dryRun,
+	}, nil
+}
+
+func (e *AWSSNSEnqueuer) Enqueue(task Task, completion func(error)) {
+	// sns.Publish() blocks until the message has been saved by SNS, so no need
+	// to asynchronously handle completion. However we still want to maintain
+	// the guarantee that Stop() will block until all pending calls to Enqueue()
+	// complete, so we still use a waitgroup.
+	e.waitGroup.Add(1)
+	defer e.waitGroup.Done()
+
+	jsonTask, err := json.Marshal(task)
+	if err != nil {
+		completion(fmt.Errorf("marshaling task to JSON: %w", err))
+		return
+	}
+
+	if e.dryRun {
+		log.Printf("dry run, not enqueuing task")
+		completion(nil)
+		return
+	}
+	// There's nothing in the PublishOutput we care about, so we discard it.
+	_, err = e.service.Publish(&sns.PublishInput{
+		TopicArn: aws.String(e.topicARN),
+		Message:  aws.String(string(jsonTask)),
+	})
+	if err != nil {
+		completion(fmt.Errorf("failed to publish task %+v: %w", task, err))
+		return
+	}
+
+	completion(nil)
+}
+
+func (e *AWSSNSEnqueuer) Stop() {
+	e.waitGroup.Wait()
+}

--- a/workflow-manager/utils/utils.go
+++ b/workflow-manager/utils/utils.go
@@ -1,5 +1,9 @@
 package utils
 
+import (
+	"time"
+)
+
 // Index returns the appropriate int to use in construction of filenames
 // based on whether the file creator was the "first" aka PHA server.
 func Index(isFirst bool) int {
@@ -7,4 +11,27 @@ func Index(isFirst bool) int {
 		return 0
 	}
 	return 1
+}
+
+// Clock allows mocking of time for testing purposes
+type Clock struct {
+	now time.Time
+}
+
+// DefaultClock reutrns a Clock that returns the real time from time.Now
+func DefaultClock() Clock {
+	return Clock{}
+}
+
+// ClockWithFixedNow returns a Clock that always returns the provided now
+func ClockWithFixedNow(now time.Time) Clock {
+	return Clock{now: now}
+}
+
+// Now returns the current time according to this clock
+func (c *Clock) Now() time.Time {
+	if c.now.IsZero() {
+		return time.Now()
+	}
+	return c.now
 }


### PR DESCRIPTION
This pull request implements a publisher/subscriber task model as we discussed on December 23rd. Note that I use the word _task_ to disambiguate from Kubernetes _jobs_.

 - `workflow-manager` is still a cronjob and still scans buckets for work to do, but now schedules tasks by publishing to PubSub topics. We use distinct topics for intake and aggregation.
 - `facilitator` has two new entry points, `intake-batch-worker` and `aggregate-worker`, that poll PubSub subscriptions in a loop for tasks to execute.
 - On the Terraform side, we now create a PubSub topic and subscription for intake and aggregation for each ingestor/locality pair. Correspondingly, we create a Kubernetes deployment for each subscription that dequeues tasks.
 - The deployments run a number of persistent replicas instead of having many, many individual jobs. The deployments can be scaled independently from each other by tuning the desired replica count.
 - We now have a staging environment, composed of the `staging-pha` and `staging-facil` environments for which I added .tfvars files. I'd like future releases of the application to bake in staging for some interval of time (at least long enough to run an aggregation) but I have no concrete plans around release flows or testing plans at the moment.
- Experimental support for task queues based on publishing to an SNS topic and pulling messages from an SQS queue subscribed to that topic. These implementations compile but have not been tested.