### PR TITLE
workflow-manager: additional metrics

### DIFF
--- a/workflow-manager/main_test.go
+++ b/workflow-manager/main_test.go
@@ -187,7 +187,7 @@ func TestScheduleIntakeTasks(t *testing.T) {
 			aggregateTaskEnqueuer := mockEnqueuer{enqueuedTasks: []task.Task{}}
 			ownValidationBucket := mockBucket{writtenObjectKeys: []string{}}
 
-			scheduleTasks(scheduleTasksConfig{
+			err := scheduleTasks(scheduleTasksConfig{
 				isFirst: false,
 				clock:   clock,
 				intakeFiles: []string{
@@ -205,6 +205,9 @@ func TestScheduleIntakeTasks(t *testing.T) {
 				aggregationPeriod:       aggregationPeriod,
 				gracePeriod:             gracePeriod,
 			})
+			if err != nil {
+				t.Errorf("unexpected error %q", err)
+			}
 
 			if testCase.expectedIntakeTask == nil {
 				if len(intakeTaskEnqueuer.enqueuedTasks) != 0 {
@@ -470,7 +473,7 @@ func TestScheduleAggregationTasks(t *testing.T) {
 			aggregateTaskEnqueuer := mockEnqueuer{enqueuedTasks: []task.Task{}}
 			ownValidationBucket := mockBucket{writtenObjectKeys: []string{}}
 
-			scheduleTasks(scheduleTasksConfig{
+			err := scheduleTasks(scheduleTasksConfig{
 				isFirst: false,
 				clock:   clock,
 				intakeFiles: []string{
@@ -488,6 +491,9 @@ func TestScheduleAggregationTasks(t *testing.T) {
 				aggregationPeriod:       aggregationPeriod,
 				gracePeriod:             gracePeriod,
 			})
+			if err != nil {
+				t.Errorf("unexpected error: %q", err)
+			}
 
 			if len(intakeTaskEnqueuer.enqueuedTasks) != 0 {
 				t.Errorf("unexpected intake tasks scheduled: %q", intakeTaskEnqueuer.enqueuedTasks)

--- a/workflow-manager/monitor/monitor.go
+++ b/workflow-manager/monitor/monitor.go
@@ -1,13 +1,19 @@
 package monitor
 
-type CounterMonitor interface {
+type GaugeMonitor interface {
 	Inc()
+	Set(float64)
+	SetToCurrentTime()
 }
 
-type NoopCounter struct {
+type NoopGauge struct {
 	counted int
 }
 
-func (c *NoopCounter) Inc() {
+func (c *NoopGauge) Inc() {
 	c.counted = c.counted + 1
 }
+
+func (c *NoopGauge) Set(value float64) {}
+
+func (c *NoopGauge) SetToCurrentTime() {}

--- a/workflow-manager/monitor/monitor_test.go
+++ b/workflow-manager/monitor/monitor_test.go
@@ -2,8 +2,8 @@ package monitor
 
 import "testing"
 
-func TestNoopCounterIncrement(t *testing.T) {
-	c := NoopCounter{}
+func TestNoopGaugeIncrement(t *testing.T) {
+	c := NoopGauge{}
 
 	c.Inc()
 	c.Inc()


### PR DESCRIPTION
Fixes a bug where metrics were being pushed to the pushgateway at the
beginning of the workflow-manager instead of the end, such that no
metrics were pushed before being gathered locally.

Additionally adds new gauges for:
 - number of tasks scheduled
 - number of tasks detected but skipped due to age, task marker or
   existing k8s job
 - time of last successful and failed runs
 - how long it took to run workflow-manager

All of these are gauges, in keeping with the advice in Prometheus
documentation (https://prometheus.io/docs/practices/instrumentation).
Because this is a batch job, we can't meaningfully use anything but
gauges, as other collector types would get reset with each run of
workflow-manager.

Existing metrics are renamed to prefix them with `workflow_manager_`,
and all metrics are grouped under the `locality` label, which is
populated with the Kubernetes namespace name. `instance` is not set,
which will cause pushgateway to set it to `""`. This is the desired
behavior, since there are no persistent instances of `workflow-manager`.