### PR TITLE
terraform: configure worker pools and pin 0.6.0

### DIFF
--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -13,17 +13,43 @@ ingestors = {
   apple = {
     manifest_base_url = "exposure-notification.apple.com/manifest"
     localities = {
-      us-ct = {
+      aq-aq = {
         intake_worker_count    = 1
         aggregate_worker_count = 1
+      }
+      ta-ta = {
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
+      }
+      us-ct = {
+        intake_worker_count    = 5
+        aggregate_worker_count = 3
+      }
+      us-md = {
+        intake_worker_count    = 5
+        aggregate_worker_count = 3
       }
     }
   }
   g-enpa = {
     manifest_base_url = "storage.googleapis.com/prio-manifests"
-    us-ct = {
-      intake_worker_count    = 1
-      aggregate_worker_count = 1
+    localities = {
+      aq-aq = {
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
+      }
+      ta-ta = {
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
+      }
+      us-ct = {
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
+      }
+      us-md = {
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
+      }
     }
   }
 }
@@ -33,6 +59,6 @@ is_first                               = false
 use_aws                                = false
 aggregation_period                     = "8h"
 aggregation_grace_period               = "4h"
-workflow_manager_version               = "0.5.2"
-facilitator_version                    = "0.5.2"
+workflow_manager_version               = "0.6.0"
+facilitator_version                    = "0.6.0"
 pushgateway                            = "prometheus-pushgateway.monitoring:9091"

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -51,7 +51,8 @@ test_peer_environment = {
   env_with_ingestor    = "staging-facil"
   env_without_ingestor = "staging-pha"
 }
-is_first           = false
-use_aws            = false
-container_registry = "us.gcr.io/prio-staging-300104"
-pushgateway        = "prometheus-pushgateway.monitoring:9091"
+is_first                 = false
+use_aws                  = false
+workflow_manager_version = "0.6.0"
+facilitator_version      = "0.6.0"
+pushgateway              = "prometheus-pushgateway.monitoring:9091"

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -51,7 +51,8 @@ test_peer_environment = {
   env_with_ingestor    = "staging-facil"
   env_without_ingestor = "staging-pha"
 }
-is_first           = true
-use_aws            = true
-container_registry = "us.gcr.io/prio-staging-300104"
-pushgateway        = "prometheus-pushgateway.monitoring:9091"
+is_first                 = true
+use_aws                  = true
+workflow_manager_version = "0.6.0"
+facilitator_version      = "0.6.0"
+pushgateway              = "prometheus-pushgateway.monitoring:9091"


### PR DESCRIPTION
Per estimates described in #300, this commit configures appropriately
sized worker pools for `us-ct` and `us-md`, and pins the `prod-us`
deployment to `prio-facilitator` and `prio-workflow-manager` 0.6.0.