### PR TITLE
workflow-manager: add timeouts to context.Contexts

### DIFF
--- a/workflow-manager/kubernetes/kubernetes.go
+++ b/workflow-manager/kubernetes/kubernetes.go
@@ -2,8 +2,9 @@
 package kubernetes
 
 import (
-	"context"
 	"fmt"
+
+	"github.com/letsencrypt/prio-server/workflow-manager/utils"
 
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,7 +56,9 @@ func (c *Client) ListJobs() (map[string]batchv1.Job, error) {
 	// provide on subsequent requests.
 	continueToken := ""
 	for {
-		jobsList, err := c.client.BatchV1().Jobs(c.namespace).List(context.Background(), metav1.ListOptions{
+		ctx, cancel := utils.ContextWithTimeout()
+		defer cancel()
+		jobsList, err := c.client.BatchV1().Jobs(c.namespace).List(ctx, metav1.ListOptions{
 			Limit:    1000,
 			Continue: continueToken,
 		})

--- a/workflow-manager/utils/utils.go
+++ b/workflow-manager/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"time"
 )
 
@@ -11,6 +12,10 @@ func Index(isFirst bool) int {
 		return 0
 	}
 	return 1
+}
+
+func ContextWithTimeout() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 30*time.Second)
 }
 
 // Clock allows mocking of time for testing purposes


### PR DESCRIPTION
use context.Context to set a 30s timeout on GCP and Kubernetes API
calls.