### PR TITLE
facilitator: don't abort integration for bad batch

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -72,6 +72,8 @@ trait AppArgumentAdder {
     fn add_task_queue_arguments(self: Self) -> Self;
 
     fn add_metrics_scrape_port_argument(self: Self) -> Self;
+
+    fn add_use_bogus_packet_file_digest_argument(self: Self) -> Self;
 }
 
 const SHARED_HELP: &str = "Storage arguments: Any flag ending in -input or -output can take an \
@@ -380,6 +382,26 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                 .validator(num_validator::<u16>),
         )
     }
+
+    fn add_use_bogus_packet_file_digest_argument(self: App<'a, 'b>) -> App<'a, 'b> {
+        self.arg(
+            Arg::with_name("use-bogus-packet-file-digest")
+                .long("use-bogus-packet-file-digest")
+                .env("USE_BOGUS_PACKET_FILE_DIGEST")
+                .help("whether to tamper with validation batch headers")
+                .long_help(
+                    "If set, then instead of the computed digest of the packet \
+                    file, a fixed, bogusddigest will be inserted into the own \
+                    and peer validation batch headers written out during \
+                    intake tasks. This should only be used in test scenarios \
+                    to simulate buggy data share processors.",
+                )
+                .value_name("BOOL")
+                .possible_value("true")
+                .possible_value("false")
+                .default_value("false"),
+        )
+    }
 }
 
 fn main() -> Result<(), anyhow::Error> {
@@ -543,7 +565,8 @@ fn main() -> Result<(), anyhow::Error> {
                 .add_storage_arguments(Entity::Ingestor, InOut::Input)
                 .add_manifest_base_url_argument(Entity::Peer)
                 .add_storage_arguments(Entity::Peer, InOut::Output)
-                .add_storage_arguments(Entity::Own, InOut::Output),
+                .add_storage_arguments(Entity::Own, InOut::Output)
+                .add_use_bogus_packet_file_digest_argument()
         )
         .subcommand(
             SubCommand::with_name("aggregate")
@@ -680,6 +703,7 @@ fn main() -> Result<(), anyhow::Error> {
                 .add_storage_arguments(Entity::Own, InOut::Output)
                 .add_task_queue_arguments()
                 .add_metrics_scrape_port_argument()
+                .add_use_bogus_packet_file_digest_argument()
         )
         .subcommand(
             SubCommand::with_name("aggregate-worker")
@@ -821,6 +845,10 @@ fn intake_batch<F: FnMut()>(
         &mut own_validation_transport,
         is_first_from_arg(sub_matches),
     )?;
+
+    if let Some("true") = sub_matches.value_of("use-bogus-packet-file-digest") {
+        batch_intaker.set_use_bogus_packet_file_digest(true);
+    }
 
     if let Some(collector) = metrics_collector {
         batch_intaker.set_metrics_collector(collector);

--- a/facilitator/src/metrics.rs
+++ b/facilitator/src/metrics.rs
@@ -83,6 +83,8 @@ impl IntakeMetricsCollector {
 pub struct AggregateMetricsCollector {
     pub aggregate_tasks_started: IntCounter,
     pub aggregate_tasks_finished: IntCounterVec,
+    pub invalid_own_validation_batches: IntCounterVec,
+    pub invalid_peer_validation_batches: IntCounterVec,
 }
 
 impl AggregateMetricsCollector {
@@ -100,9 +102,25 @@ impl AggregateMetricsCollector {
         )
         .context("failed to register metrics counter for finished aggregations")?;
 
+        let invalid_own_validation_batches = register_int_counter_vec!(
+            "facilitator_invalid_own_validation_batches",
+            "Number of invalid own validation batches encountered during aggregation",
+            &["reason"]
+        )
+        .context("failed to register metrics counter for invalid own validation batches")?;
+
+        let invalid_peer_validation_batches = register_int_counter_vec!(
+            "facilitator_invalid_peer_validation_batches",
+            "Number of invalid peer validation batches encountered during aggregation",
+            &["reason"]
+        )
+        .context("failed to register metrics counter for invalid peer validation batches")?;
+
         Ok(AggregateMetricsCollector {
             aggregate_tasks_started,
             aggregate_tasks_finished,
+            invalid_own_validation_batches,
+            invalid_peer_validation_batches,
         })
     }
 }

--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -19,6 +19,7 @@ use facilitator::{
 };
 use prio::{encrypt::PrivateKey, util::reconstruct_shares};
 use std::collections::{HashMap, HashSet};
+use tempfile::TempDir;
 use uuid::Uuid;
 
 #[test]
@@ -33,12 +34,380 @@ fn inconsistent_ingestion_batches() {
     end_to_end_test(Some(3), Some(4))
 }
 
+/// This test verifies that if some subset of the batches being aggregated are
+/// invalid due to either an invalid signature or an invalid packet file digest,
+/// the remainder of the valid batches will still be summed.
+#[test]
+fn aggregation_including_invalid_batch() {
+    log_init();
+
+    let pha_tempdir = TempDir::new().unwrap();
+    let facilitator_tempdir = TempDir::new().unwrap();
+
+    let instance_name = "fake-instance";
+    let aggregation_name = "fake-aggregation-1";
+    let date = NaiveDateTime::from_timestamp(2234567890, 654321);
+    let start_date = NaiveDateTime::from_timestamp(1234567890, 654321);
+    let end_date = NaiveDateTime::from_timestamp(3234567890, 654321);
+
+    let mut ingestor_pub_keys = HashMap::new();
+    ingestor_pub_keys.insert(
+        default_ingestor_private_key().identifier,
+        default_ingestor_public_key(),
+    );
+
+    let mut pha_output = SampleOutput {
+        transport: SignableTransport {
+            transport: Box::new(LocalFileTransport::new(
+                pha_tempdir.path().join("ingestion"),
+            )),
+            batch_signing_key: default_ingestor_private_key(),
+        },
+        packet_encryption_key: PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap(),
+        drop_nth_packet: None,
+    };
+
+    let mut facilitator_output = SampleOutput {
+        transport: SignableTransport {
+            transport: Box::new(LocalFileTransport::new(
+                facilitator_tempdir.path().join("ingestion"),
+            )),
+            batch_signing_key: default_ingestor_private_key(),
+        },
+        packet_encryption_key: PrivateKey::from_base64(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY)
+            .unwrap(),
+        drop_nth_packet: None,
+    };
+
+    // We generate four batches:
+    //   - batches 1 and 2 will have valid ingestion, own and peer batches and
+    //     should be summed normally
+    //   - batch 3's peer validation batches will be signed with the wrong key
+    //     by PHA and facilitator
+    //   - batch 4's own validation batches will have the wrong packet file
+    //     digest inserted into their headers by PHA and facilitator
+    let batch_uuids_and_dates = vec![
+        (Uuid::new_v4(), date),
+        (Uuid::new_v4(), date),
+        (Uuid::new_v4(), date),
+        (Uuid::new_v4(), date),
+    ];
+
+    let mut reference_sums = vec![];
+
+    for (batch_uuid, _) in &batch_uuids_and_dates {
+        let reference_sum = generate_ingestion_sample(
+            batch_uuid,
+            aggregation_name,
+            &date,
+            10,
+            100,
+            0.11,
+            100,
+            100,
+            &mut pha_output,
+            &mut facilitator_output,
+        )
+        .unwrap();
+
+        reference_sums.push(reference_sum);
+    }
+
+    let mut ingestor_pub_keys = HashMap::new();
+    ingestor_pub_keys.insert(
+        default_ingestor_private_key().identifier,
+        default_ingestor_public_key(),
+    );
+
+    // PHA reads ingestion batches from this transport
+    let mut pha_ingest_transport = VerifiableAndDecryptableTransport {
+        transport: VerifiableTransport {
+            transport: Box::new(LocalFileTransport::new(
+                pha_tempdir.path().join("ingestion"),
+            )),
+            batch_signing_public_keys: ingestor_pub_keys.clone(),
+        },
+        packet_decryption_keys: vec![
+            PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap(),
+            PrivateKey::from_base64(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY).unwrap(),
+        ],
+    };
+
+    // Facilitator reads ingestion batches from this transport
+    let mut facilitator_ingest_transport = VerifiableAndDecryptableTransport {
+        transport: VerifiableTransport {
+            transport: Box::new(LocalFileTransport::new(
+                facilitator_tempdir.path().join("ingestion"),
+            )),
+            batch_signing_public_keys: ingestor_pub_keys,
+        },
+        packet_decryption_keys: vec![
+            PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap(),
+            PrivateKey::from_base64(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY).unwrap(),
+        ],
+    };
+
+    // PHA uses this transport to send correctly signed validation batches to
+    // facilitator
+    let mut pha_to_facilitator_validation_transport_valid_key = SignableTransport {
+        transport: Box::new(LocalFileTransport::new(
+            facilitator_tempdir.path().join("peer-validation"),
+        )),
+        batch_signing_key: default_pha_signing_private_key(),
+    };
+
+    // PHA uses this transport to send incorrectly signed validation batches to
+    // facilitator
+    let mut pha_to_facilitator_validation_transport_wrong_key = SignableTransport {
+        transport: Box::new(LocalFileTransport::new(
+            facilitator_tempdir.path().join("peer-validation"),
+        )),
+        // Intentionally the wrong key
+        batch_signing_key: default_facilitator_signing_private_key(),
+    };
+
+    // Facilitator uses this transport to send correctly signed validation
+    // batches to PHA
+    let mut facilitator_to_pha_validation_transport_valid_key = SignableTransport {
+        transport: Box::new(LocalFileTransport::new(
+            pha_tempdir.path().join("peer-validation"),
+        )),
+        batch_signing_key: default_facilitator_signing_private_key(),
+    };
+
+    // Facilitator uses this transport to send incorrectly signed validation
+    // batches to facilitator
+    let mut facilitator_to_pha_validation_transport_wrong_key = SignableTransport {
+        transport: Box::new(LocalFileTransport::new(
+            pha_tempdir.path().join("peer-validation"),
+        )),
+        // Intentionally the wrong key
+        batch_signing_key: default_pha_signing_private_key(),
+    };
+
+    // PHA uses this transport to send correctly signed validation batches to
+    // itself
+    let mut pha_own_validation_transport = SignableTransport {
+        transport: Box::new(LocalFileTransport::new(
+            pha_tempdir.path().join("own-validation"),
+        )),
+        batch_signing_key: default_pha_signing_private_key(),
+    };
+
+    // Facilitator uses this transport to send correctly signed validation
+    // batches to itself
+    let mut facilitator_own_validation_transport = SignableTransport {
+        transport: Box::new(LocalFileTransport::new(
+            facilitator_tempdir.path().join("own-validation"),
+        )),
+        batch_signing_key: default_facilitator_signing_private_key(),
+    };
+
+    // Perform the intake over the batches, on the PHA and then facilitator,
+    // tampering with signatures or batch headers as needed.
+    for (index, (uuid, _)) in batch_uuids_and_dates.iter().enumerate() {
+        let pha_peer_validation_transport = if index == 2 {
+            log::info!("using wrong key for peer validations");
+            &mut pha_to_facilitator_validation_transport_wrong_key
+        } else {
+            &mut pha_to_facilitator_validation_transport_valid_key
+        };
+        let facilitator_peer_validation_transport = if index == 2 {
+            log::info!("using wrong key for peer validations");
+            &mut facilitator_to_pha_validation_transport_wrong_key
+        } else {
+            &mut facilitator_to_pha_validation_transport_valid_key
+        };
+
+        let mut pha_batch_intaker = BatchIntaker::new(
+            aggregation_name,
+            &uuid,
+            &date,
+            &mut pha_ingest_transport,
+            &mut pha_own_validation_transport,
+            pha_peer_validation_transport,
+            true, // is_first
+        )
+        .unwrap();
+
+        let mut facilitator_batch_intaker = BatchIntaker::new(
+            aggregation_name,
+            &uuid,
+            &date,
+            &mut facilitator_ingest_transport,
+            &mut facilitator_own_validation_transport,
+            facilitator_peer_validation_transport,
+            false, // is_first
+        )
+        .unwrap();
+
+        if index == 3 {
+            pha_batch_intaker.set_use_bogus_packet_file_digest(true);
+            facilitator_batch_intaker.set_use_bogus_packet_file_digest(true);
+        }
+
+        pha_batch_intaker.generate_validation_share(|| {}).unwrap();
+        facilitator_batch_intaker
+            .generate_validation_share(|| {})
+            .unwrap();
+    }
+
+    // Batch signing keys advertised by PHA
+    let mut pha_pub_keys = HashMap::new();
+    pha_pub_keys.insert(
+        default_pha_signing_private_key().identifier,
+        default_pha_signing_public_key(),
+    );
+
+    // Batch signing keys advertised by facilitator
+    let mut facilitator_pub_keys = HashMap::new();
+    facilitator_pub_keys.insert(
+        default_facilitator_signing_private_key().identifier,
+        default_facilitator_signing_public_key(),
+    );
+
+    // PHA uses this transport to read its own validations
+    let mut pha_own_validation_transport = VerifiableTransport {
+        transport: Box::new(LocalFileTransport::new(
+            pha_tempdir.path().join("own-validation"),
+        )),
+        batch_signing_public_keys: pha_pub_keys.clone(),
+    };
+
+    // PHA uses this transport to read facilitator's validations
+    let mut pha_peer_validation_transport = VerifiableTransport {
+        transport: Box::new(LocalFileTransport::new(
+            pha_tempdir.path().join("peer-validation"),
+        )),
+        batch_signing_public_keys: facilitator_pub_keys.clone(),
+    };
+
+    // Facilitator uses this transport to read its own validations
+    let mut facilitator_own_validation_transport = VerifiableTransport {
+        transport: Box::new(LocalFileTransport::new(
+            facilitator_tempdir.path().join("own-validation"),
+        )),
+        batch_signing_public_keys: facilitator_pub_keys.clone(),
+    };
+
+    // Facilitator uses this transport to read PHA's validations
+    let mut facilitator_peer_validation_transport = VerifiableTransport {
+        transport: Box::new(LocalFileTransport::new(
+            facilitator_tempdir.path().join("peer-validation"),
+        )),
+        batch_signing_public_keys: pha_pub_keys.clone(),
+    };
+
+    // PHA uses this transport to send sum parts
+    let mut pha_aggregation_transport = SignableTransport {
+        transport: Box::new(LocalFileTransport::new(pha_tempdir.path().to_path_buf())),
+        batch_signing_key: default_pha_signing_private_key(),
+    };
+
+    // Facilitator uses this transport to send sum parts
+    let mut facilitator_aggregation_transport = SignableTransport {
+        transport: Box::new(LocalFileTransport::new(
+            facilitator_tempdir.path().to_path_buf(),
+        )),
+        batch_signing_key: default_facilitator_signing_private_key(),
+    };
+
+    // Perform the aggregation on PHA and facilitator
+    BatchAggregator::new(
+        instance_name,
+        aggregation_name,
+        &start_date,
+        &end_date,
+        true, // is_first
+        &mut pha_ingest_transport,
+        &mut pha_own_validation_transport,
+        &mut pha_peer_validation_transport,
+        &mut pha_aggregation_transport,
+    )
+    .unwrap()
+    .generate_sum_part(&batch_uuids_and_dates, || {})
+    .unwrap();
+
+    BatchAggregator::new(
+        instance_name,
+        aggregation_name,
+        &start_date,
+        &end_date,
+        false, // is_first
+        &mut facilitator_ingest_transport,
+        &mut facilitator_own_validation_transport,
+        &mut facilitator_peer_validation_transport,
+        &mut facilitator_aggregation_transport,
+    )
+    .unwrap()
+    .generate_sum_part(&batch_uuids_and_dates, || {})
+    .unwrap();
+
+    // Read in sum parts written by PHA and facilitator
+    let mut pha_aggregation_batch_reader: BatchReader<'_, SumPart, InvalidPacket> =
+        BatchReader::new(
+            Batch::new_sum(
+                instance_name,
+                aggregation_name,
+                &start_date,
+                &end_date,
+                true, // is_first
+            ),
+            &mut *pha_aggregation_transport.transport,
+        );
+    let pha_sum_part = pha_aggregation_batch_reader.header(&pha_pub_keys).unwrap();
+
+    let mut facilitator_aggregation_batch_reader: BatchReader<'_, SumPart, InvalidPacket> =
+        BatchReader::new(
+            Batch::new_sum(
+                instance_name,
+                aggregation_name,
+                &start_date,
+                &end_date,
+                false, // is_first
+            ),
+            &mut *facilitator_aggregation_transport.transport,
+        );
+    let facilitator_sum_part = facilitator_aggregation_batch_reader
+        .header(&facilitator_pub_keys)
+        .unwrap();
+
+    // We expect only the first two batches to be included in the aggregation
+    // because we tampered with 3 and 4
+    let reference_sum = reconstruct_shares(&reference_sums[0].sum, &reference_sums[1].sum).unwrap();
+    let expected_included_batch_uuids =
+        vec![batch_uuids_and_dates[0].0, batch_uuids_and_dates[1].0];
+    let expected_contributions_count =
+        reference_sums[0].contributions as i64 + reference_sums[1].contributions as i64;
+
+    assert_eq!(
+        pha_sum_part.total_individual_clients,
+        expected_contributions_count
+    );
+    assert_eq!(pha_sum_part.batch_uuids, expected_included_batch_uuids);
+    assert_eq!(
+        facilitator_sum_part.total_individual_clients,
+        expected_contributions_count
+    );
+    assert_eq!(
+        facilitator_sum_part.batch_uuids,
+        expected_included_batch_uuids
+    );
+
+    let reconstructed_sum = reconstruct_shares(
+        &pha_sum_part.sum().unwrap(),
+        &facilitator_sum_part.sum().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(reference_sum, reconstructed_sum);
+}
+
 fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usize>) {
     log_init();
-    let pha_tempdir = tempfile::TempDir::new().unwrap();
-    let pha_copy_tempdir = tempfile::TempDir::new().unwrap();
-    let facilitator_tempdir = tempfile::TempDir::new().unwrap();
-    let facilitator_copy_tempdir = tempfile::TempDir::new().unwrap();
+    let pha_tempdir = TempDir::new().unwrap();
+    let pha_copy_tempdir = TempDir::new().unwrap();
+    let facilitator_tempdir = TempDir::new().unwrap();
+    let facilitator_copy_tempdir = TempDir::new().unwrap();
 
     let instance_name = "fake-instance";
     let aggregation_name = "fake-aggregation-1".to_owned();


### PR DESCRIPTION
We are losing whole aggregations because one peer validation batch out
of ~900 happens to have an invalid signature or an incorrect packet file
digest in its header. We should still be able to aggregate the other 899
batches in such a case. We now continue with the aggregation if an
individual call to `BatchAggregator::aggregate_share()` fails.

We also now gather metrics on how many invalid own and peer validation
batches are encountered during an aggregation. This will enable us to
get a better idea of how often the bug that caused invalid validation
batches occurs.

Resolves #343
Resolves #345