### PR TITLE
terraform: configurable intake-max-age

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -78,6 +78,15 @@ variable "is_first" {
   description = "Whether the data share processors created by this environment are \"first\" or \"PHA servers\""
 }
 
+variable "intake_max_age" {
+  type        = string
+  default     = "6h"
+  description = <<DESCRIPTION
+Maximum age of ingestion batches for workflow-manager to schedule intake tasks
+for. The value should be a string parseable by Go's time.ParseDuration.
+DESCRIPTION
+}
+
 variable "aggregation_period" {
   type        = string
   default     = "3h"
@@ -375,6 +384,7 @@ module "data_share_processors" {
   own_manifest_base_url                          = module.manifest.base_url
   test_peer_environment                          = var.test_peer_environment
   is_first                                       = var.is_first
+  intake_max_age                                 = var.intake_max_age
   aggregation_period                             = var.aggregation_period
   aggregation_grace_period                       = var.aggregation_grace_period
   kms_keyring                                    = module.gke.kms_keyring

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -80,6 +80,10 @@ variable "is_first" {
   type = bool
 }
 
+variable "intake_max_age" {
+  type = string
+}
+
 variable "aggregation_period" {
   type = string
 }
@@ -431,6 +435,7 @@ module "kubernetes" {
   is_env_with_ingestor                    = local.is_env_with_ingestor
   test_peer_ingestion_bucket              = local.test_peer_ingestion_bucket
   is_first                                = var.is_first
+  intake_max_age                          = var.intake_max_age
   aggregation_period                      = var.aggregation_period
   aggregation_grace_period                = var.aggregation_grace_period
   pushgateway                             = var.pushgateway

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -100,6 +100,10 @@ variable "is_first" {
   type = bool
 }
 
+variable "intake_max_age" {
+  type = string
+}
+
 variable "aggregation_period" {
   type = string
 }
@@ -287,7 +291,7 @@ resource "kubernetes_cron_job" "workflow_manager" {
               args = [
                 "--aggregation-period", var.aggregation_period,
                 "--grace-period", var.aggregation_grace_period,
-                "--intake-max-age", "24h",
+                "--intake-max-age", var.intake_max_age,
                 "--is-first=${var.is_first ? "true" : "false"}",
                 "--k8s-namespace", var.kubernetes_namespace,
                 "--ingestor-label", var.ingestor,


### PR DESCRIPTION
The `intake-max-age` parameter to `workflow-manager` had been hard-coded
to 24h. This is longer than makes sense given our aggregation window of
8 hours in production, and in any case this should be configurable,
since being able to tune that parameter has already helped us out of a
couple of different incidents. This commit adds a top level Terraform
variable for `intake-max-age`, and sets the default to the more
reasonable value of six hours.

Resolves #331