### PR TITLE
terraform: adjust workflow-manager resource limits

### DIFF
--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -280,8 +280,8 @@ resource "kubernetes_cron_job" "workflow_manager" {
                   cpu    = "0.5"
                 }
                 limits {
-                  memory = "550Mi"
-                  cpu    = "0.7"
+                  memory = "2Gi"
+                  cpu    = "1.5"
                 }
               }
 


### PR DESCRIPTION
Raises memory and CPU limits for the workflow-manager so that long lists
of Kubernetes jobs and cloud storage bucket listings can fit safely in
memory. The CPU limits are raised just to let the workflow-manager go a
little faster, though realistically it's going to spend most of its time
waiting on API calls.