### PR TITLE
facilitator: extend task deadlines

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -8,7 +8,7 @@ use ring::signature::{
     EcdsaKeyPair, KeyPair, UnparsedPublicKey, ECDSA_P256_SHA256_ASN1,
     ECDSA_P256_SHA256_ASN1_SIGNING,
 };
-use std::{collections::HashMap, fs, fs::File, io::Read, str::FromStr};
+use std::{collections::HashMap, fs, fs::File, io::Read, str::FromStr, time::Instant};
 use uuid::Uuid;
 
 use facilitator::{
@@ -755,11 +755,12 @@ fn generate_sample(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-fn intake_batch(
+fn intake_batch<F: FnMut()>(
     aggregation_id: &str,
     batch_id: &str,
     date: &str,
     sub_matches: &ArgMatches,
+    callback: F,
 ) -> Result<(), anyhow::Error> {
     let mut intake_transport = intake_transport_from_args(sub_matches)?;
 
@@ -805,7 +806,7 @@ fn intake_batch(
         is_first_from_arg(sub_matches),
     )?;
 
-    batch_intaker.generate_validation_share()
+    batch_intaker.generate_validation_share(callback)
 }
 
 fn intake_batch_subcommand(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
@@ -814,6 +815,7 @@ fn intake_batch_subcommand(sub_matches: &ArgMatches) -> Result<(), anyhow::Error
         sub_matches.value_of("batch-id").unwrap(),
         sub_matches.value_of("date").unwrap(),
         sub_matches,
+        || {}, // no-op callback
     )
 }
 
@@ -837,11 +839,20 @@ fn intake_batch_worker(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
         if let Some(task_handle) = queue.dequeue()? {
             info!("dequeued task: {}", task_handle);
             intake_started.inc();
+            let task_start = Instant::now();
+
             let result = intake_batch(
                 &task_handle.task.aggregation_id,
                 &task_handle.task.batch_id,
                 &task_handle.task.date,
                 sub_matches,
+                || {
+                    if let Err(e) =
+                        queue.maybe_extend_task_deadline(&task_handle, &task_start.elapsed())
+                    {
+                        error!("{}", e);
+                    }
+                },
             );
 
             match result {
@@ -861,12 +872,13 @@ fn intake_batch_worker(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
     // unreachable
 }
 
-fn aggregate(
+fn aggregate<F: FnMut()>(
     aggregation_id: &str,
     start: &str,
     end: &str,
     batches: Vec<(&str, &str)>,
     sub_matches: &ArgMatches,
+    callback: F,
 ) -> Result<()> {
     let instance_name = sub_matches.value_of("instance-name").unwrap();
     let is_first = is_first_from_arg(sub_matches);
@@ -994,7 +1006,7 @@ fn aggregate(
         &mut aggregation_transport,
     )?;
 
-    aggregator.generate_sum_part(&parsed_batches)
+    aggregator.generate_sum_part(&parsed_batches, callback)
 }
 
 fn aggregate_subcommand(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
@@ -1020,6 +1032,7 @@ fn aggregate_subcommand(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
         sub_matches.value_of("aggregation-end").unwrap(),
         batch_info,
         sub_matches,
+        || {}, // no-op callback
     )
 }
 
@@ -1042,6 +1055,7 @@ fn aggregate_worker(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
         if let Some(task_handle) = queue.dequeue()? {
             info!("dequeued task: {}", task_handle);
             aggregation_started.inc();
+            let task_start = Instant::now();
 
             let batches: Vec<(&str, &str)> = task_handle
                 .task
@@ -1055,6 +1069,13 @@ fn aggregate_worker(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
                 &task_handle.task.aggregation_end,
                 batches,
                 sub_matches,
+                || {
+                    if let Err(e) =
+                        queue.maybe_extend_task_deadline(&task_handle, &task_start.elapsed())
+                    {
+                        error!("{}", e);
+                    }
+                },
             );
 
             match result {

--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -24,6 +24,7 @@ pub struct BatchIntaker<'a> {
     own_validation_batch: BatchWriter<'a, ValidationHeader, ValidationPacket>,
     own_validation_batch_signing_key: &'a BatchSigningKey,
     is_first: bool,
+    callback_cadence: u32,
 }
 
 impl<'a> BatchIntaker<'a> {
@@ -54,13 +55,23 @@ impl<'a> BatchIntaker<'a> {
             peer_validation_batch_signing_key: &peer_validation_transport.batch_signing_key,
             own_validation_batch_signing_key: &own_validation_transport.batch_signing_key,
             is_first,
+            callback_cadence: 1000,
         })
+    }
+
+    /// Set the cadence at which the callback passed to
+    /// generate_validation_share is invoked, i.e., after how many processed
+    /// packets. This function is not safe to call while a call to
+    /// generate_validation_share is in flight and is intended only for testing.
+    pub fn set_callback_cadence(&mut self, cadence: u32) {
+        self.callback_cadence = cadence;
     }
 
     /// Fetches the ingestion batch, validates the signatures over its header
     /// and packet file, then computes validation shares and sends them to the
-    /// peer share processor.
-    pub fn generate_validation_share(&mut self) -> Result<()> {
+    /// peer share processor. The provided callback is invoked once for every
+    /// thousand processed packets, unless set_callback_cadence has been called.
+    pub fn generate_validation_share<F: FnMut()>(&mut self, mut callback: F) -> Result<()> {
         info!(
             "processing intake from {} and saving validity to {} and {}",
             self.intake_batch.path(),
@@ -89,6 +100,10 @@ impl<'a> BatchIntaker<'a> {
         // each, and write them to the validation batch.
         let mut ingestion_packet_reader =
             self.intake_batch.packet_file_reader(&ingestion_header)?;
+
+        let mut processed_packets = 0;
+        // Copy of callback_cadence that's safe to use in the closure
+        let callback_cadence = self.callback_cadence;
 
         let packet_file_digest = self.peer_validation_batch.multi_packet_file_writer(
             vec![&mut self.own_validation_batch],
@@ -129,6 +144,10 @@ impl<'a> BatchIntaker<'a> {
                 }
                 if !did_create_validation_packet {
                     return Err(anyhow!("failed to construct validation message"));
+                }
+                processed_packets += 1;
+                if processed_packets % callback_cadence == 0 {
+                    callback();
                 }
             },
         )?;
@@ -288,7 +307,7 @@ mod tests {
         .unwrap();
 
         pha_ingestor
-            .generate_validation_share()
+            .generate_validation_share(|| {})
             .expect("PHA failed to generate validation");
 
         let mut facilitator_ingestor = BatchIntaker::new(
@@ -303,7 +322,7 @@ mod tests {
         .unwrap();
 
         facilitator_ingestor
-            .generate_validation_share()
+            .generate_validation_share(|| {})
             .expect("facilitator failed to generate validation");
     }
 }


### PR DESCRIPTION
Adds methods to the `TaskQueue` trait that allow extending task
deadlines (aka ack deadline in GCP PubSub or visibility timeout in AWS
SQS) when tassk are running long. Also adds callback parameters to
`BatchIntaker::generate_validation_share` and
`BatchAggregator::generate_sum_part` which fire periodically to give a
caller an opportunity to evaluate how much time has elapsed since the
start of the task and extend deadlines as necessary. See #308 for more
context on why this is needed.

Resolves #308