### PR TITLE
terraform: set workflow-manager memory limit to 8G

### DIFF
--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -283,7 +283,7 @@ resource "kubernetes_cron_job" "workflow_manager" {
                   cpu    = "0.5"
                 }
                 limits {
-                  memory = "2Gi"
+                  memory = "8Gi"
                   cpu    = "1.5"
                 }
               }


### PR DESCRIPTION
On 2021/2/4, we saw some `workflow-manager` jobs fail with OOM, because
the arrival of new aggregations on the Apple side increased the
steady-state count of objects in ingestion buckets, eventually pushing
those `workflow-manager` jobs over the existing 2 Gi memory limit. This
was resolved by manually bumping the failing cronjobs' memory limits to
4 Gi. This commit makes a more permanent change to set the memory limits
to 8 Gi (because I _really_ don't want to get paged about this again). A
more robust change to limit the memory footprint of `workflow-manager`
will come when we address #162.