### PR TITLE
workflow-manager: relax timeout on GCS object list

### DIFF
--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -78,8 +78,8 @@ var (
 )
 
 func fail(format string, args ...interface{}) {
-	log.Printf(format, args...)
 	workflowManagerLastFailure.SetToCurrentTime()
+	log.Fatalf(format, args...)
 }
 
 func main() {

--- a/workflow-manager/task/task.go
+++ b/workflow-manager/task/task.go
@@ -5,6 +5,7 @@
 package task
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -112,8 +113,9 @@ type Enqueuer interface {
 // subscription with the same ID that can later be used by a facilitator.
 // Returns error on failure.
 func CreatePubSubTopic(project string, topicID string) error {
-	ctx, cancel := utils.ContextWithTimeout()
-	defer cancel()
+	// Google documentation advises against timeouts on client creation
+	// https://godoc.org/cloud.google.com/go#hdr-Timeouts_and_Cancellation
+	ctx := context.Background()
 
 	client, err := pubsub.NewClient(ctx, project)
 	if err != nil {
@@ -151,8 +153,9 @@ type GCPPubSubEnqueuer struct {
 // should re-use a single instance as much as possible to enable batching of
 // publish requests.
 func NewGCPPubSubEnqueuer(project string, topicID string, dryRun bool) (*GCPPubSubEnqueuer, error) {
-	ctx, cancel := utils.ContextWithTimeout()
-	defer cancel()
+	// Google documentation advises against timeouts on client creation
+	// https://godoc.org/cloud.google.com/go#hdr-Timeouts_and_Cancellation
+	ctx := context.Background()
 
 	client, err := pubsub.NewClient(ctx, project)
 	if err != nil {


### PR DESCRIPTION
We observed workflow-manager failing in the `us-md-apple` instance
because we were hitting timeouts enumerating the contents of GCS
buckets. This is because the `list` API on buckets is paginated
(https://cloud.google.com/storage/docs/json_api/v1/buckets/list), which
the Go SDK handles by returning an `ObjectIterator` from
`BucketHandle.Objects()`. However you can only provide a
`context.Context` to the initial call to `Objects()`, and each
subsequent call to `ObjectIterator.next()` is subject to the same
initial timeout. There's no way to reset the timeout on a
`context.Context` that I can find, so I believe the thing to do is to
raise the timeout for this particular operation, which we understand
actually does take longer than 30 seconds, to 120 seconds.

Additionally, while looking into correct handling of timeouts in GCS, I
found mention in Google documentation that timeouts should not be
applied when calling the various `NewClient()` functions from the GCP
SDK. Accordingly those calls are amended to use `context.Background()`.