### PR TITLE
terraform: provide GCP project *ID* to stackdriver

### DIFF
--- a/terraform/modules/monitoring/monitoring.tf
+++ b/terraform/modules/monitoring/monitoring.tf
@@ -233,7 +233,7 @@ resource "helm_release" "stackdriver_exporter" {
 
   set {
     name  = "stackdriver.projectId"
-    value = data.google_project.current.name
+    value = data.google_project.current.project_id
   }
 
   set {


### PR DESCRIPTION
Another GCP project *name* vs. *ID* bug: `stackdriver-exporter` needs
the GCP project ID so it can authenticate to the monitoring API. We were
providing the name, which is not the same value in staging.