### PR TITLE
workflow-manager: ignore task markers

### DIFF
--- a/workflow-manager/batchpath/batchpath.go
+++ b/workflow-manager/batchpath/batchpath.go
@@ -94,6 +94,10 @@ func (b *BatchPath) isComplete() bool {
 func ReadyBatches(files []string, infix string) (List, error) {
 	batches := make(map[string]*BatchPath)
 	for _, name := range files {
+		// Ignore task marker objects
+		if strings.HasPrefix(name, "task-markers/") {
+			continue
+		}
 		basename := basename(name, infix)
 		b := batches[basename]
 		var err error


### PR DESCRIPTION
The new version of workflow-manager introduced in #292 writes out task
marker objects to the own validation bucket to track which intake and
aggregation tasks have been scheduled. This commit teaches the old
version of workflow-manager to gracefully ignore any such files, to give
us something safe to roll back to in case deploying #292 to production
fails in such a way that leaves task markers behind.