### PR TITLE
Reject unexpected manifest keys

### DIFF
--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -479,7 +479,7 @@ mod tests {
     }
 }
         "#,
-            // unexpected field
+            // unexpected top-level field
             r#"
 {
     "format": 0,
@@ -672,7 +672,7 @@ mod tests {
     "peer-validation-bucket": "us-west-1/validation"
 }
 "#,
-            // Unexpected field
+            // Unexpected top-level field
             r#"
 {
     "format": 1,
@@ -936,7 +936,7 @@ mod tests {
     }
 }
     "#,
-            // Unexpected field
+            // Unexpected top-level field
             r#"
 {
     "format": 1,
@@ -1048,7 +1048,7 @@ mod tests {
     "facilitator-sum-part-bucket": "gs://facilitator-bucket"
 }
     "#,
-            // Unexpected field
+            // Unexpected top-level field
             r#"
 {
     "format": 1,

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -53,7 +53,7 @@ pub struct DataShareProcessorGlobalManifest {
 /// Represents the server-identity map inside a data share processor global
 /// manifest.
 #[derive(Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct DataShareProcessorServerIdentity {
     /// The numeric account ID of the AWS account this data share processor will
     /// use to access peer cloud resources.
@@ -488,6 +488,17 @@ mod tests {
         "gcp-service-account-email": "service-account@project-name.iam.gserviceaccount.com"
     },
     "unexpected": "some value"
+}
+        "#,
+            // unexpected server-identity field
+            r#"
+{
+    "format": 0,
+    "server-identity": {
+        "aws-account-id": 12345678901234567,
+        "gcp-service-account-email": "service-account@project-name.iam.gserviceaccount.com",
+        "unexpected": "some value"
+    }
 }
         "#,
         ];

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -40,7 +40,7 @@ struct PacketEncryptionCertificateSigningRequest {
 /// design document for the full specification.
 /// https://docs.google.com/document/d/1MdfM3QT63ISU70l63bwzTrxr93Z7Tv7EDjLfammzo6Q/edit#heading=h.3j8dgxqo5h68
 #[derive(Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct DataShareProcessorGlobalManifest {
     /// Format version of the manifest. Versions besides the currently supported
     /// one are rejected.
@@ -477,6 +477,17 @@ mod tests {
         "aws-account-id": 12345678901234567,
         "gcp-service-account-email": 14
     }
+}
+        "#,
+            // unexpected field
+            r#"
+{
+    "format": 0,
+    "server-identity": {
+        "aws-account-id": 12345678901234567,
+        "gcp-service-account-email": "service-account@project-name.iam.gserviceaccount.com"
+    },
+    "unexpected": "some value"
 }
         "#,
         ];

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -263,7 +263,7 @@ impl IngestionServerManifest {
 
 /// Represents the global manifest for a portal server.
 #[derive(Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct PortalServerGlobalManifest {
     /// Format version of the manifest. Versions besides the currently supported
     /// one are rejected.
@@ -1044,8 +1044,17 @@ mod tests {
             // Missing field
             r#"
 {
-    "format": 0,
+    "format": 1,
+    "facilitator-sum-part-bucket": "gs://facilitator-bucket"
+}
+    "#,
+            // Unexpected field
+            r#"
+{
+    "format": 1,
     "facilitator-sum-part-bucket": "gs://facilitator-bucket",
+    "pha-sum-part-bucket": "gs://pha-bucket",
+    "unexpected": "some value"
 }
     "#,
         ];

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -169,7 +169,7 @@ impl SpecificManifest {
 /// Represents the server-identity structure within an ingestion server global
 /// manifest. One of aws_iam_entity or google_service_account should be Some.
 #[derive(Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct IngestionServerIdentity {
     /// The ARN of the AWS IAM entity that this ingestion server uses to access
     /// ingestion buckets,
@@ -927,6 +927,23 @@ mod tests {
     "server-identity": {
         "aws-iam-entity": "arn:aws:iam::338276578713:role/ingestor-1-role",
         "gcp-service-account-email": "foo@bar.com"
+    },
+    "batch-signing-public-keys": {
+        "key-identifier-1": {
+            "public-key": "----BEGIN PUBLIC KEY----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEI3MQm+HzXvaYa2mVlhB4zknbtAT8cSxakmBoJcBKGqGw\nYS0bhxSpuvABM1kdBTDpQhXnVdcq+LSiukXJRpGHVg==\n----END PUBLIC KEY----",
+            "expiration": "2021-01-15T18:53:20Z"
+        }
+    }
+}
+    "#,
+            // Unexpected server-identity field
+            r#"
+{
+    "format": 1,
+    "server-identity": {
+        "aws-iam-entity": "arn:aws:iam::338276578713:role/ingestor-1-role",
+        "gcp-service-account-email": "foo@bar.com",
+        "unexpected": "some value"
     },
     "batch-signing-public-keys": {
         "key-identifier-1": {

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -187,7 +187,7 @@ struct IngestionServerIdentity {
 /// Represents an ingestion server's manifest. This could be a global manifest
 /// or a locality-specific manifest.
 #[derive(Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct IngestionServerManifest {
     /// Format version of the manifest. Versions besides the currently supported
     /// one are rejected.
@@ -924,6 +924,23 @@ mod tests {
             r#"
 {
     "format": "zero",
+    "server-identity": {
+        "aws-iam-entity": "arn:aws:iam::338276578713:role/ingestor-1-role",
+        "gcp-service-account-email": "foo@bar.com"
+    },
+    "batch-signing-public-keys": {
+        "key-identifier-1": {
+            "public-key": "----BEGIN PUBLIC KEY----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEI3MQm+HzXvaYa2mVlhB4zknbtAT8cSxakmBoJcBKGqGw\nYS0bhxSpuvABM1kdBTDpQhXnVdcq+LSiukXJRpGHVg==\n----END PUBLIC KEY----",
+            "expiration": "2021-01-15T18:53:20Z"
+        }
+    }
+}
+    "#,
+            // Unexpected field
+            r#"
+{
+    "format": 1,
+    "unexpected": "some value",
     "server-identity": {
         "aws-iam-entity": "arn:aws:iam::338276578713:role/ingestor-1-role",
         "gcp-service-account-email": "foo@bar.com"

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -19,7 +19,7 @@ pub type BatchSigningPublicKeys = HashMap<String, UnparsedPublicKey<Vec<u8>>>;
 /// Represents the description of a batch signing public key in a specific
 /// manifest.
 #[derive(Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct BatchSigningPublicKey {
     /// The PEM-armored base64 encoding of the ASN.1 encoding of the PKIX
     /// SubjectPublicKeyInfo structure of an ECDSA P256 key.
@@ -648,6 +648,27 @@ mod tests {
     "ingestion-bucket": "us-west-1/ingestion",
     "ingestion-identity": 1,
     "peer-validation-bucket": "us-west-1/validation"
+}
+"#,
+            // Unexpected BatchSigningPublicKey field
+            r#"
+{
+    "format": 1,
+    "packet-encryption-keys": {
+        "fake-key-1": {
+            "certificate-signing-request": "who cares"
+        }
+    },
+    "batch-signing-public-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\nfoo\n-----END PUBLIC KEY-----",
+        "unexpected": "some value"
+      }
+    },
+    "ingestion-bucket": "s3://us-west-1/ingestion",
+    "ingestion-identity": "arn:aws:iam:something:fake",
+    "peer-validation-bucket": "gs://validation"
 }
 "#,
         ];

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -574,9 +574,9 @@ mod tests {
             // No format key
             r#"
 {
-    "packet-encryption-certificates": {
+    "packet-encryption-keys": {
         "fake-key-1": {
-            "certificate": "who cares"
+            "certificate-signing-request": "who cares"
         }
     },
     "batch-signing-public-keys": {
@@ -594,9 +594,9 @@ mod tests {
             r#"
 {
     "format": 0,
-    "packet-encryption-certificates": {
+    "packet-encryption-keys": {
         "fake-key-1": {
-            "certificate": "who cares"
+            "certificate-signing-request": "who cares"
         }
     },
     "batch-signing-public-keys": {
@@ -614,9 +614,9 @@ mod tests {
             r#"
 {
     "format": "zero",
-    "packet-encryption-certificates": {
+    "packet-encryption-keys": {
         "fake-key-1": {
-            "certificate": "who cares"
+            "certificate-signing-request": "who cares"
         }
     },
     "batch-signing-public-keys": {
@@ -633,10 +633,10 @@ mod tests {
             // Role ARN with wrong type
             r#"
 {
-    "format": 0,
-    "packet-encryption-certificates": {
+    "format": 1,
+    "packet-encryption-keys": {
         "fake-key-1": {
-            "certificate": "who cares"
+            "certificate-signing-request": "who cares"
         }
     },
     "batch-signing-public-keys": {

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -29,7 +29,7 @@ struct BatchSigningPublicKey {
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 struct PacketEncryptionCertificateSigningRequest {
     /// The PEM-armored base64 encoding of the ASN.1 encoding of a PKCS#10
     /// certificate signing request containing an ECDSA P256 key.
@@ -664,6 +664,27 @@ mod tests {
         "expiration": "",
         "public-key": "-----BEGIN PUBLIC KEY-----\nfoo\n-----END PUBLIC KEY-----",
         "unexpected": "some value"
+      }
+    },
+    "ingestion-bucket": "s3://us-west-1/ingestion",
+    "ingestion-identity": "arn:aws:iam:something:fake",
+    "peer-validation-bucket": "gs://validation"
+}
+"#,
+            // Unexpected PacketEncryptionCertificateSigningRequest field
+            r#"
+{
+    "format": 1,
+    "packet-encryption-keys": {
+        "fake-key-1": {
+            "certificate-signing-request": "who cares",
+            "unexpected": "some value"
+        }
+    },
+    "batch-signing-public-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\nfoo\n-----END PUBLIC KEY-----"
       }
     },
     "ingestion-bucket": "s3://us-west-1/ingestion",

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -893,7 +893,7 @@ mod tests {
             r#"
 {
     "server-identity": {
-        "aws-iam-entity": "arn:aws:iam::338276578713:role/ingestor-1-role"
+        "aws-iam-entity": "arn:aws:iam::338276578713:role/ingestor-1-role",
         "gcp-service-account-email": "foo@bar.com"
     },
     "batch-signing-public-keys": {
@@ -909,7 +909,7 @@ mod tests {
 {
     "format": 2,
     "server-identity": {
-        "aws-iam-entity": "arn:aws:iam::338276578713:role/ingestor-1-role"
+        "aws-iam-entity": "arn:aws:iam::338276578713:role/ingestor-1-role",
         "gcp-service-account-email": "foo@bar.com"
     },
     "batch-signing-public-keys": {
@@ -925,7 +925,7 @@ mod tests {
 {
     "format": "zero",
     "server-identity": {
-        "aws-iam-entity": "arn:aws:iam::338276578713:role/ingestor-1-role"
+        "aws-iam-entity": "arn:aws:iam::338276578713:role/ingestor-1-role",
         "gcp-service-account-email": "foo@bar.com"
     },
     "batch-signing-public-keys": {

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -88,7 +88,7 @@ impl DataShareProcessorGlobalManifest {
 /// specification.
 /// https://docs.google.com/document/d/1MdfM3QT63ISU70l63bwzTrxr93Z7Tv7EDjLfammzo6Q/edit#heading=h.3j8dgxqo5h68
 #[derive(Debug, Deserialize, PartialEq)]
-#[serde(rename_all = "kebab-case")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case")]
 pub struct SpecificManifest {
     /// Format version of the manifest. Versions besides the currently supported
     /// one are rejected.
@@ -670,6 +670,27 @@ mod tests {
     "ingestion-bucket": "us-west-1/ingestion",
     "ingestion-identity": 1,
     "peer-validation-bucket": "us-west-1/validation"
+}
+"#,
+            // Unexpected field
+            r#"
+{
+    "format": 1,
+    "packet-encryption-keys": {
+        "fake-key-1": {
+            "certificate-signing-request": "who cares"
+        }
+    },
+    "batch-signing-public-keys": {
+        "fake-key-2": {
+        "expiration": "",
+        "public-key": "-----BEGIN PUBLIC KEY-----\nfoo\n-----END PUBLIC KEY-----"
+      }
+    },
+    "ingestion-bucket": "s3://us-west-1/ingestion",
+    "ingestion-identity": "arn:aws:iam:something:fake",
+    "peer-validation-bucket": "gs://validation",
+    "unexpected": "some value"
 }
 "#,
             // Unexpected BatchSigningPublicKey field


### PR DESCRIPTION
Fixes https://github.com/abetterinternet/prio-server/issues/266.

Now when running `facilitator lint-manifest` on the manifest from #266, the output is:
```
Error: failed to decode JSON manifest

Caused by:
    unknown field `google-service-account`, expected one of `aws-iam-entity`, `gcp-service-account-id`, `gcp-service-account-email` at line 5 column 28
```

The changes made to the other test cases in this PR were to get them passing for the documented reason. For instance, the comment above a manifest we expect to be invalid may say something like `// No format key`, however, the manifest was also invalid due to an incorrect field name, missing comma, etc.