### PR TITLE
terraform: larger and regional prometheus disks

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -141,6 +141,12 @@ variable "facilitator_version" {
   default = "latest"
 }
 
+variable "prometheus_server_persistent_disk_size_gb" {
+  type = number
+  # This is quite high, but it's the minimum for GCE regional disks
+  default = 200
+}
+
 terraform {
   backend "gcs" {}
 
@@ -409,8 +415,12 @@ module "fake_server_resources" {
 
 module "monitoring" {
   source                 = "./modules/monitoring"
+  environment            = var.environment
+  gcp_region             = var.gcp_region
   cluster_endpoint       = module.gke.cluster_endpoint
   cluster_ca_certificate = base64decode(module.gke.certificate_authority_data)
+
+  prometheus_server_persistent_disk_size_gb = var.prometheus_server_persistent_disk_size_gb
 }
 
 output "manifest_bucket" {

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -53,12 +53,13 @@ ingestors = {
     }
   }
 }
-peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-portal_server_manifest_base_url        = "manifest.enpa-pha.io"
-is_first                               = false
-use_aws                                = false
-aggregation_period                     = "8h"
-aggregation_grace_period               = "4h"
-workflow_manager_version               = "0.6.1"
-facilitator_version                    = "0.6.1"
-pushgateway                            = "prometheus-pushgateway.monitoring:9091"
+peer_share_processor_manifest_base_url    = "en-analytics.cancer.gov"
+portal_server_manifest_base_url           = "manifest.enpa-pha.io"
+is_first                                  = false
+use_aws                                   = false
+aggregation_period                        = "8h"
+aggregation_grace_period                  = "4h"
+workflow_manager_version                  = "0.6.1"
+facilitator_version                       = "0.6.1"
+pushgateway                               = "prometheus-pushgateway.monitoring:9091"
+prometheus_server_persistent_disk_size_gb = 1000


### PR DESCRIPTION
During a recent production incident, we saw that prometheus-server
entered a crashloop because it filled up the 8 GB persistent volume it
used to store metrics. This commit resolves that by:

 - creating regional persistent disks for prometheus-server and
   prometheus-alertmanager, with replicas in two zones
 - making those disks much bigger than before (the minimum size for a
   GCE regional disk is 200 GB, but we use an even bigger one in
   prod-us)
 - constructing our own Kubernetes PersistentVolumes and
   PersistentVolumeClaims since the Prometheus Helm chart can only
   manage zonal disks

#233 mentions introducing regional storage for Prometheus Alertmanager. I opted not to do that, because Alertmanager doesn't need a lot of storage (all it stores are alert silences), so allocating a whole 200 GB volume (the minimum for GCE regional disks) seems wasteful. I thought about creating multiple partitions on a single GCE regional disk so it could be shared between server and alertmanager, but I'm not sure if that's possible: [the `GCEPersistentDisk` volume plugin does not support the `ReadWriteMany` access mode](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes), so I don't believe the `PersistentVolume` could be mounted as writable by two different pods. I think we would then also be responsible for partitioning the GCE-level volume (which Google [recommends against](https://cloud.google.com/compute/docs/disks#pdspecs), and also creating filesystems (afaict the ext4 filesystems get created by Kubernetes when a `PersistentVolumeClaim` is created).

In any case, if the GCE zone dies where we run alertmanager dies, then if we restart it in another zone, we would just have to re-create any alert silences, which seems tolerable. We can revisit this with a more

Resolves #233, #318