### PR TITLE
terraform: basic Prometheus alerting rules

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,90 @@
+# Metrics, graphs and alerting
+
+We deploy Prometheus and Grafana into Prio clusters. We gather metrics from a few sources:
+
+ - host level metrics via [`prometheus-node-exporter`](https://prometheus.io/docs/guides/node-exporter/)
+ - Kubernetes metrics via [`prometheus-kube-state-metrics`](https://github.com/kubernetes/kube-state-metrics)
+ - [GCP Cloud Monitoring](https://cloud.google.com/monitoring) via [`stackdriver-exporter`](https://github.com/prometheus-community/stackdriver_exporter)
+ - `workflow-manager` pushes metrics via [`prometheus-pushgateway`](https://prometheus.io/docs/instrumenting/pushing/)
+ - `facilitator` serves metrics from a `/metrics` endpoint on a configurable port.
+
+## Dealing with alerts
+
+The `prod-us` and `staging` environments are configured to deliver alerts to VictorOps. By default, other environments will track alerts in `prometheus-alertmanager`, but no alerts will be forwarded to VictorOps. Regardless of environment, alerts are tracked by `prometheus-alertmanager`.
+
+To silence alerts, use the `prometheus-alertmanager` web interface. See [below](#access-prometheus-and-grafana-ui) for guidance on accessing the web interfaces, and [Prometheus documentation](https://prometheus.io/docs/alerting/latest/alertmanager/) for more on Alertmanager silences.
+
+### Dead letter queue alerts
+
+We alert if there are undelivered messages in any dead letter queue for five minutes, meaning that some message has repeatedly failed to be handled by a worker. You can examine the undeliverable messages by examining the relevant dead letter subscription (see the `subscription_id` label in the firing alert) [in the GCP PubSub console](https://console.cloud.google.com/cloudpubsub/subscription/list), and you can dismiss the alert by acking the undeliverable messages in the subscription.
+
+## Storage
+
+We configure a regional Google Compute Engine disk for `prometheus-server`'s storage. Its size is configurable in the an environment's `tfvars` file. the GCE disk is made available to `prometheus-server` as a Kubernetes persistent volume claim.
+
+## Configuration
+
+Most configuration is handled via Terraform, in the `monitoring` module.
+
+### Alerting rules
+
+Alerting rules are defined in `modules/monitoring/prometheus_alerting_rules.yml`. When writing alerting rules, note carefully the difference between Terraform template variables (e.g., `${environment}`), which are substituted by Terraform during `apply`, and Prometheus template variables (e.g., `{{ $labels.kubernetes_name }}`), which are rendered by Prometheus when an alert fires.
+
+### Alertmanager
+
+`prometheus-alertmanager` is configured to send alerts to VictorOps. If an environment's alerts should generate VictorOps pages, then the `victorops_routing_key` variable in the environment's `tfvars` should be set to an existing routing key in VictorOps. If no valid routing key is provided, then alerts will still be tracked in `prometheus-alertmanager` and visible in its GUI, but nothing will page.
+
+`alertmanager`'s configuration is stored in the Kubernetes secret `prometheus-alertmanager-config` in the `monitoring` namespace. That config document contains the VictorOps API key, which we do not check into source control (see [below](#hooking-up-victoropssplunk-oncall-alerts) for details on providing the API key). Because Terraform is configured to ignore changes to the contents of the secret, if you make changes to `alertmanager` configuration via Terraform, you will either need to apply those changes to the Kubernetes secret manually, or you will need to delete the secret `monitoring/prometheus-alertmanager-config` so that Terraform can re-create the secret from scratch.
+
+### Stackdriver exporter
+
+`stackdriver-exporter` is configured with an allow-list of GCP Cloud Monitoring/Stackdriver metric name prefixes to be exported to Prometheus. You can export additional Stackdriver metrics by [looking up the prefix(es)](https://cloud.google.com/monitoring/api/metrics_gcp) and appending to the `stackdriver.metrics.typePrefixes` list in `resource.helm_release.stackdriver_exporter` in `monitoring.tf`.
+
+### Ad-hoc configuration changes
+
+For development or incident response purposes, you might want to make rapid changes to `prometheus` configuration without going through Terraform.
+
+If you want to modify `prometheus-server` config or alert definitions, you can modify the relevant key in the `prometheus-server` ConfigMap in the `monitoring` namespace. The various Prometheus components will detect your changes and automatically reload configuration.
+
+If you want to modify `stackdriver-exporter` configuration, you can edit the `stackdriver-exporter-prometheus-stackdriver-exporter` deployment in the `monitoring` namespace as its configuration is provided in environment variables in the container spec.
+
+## Accessing Prometheus and Grafana UI
+
+None of Grafana, Prometheus or any of Prometheus' components are exposed publicly. You can access them using `kubectl port-forward` to make a port on remote pod's network accessible locally. So, to make Prometheus' `server` component reachable at `localhost:8080`, you would do:
+
+    kubectl -n monitoring port-forward $(kubectl -n monitoring get pod --selector="app=prometheus,component=server,release=prometheus" --output jsonpath='{.items[0].metadata.name}') 8080:9090
+
+For `prometheus-alertmanager`:
+
+    kubectl -n monitoring port-forward $(kubectl -n monitoring get pod --selector="app=prometheus,component=alertmanager,release=prometheus" --output jsonpath='{.items[0].metadata.name}') 8081:9093
+
+And for Grafana:
+
+    kubectl -n monitoring port-forward $(kubectl -n monitoring get pod --selector="app.kubernetes.io/instance=grafana,app.kubernetes.io/name=grafana" --output jsonpath='{.items[0].metadata.name}') 8082:3000
+
+To access other components, look up the labels on the pod for the component you want to reach to construct an appropriate `--selector` argument, and check the running container's configuration to see what port(s) it listens on. Naturally, this requires you to have valid Kubernetes cluster credentials in place for use with `kubectl`.
+
+Grafana requires authentication. You can login as the `admin` user, whose password is in a Kubernetes secret. Run `kubectl -n monitoring get secret grafana -o=yaml`, then base64 decode the value for `admin-password` and use it to authenticate.
+
+## Hooking up VictorOps/Splunk Oncall alerts
+
+Sending alerts from Prometheus Alertmanager to VictorOps requires an API key, which we do not want to store in source control, and so you must update a Kubernetes secret. First, get the API key from the [VictorOps portal](https://portal.victorops.com) (configuring VictorOps teams, rotations, and escalation policies is out of scope for this document). Then, get the existing `prometheus-alertmanager` config out of the Kubernetes secret:
+
+    kubectl -n monitoring get secrets  prometheus-alertmanager-config -o jsonpath="{.data.alertmanager\.yml}" | base64 -d > /path/to/config/file.yml
+
+Update the `api_key` value in the `victorops_config` and `apply` the secret back into place. There's no straightforward way to update a secret value using kubectl, so we use [this trick](https://blog.atomist.com/updating-a-kubernetes-secret-or-configmap/):
+
+    kubectl -n monitoring create secret generic prometheus-alertmanager-config --from-file=alertmanager.yml=/path/to/config/file.yml --dry-run=client -o=json | kubectl apply -f -
+
+For more details, see the [VictorOps docs on Prometheus integration](https://help.victorops.com/knowledge-base/victorops-prometheus-integration/).
+
+## Configuring Kubernetes dashboard in Grafana
+
+No dashboards are automatically configured in Grafana. To get [a dashboard with an overview of Kubernetes status](https://grafana.com/grafana/dashboards/315):
+
+* Log into Grafana (see "Accessing Prometheus and Grafana", above)
+* Go to Dashboards -> Manage
+* Hit "Import"
+* Enter "315" into the "Import via grafana.com" box (or the ID of whatever dashboard you wish to configure)
+* Select the "prometheus" data source
+* Enjoy the graphs'n'gauges

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -71,67 +71,6 @@ In your test setup, you might want to exercise reading and writing data to AWS S
 
 When instantiating a new GKE cluster, you will want to merge its configuration into your local `~/.kube/config` so that you can use `kubectl` for cluster management. After a successful `apply`, Terraform will emit a `gcloud` invocation that will update your local config file. More generally, `gcloud container clusters get-credentials <YOUR CLUSTER NAME> --region <GCP REGION>"` will do the trick.
 
-## Metrics, graphs and alerting
-
-We deploy Prometheus and Grafana into Prio clusters. A variety of Kubernetes metrics automagically are recorded into Prometheus, and a small number of metrics are recorded by `workflow-manager` and `facilitator`. There are some manual steps before you can see any graphs or get alerts, though.
-
-### Accessing Prometheus and Grafana
-
-None of Grafana, Prometheus or any of Prometheus' components are exposed publicly. You can access them using `kubectl port-forward` to make a port on remote pod's network accessible locally. So, to make Prometheus' `server` component reachable at `localhost:8080`, you would do:
-
-    kubectl -n monitoring port-forward $(kubectl -n monitoring get pod --selector="app=prometheus,component=server,release=prometheus" --output jsonpath='{.items[0].metadata.name}') 8080:9090
-
-For `prometheus-alertmanager`:
-
-    kubectl -n monitoring port-forward $(kubectl -n monitoring get pod --selector="app=prometheus,component=alertmanager,release=prometheus" --output jsonpath='{.items[0].metadata.name}') <LOCAL PORT>:9093
-
-And for Grafana:
-
-    kubectl -n monitoring port-forward $(kubectl -n monitoring get pod --selector="app.kubernetes.io/instance=grafana,app.kubernetes.io/name=grafana" --output jsonpath='{.items[0].metadata.name}') <LOCAL PORT>:3000
-
-To access other components, look up the labels on the pod for the component you want to reach to construct an appropriate `--selector` argument, and check the running container's configuration to see what port(s) it listens on.
-
-Grafana requires authentication. You can login as the `admin` user. The password is in a Kubernetes secret. Run `kubectl -n monitoring get secret grafana -o=yaml`, then base64 decode the value for `admin-password` and use it to authenticate.
-
-### Hooking up VictorOps/Splunk Oncall alerts
-
-Sending alerts from Prometheus Alertmanager to VictorOps requires an API key, which we do not want to store in source control, and so you must update a Kubernetes secret. First, get the appropriate routing key and API key from the [VictorOps portal](https://portal.victorops.com) (configuring VictorOps teams, rotations, and escalation policies is out of scope for this document). Then, make a YAML file like this:
-
-    global:
-      resolve_timeout: 5m
-      http_config: {}
-      victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/
-    route:
-      receiver: victorops-receiver
-      group_by: ['alertname', 'cluster', 'service']
-      group_wait: 10s
-      group_interval: 5m
-      repeat_interval: 3h
-    receivers:
-    - name: victorops-receiver
-      victorops_configs:
-      - api_key: <VICTOROPS SECRET API KEY HERE>
-        routing_key: <VICTOROPS ROUTING KEY HERE>
-        state_message: 'Alert: {{ .CommonLabels.alertname }}. Summary:{{ .CommonAnnotations.summary }}. RawData: {{ .CommonLabels }}'
-    templates: []
-
-Next, we want to store this in the `prometheus-alertmanager-config` Kubernetes secret that was created by Terraform with a dummy value. There's no straightforward way to update a secret value using kubectl, so we use [this trick](https://blog.atomist.com/updating-a-kubernetes-secret-or-configmap/):
-
-    kubectl -n monitoring create secret generic prometheus-alertmanager-config --from-file=alertmanager.yml=/path/to/config/file.yml --dry-run=client -o=json | kubectl apply -f -
-
-For more details, see the [VictorOps docs on Prometheus integration](https://help.victorops.com/knowledge-base/victorops-prometheus-integration/).
-
-### Configuring Kubernetes dashboard in Grafana
-
-No dashboards are automatically configured in Grafana. To get [a dashboard with an overview of Kubernetes status](https://grafana.com/grafana/dashboards/315):
-
-* Log into Grafana (see "Accessing Prometheus and Grafana", above)
-* Go to Dashboards -> Manage
-* Hit "Import"
-* Enter "315" into the "Import via grafana.com" box (or the ID of whatever dashboard you wish to configure)
-* Select the "prometheus" data source
-* Enjoy the graphs'n'gauges
-
 ## Formatting
 
 Our continuous integration is set up to do basic validation of Terraform files on pull requests. Besides any other testing, make sure to run `terraform fmt --recursive` or you will get build failures!

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -156,6 +156,12 @@ variable "prometheus_server_persistent_disk_size_gb" {
   default = 200
 }
 
+variable "victorops_routing_key" {
+  type        = string
+  description = "VictorOps/Splunk OnCall routing key for prometheus-alertmanager"
+  default     = "bogus-routing-key"
+}
+
 terraform {
   backend "gcs" {}
 
@@ -429,6 +435,8 @@ module "monitoring" {
   gcp_region             = var.gcp_region
   cluster_endpoint       = module.gke.cluster_endpoint
   cluster_ca_certificate = base64decode(module.gke.certificate_authority_data)
+  victorops_routing_key  = var.victorops_routing_key
+  aggregation_period     = var.aggregation_period
 
   prometheus_server_persistent_disk_size_gb = var.prometheus_server_persistent_disk_size_gb
 }

--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -1,0 +1,54 @@
+groups:
+- name: default
+  rules:
+  - alert: workflow_manager_heartbeat
+    expr: (time() - workflow_manager_last_success_seconds) > 1800
+    for: 5m
+    labels:
+      severity: page
+    annotations:
+      summary: "Workflow manager {{ $labels.locality }}-{{ $labels.ingestor }}
+        not running"
+      description: "workflow-manager instance {{ $labels.locality }}-{{ $labels.ingestor }}
+        has not run successfully for 30 minutes"
+  - alert: facilitator_intake_failure_rate
+    expr: rate(facilitator_intake_tasks_finished{status="success"}[1h]) / rate(facilitator_intake_tasks_finished[1h]) < 0.95
+    for: 5m
+    labels:
+      severity: page
+    annotations:
+      summary: "High failure rate for intake worker
+        {{ $labels.kubernetes_namespace }}-{{ $labels.kubernetes_name }}"
+      description: "intake worker instance {{ $labels.kubernetes_namespace }}-
+        {{ $labels.kubernetes_name }} is failing more than 95% of the time in
+        the last hour"
+  - alert: facilitator_aggregate_failure_rate
+    # aggregations run much less often than intake so use a larger window of time
+    expr: rate(facilitator_aggregate_tasks_finished{status="success"}[8h]) / rate(facilitator_aggregate_tasks_finished[8h]) < 0.95
+    for: 5m
+    labels:
+      severity: page
+    annotations:
+      summary: "High failure rate for aggregate worker
+        {{ $labels.kubernetes_namespace }}-{{ $labels.kubernetes_name }}"
+      description: "aggregate worker instance {{ $labels.kubernetes_namespace}}-
+        {{ $labels.kubernetes_name }} in environment ${environment} is failing
+        more than 95% of the time in the last 8 hours"
+  - alert: task_queue_growth
+    expr: stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{subscription_id!~".*-dead-letter"} > 0
+    for: 2h
+    labels:
+      severity: page
+    annotations:
+      summary: "PubSub subscription {{ $labels.subscription_id }} not emptying"
+      description: "PubSub subscription {{ $labels.subscription_id }} has had
+        undelivered messages for 2 hours"
+  - alert: dead_letter_queue
+    expr: stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{subscription_id=~".*-dead-letter"} > 0
+    for: 5m
+    labels:
+      severity: page
+    annotations:
+      summary: "Undelivered messages in dead letter queue {{ $labels.subscription_id }}"
+      description: "There are undelivered messages in the dead letter queue for
+        PubSub subscription {{ $labels.subscription_id }}."

--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -6,28 +6,34 @@ groups:
     for: 5m
     labels:
       severity: page
+      environment: ${environment}
     annotations:
       summary: "Workflow manager {{ $labels.locality }}-{{ $labels.ingestor }}
         not running"
-      description: "workflow-manager instance {{ $labels.locality }}-{{ $labels.ingestor }}
-        has not run successfully for 30 minutes"
+      description: "At least 30 minutes have passed since workflow-manager
+        instance {{ $labels.locality }}-{{ $labels.ingestor }} in environment
+        ${environment} last ran successfully"
   - alert: facilitator_intake_failure_rate
-    expr: rate(facilitator_intake_tasks_finished{status="success"}[1h]) / rate(facilitator_intake_tasks_finished[1h]) < 0.95
+    expr: rate(facilitator_intake_tasks_finished{status="success"}[1h])
+      / rate(facilitator_intake_tasks_finished[1h]) < 0.95
     for: 5m
     labels:
       severity: page
+      environment: ${environment}
     annotations:
       summary: "High failure rate for intake worker
         {{ $labels.kubernetes_namespace }}-{{ $labels.kubernetes_name }}"
       description: "intake worker instance {{ $labels.kubernetes_namespace }}-
-        {{ $labels.kubernetes_name }} is failing more than 95% of the time in
-        the last hour"
+        {{ $labels.kubernetes_name }} in environment ${environment} is failing
+        more than 95% of the time in the last hour"
   - alert: facilitator_aggregate_failure_rate
     # aggregations run much less often than intake so use a larger window of time
-    expr: rate(facilitator_aggregate_tasks_finished{status="success"}[8h]) / rate(facilitator_aggregate_tasks_finished[8h]) < 0.95
+    expr: rate(facilitator_aggregate_tasks_finished{status="success"}[${aggregation_period}])
+      / rate(facilitator_aggregate_tasks_finished[${aggregation_period}]) < 0.95
     for: 5m
     labels:
       severity: page
+      environment: ${environment}
     annotations:
       summary: "High failure rate for aggregate worker
         {{ $labels.kubernetes_namespace }}-{{ $labels.kubernetes_name }}"
@@ -39,10 +45,11 @@ groups:
     for: 2h
     labels:
       severity: page
+      environment: ${environment}
     annotations:
       summary: "PubSub subscription {{ $labels.subscription_id }} not emptying"
-      description: "PubSub subscription {{ $labels.subscription_id }} has had
-        undelivered messages for 2 hours"
+      description: "PubSub subscription {{ $labels.subscription_id }} in
+      environment ${environment} has had undelivered messages for 2 hours"
   - alert: dead_letter_queue
     expr: stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{subscription_id=~".*-dead-letter"} > 0
     for: 5m
@@ -51,4 +58,5 @@ groups:
     annotations:
       summary: "Undelivered messages in dead letter queue {{ $labels.subscription_id }}"
       description: "There are undelivered messages in the dead letter queue for
-        PubSub subscription {{ $labels.subscription_id }}."
+        PubSub subscription {{ $labels.subscription_id }} in environment
+        ${environment}."

--- a/terraform/modules/pubsub/pubsub.tf
+++ b/terraform/modules/pubsub/pubsub.tf
@@ -79,6 +79,18 @@ resource "google_pubsub_topic_iam_binding" "dead_letter" {
   ]
 }
 
+# Subscription on the dead letter topic enabling us to alert on dead letter
+# delivery and examine undelivered messages
+resource "google_pubsub_subscription" "dead_letter" {
+  name                 = google_pubsub_topic.dead_letter.name
+  topic                = google_pubsub_topic.dead_letter.name
+  ack_deadline_seconds = 600
+  # Subscription should never expire
+  expiration_policy {
+    ttl = ""
+  }
+}
+
 output "queue" {
   value = google_pubsub_topic.task.name
 }

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -63,3 +63,4 @@ workflow_manager_version                  = "0.6.3"
 facilitator_version                       = "0.6.3"
 pushgateway                               = "prometheus-pushgateway.monitoring:9091"
 prometheus_server_persistent_disk_size_gb = 1000
+victorops_routing_key                     = "prio-prod-us"

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -56,3 +56,4 @@ use_aws                  = false
 workflow_manager_version = "0.6.3"
 facilitator_version      = "0.6.3"
 pushgateway              = "prometheus-pushgateway.monitoring:9091"
+victorops_routing_key    = "prio-staging"

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -56,3 +56,4 @@ use_aws                  = true
 workflow_manager_version = "0.6.3"
 facilitator_version      = "0.6.3"
 pushgateway              = "prometheus-pushgateway.monitoring:9091"
+victorops_routing_key    = "prio-staging"


### PR DESCRIPTION
Configures the Prometheus Helm chart to include alerting rules defined
in a standalone YAML file. Updates `prometheus-alertmanager`
configuration so that only alerts with `severity: page` are routed to
the Victorops receiver.

We now have the following alerts set up:

 - page if any `workflow-manager` instance has not run in the last 30
   minutes
 - page if more than 95% of intake tasks fail during the last hour
 - page if more than 95% of aggregate tasks fail during the last 8 hours
 - page if any PubSub queue has undelivered messages for an entire hour