### PR TITLE
Add dependabot configuration for all of our currently used packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/deploy-tool"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/faciliator"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/faciliator"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "terraform"
+    directory: "/terraform"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gomod"
+    directory: "/workflow-manager"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    directory: "/workflow-manager"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
We're relying on a bunch of dependencies, let's add dependabot (https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) configuration to our source so we can use the automated dependency updates offered by dependabot.