### PR TITLE
workflow-manager: label metrics by ingestor

### DIFF
--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -291,6 +291,7 @@ resource "kubernetes_cron_job" "workflow_manager" {
                 "--intake-max-age", "24h",
                 "--is-first=${var.is_first ? "true" : "false"}",
                 "--k8s-namespace", var.kubernetes_namespace,
+                "--ingestor-label", var.ingestor,
                 "--ingestor-input", var.ingestion_bucket,
                 "--ingestor-identity", var.ingestion_bucket_identity,
                 "--own-validation-input", var.own_validation_bucket,

--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -32,6 +32,7 @@ import (
 var BuildInfo string
 
 var k8sNS = flag.String("k8s-namespace", "", "Kubernetes namespace")
+var ingestorLabel = flag.String("ingestor-label", "", "Label of ingestion server")
 var isFirst = flag.Bool("is-first", false, "Whether this set of servers is \"first\", aka PHA servers")
 var maxAge = flag.String("intake-max-age", "1h", "Max age (in Go duration format) for intake batches to be worth processing.")
 var ingestorInput = flag.String("ingestor-input", "", "Bucket for input from ingestor (s3:// or gs://) (Required)")
@@ -90,7 +91,8 @@ func main() {
 	if *pushGateway != "" {
 		pusher := push.New(*pushGateway, "workflow-manager").
 			Gatherer(prometheus.DefaultGatherer).
-			Grouping("locality", *k8sNS)
+			Grouping("locality", *k8sNS).
+			Grouping("ingestor", *ingestorLabel)
 
 		defer pusher.Push()
 		intakesStarted = promauto.NewGauge(prometheus.GaugeOpts{


### PR DESCRIPTION
`workflow-manager` metrics were grouped by namespace (hence, locality),
but metrics emitted by either ingestor's `workflow-manager` were going
to the same time series, leaving us unable to distinguish between the
health of Apple vs. g-enpa task schedulers. This commit adds a new
grouping to metrics pushed by `workflow-manager` for ingestor name, and
amends Terraform to pass that ingestor name into the `workflow-manager`.

This also fixes a problem with the `prometheus-server` deployment: by
default, the Prometheus helm chart creates a Kubernetes deployment for
`prometheus-server` with an update strategy of `RollingUpdate`. This
doesn't work with a persistent volume because it cannot be shared across
two revisions during an update. We opt into the `Recreate` strategy to
work around this.

Resolves #317