### PR TITLE
Get rid of all clippy warnings

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -53,27 +53,27 @@ fn path_validator(s: String) -> Result<(), String> {
 // Trait applied to clap::App to extend its builder pattern with some helpers
 // specific to our use case.
 trait AppArgumentAdder {
-    fn add_is_first_argument(self: Self) -> Self;
+    fn add_is_first_argument(self) -> Self;
 
-    fn add_instance_name_argument(self: Self) -> Self;
+    fn add_instance_name_argument(self) -> Self;
 
-    fn add_manifest_base_url_argument(self: Self, entity: Entity) -> Self;
+    fn add_manifest_base_url_argument(self, entity: Entity) -> Self;
 
-    fn add_storage_arguments(self: Self, entity: Entity, in_out: InOut) -> Self;
+    fn add_storage_arguments(self, entity: Entity, in_out: InOut) -> Self;
 
-    fn add_batch_public_key_arguments(self: Self, entity: Entity) -> Self;
+    fn add_batch_public_key_arguments(self, entity: Entity) -> Self;
 
-    fn add_batch_signing_key_arguments(self: Self) -> Self;
+    fn add_batch_signing_key_arguments(self) -> Self;
 
-    fn add_packet_decryption_key_argument(self: Self) -> Self;
+    fn add_packet_decryption_key_argument(self) -> Self;
 
-    fn add_gcp_service_account_key_file_argument(self: Self) -> Self;
+    fn add_gcp_service_account_key_file_argument(self) -> Self;
 
-    fn add_task_queue_arguments(self: Self) -> Self;
+    fn add_task_queue_arguments(self) -> Self;
 
-    fn add_metrics_scrape_port_argument(self: Self) -> Self;
+    fn add_metrics_scrape_port_argument(self) -> Self;
 
-    fn add_use_bogus_packet_file_digest_argument(self: Self) -> Self;
+    fn add_use_bogus_packet_file_digest_argument(self) -> Self;
 }
 
 const SHARED_HELP: &str = "Storage arguments: Any flag ending in -input or -output can take an \
@@ -1377,18 +1377,18 @@ fn intake_task_queue_from_args(
     let task_queue_kind = TaskQueueKind::from_str(
         matches
             .value_of("task-queue-kind")
-            .ok_or(anyhow!("task-queue-kind is required"))?,
+            .ok_or_else(|| anyhow!("task-queue-kind is required"))?,
     )?;
     let identity = matches.value_of("task-queue-identity");
     let queue_name = matches
         .value_of("task-queue-name")
-        .ok_or(anyhow!("task-queue-name is required"))?;
+        .ok_or_else(|| anyhow!("task-queue-name is required"))?;
 
     match task_queue_kind {
         TaskQueueKind::GcpPubSub => {
             let gcp_project_id = matches
                 .value_of("gcp-project-id")
-                .ok_or(anyhow!("gcp-project-id is required"))?;
+                .ok_or_else(|| anyhow!("gcp-project-id is required"))?;
             let pubsub_api_endpoint = matches.value_of("pubsub-api-endpoint");
             Ok(Box::new(GcpPubSubTaskQueue::new(
                 pubsub_api_endpoint,
@@ -1400,7 +1400,7 @@ fn intake_task_queue_from_args(
         TaskQueueKind::AwsSqs => {
             let sqs_region = matches
                 .value_of("aws-sqs-region")
-                .ok_or(anyhow!("aws-sqs-region is required"))?;
+                .ok_or_else(|| anyhow!("aws-sqs-region is required"))?;
             Ok(Box::new(AwsSqsTaskQueue::new(sqs_region, queue_name)?))
         }
     }
@@ -1412,18 +1412,18 @@ fn aggregation_task_queue_from_args(
     let task_queue_kind = TaskQueueKind::from_str(
         matches
             .value_of("task-queue-kind")
-            .ok_or(anyhow!("task-queue-kind is required"))?,
+            .ok_or_else(|| anyhow!("task-queue-kind is required"))?,
     )?;
     let identity = matches.value_of("task-queue-identity");
     let queue_name = matches
         .value_of("task-queue-name")
-        .ok_or(anyhow!("task-queue-name is required"))?;
+        .ok_or_else(|| anyhow!("task-queue-name is required"))?;
 
     match task_queue_kind {
         TaskQueueKind::GcpPubSub => {
             let gcp_project_id = matches
                 .value_of("gcp-project-id")
-                .ok_or(anyhow!("gcp-project-id is required"))?;
+                .ok_or_else(|| anyhow!("gcp-project-id is required"))?;
             let pubsub_api_endpoint = matches.value_of("pubsub-api-endpoint");
             Ok(Box::new(GcpPubSubTaskQueue::new(
                 pubsub_api_endpoint,
@@ -1435,7 +1435,7 @@ fn aggregation_task_queue_from_args(
         TaskQueueKind::AwsSqs => {
             let sqs_region = matches
                 .value_of("aws-sqs-region")
-                .ok_or(anyhow!("aws-sqs-region is required"))?;
+                .ok_or_else(|| anyhow!("aws-sqs-region is required"))?;
             Ok(Box::new(AwsSqsTaskQueue::new(sqs_region, queue_name)?))
         }
     }

--- a/facilitator/src/http.rs
+++ b/facilitator/src/http.rs
@@ -124,7 +124,7 @@ pub(crate) fn send_json_request(request: Request, body: SerdeValue) -> Result<Re
 // string.
 pub(crate) fn simple_get_request(url: Url) -> Result<String> {
     let request = prepare_request_without_agent(RequestParameters {
-        url: url,
+        url,
         method: Method::Get,
         ..Default::default()
     })

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -342,7 +342,7 @@ fn public_key_from_pem(pem_key: &str) -> Result<UnparsedPublicKey<Vec<u8>>> {
     // blob inside the PEM has the expected prefix for this kind of key in
     // this kind of encoding, as suggested in this GitHub issue on ring:
     // https://github.com/briansmith/ring/issues/881
-    if pem_key == "" {
+    if pem_key.is_empty() {
         return Err(anyhow!("empty PEM input"));
     }
     let pem = pem::parse(&pem_key).context(format!("failed to parse key as PEM: {}", pem_key))?;

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -42,10 +42,7 @@ pub struct ReferenceSum {
 }
 
 fn drop_packet(count: usize, drop_nth_packet: Option<usize>) -> bool {
-    match drop_nth_packet {
-        Some(nth) if count % nth == 0 => true,
-        _ => false,
-    }
+    matches!(drop_nth_packet, Some(nth) if count % nth == 0)
 }
 
 #[allow(clippy::too_many_arguments)] // Grandfathered in

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -152,7 +152,6 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
                 )?,
                 method: Method::Post,
                 token_provider: Some(&mut self.oauth_token_provider),
-                ..Default::default()
             },
         )?;
 
@@ -181,7 +180,7 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
             ));
         }
 
-        if received_messages.len() == 0 {
+        if received_messages.is_empty() {
             return Ok(None);
         }
 
@@ -193,7 +192,7 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
             .context(format!("failed to decode task {:?} from JSON", task_json))?;
 
         let handle = TaskHandle {
-            task: task,
+            task,
             acknowledgment_id: received_messages[0].ack_id.clone(),
         };
 
@@ -219,7 +218,6 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
                 )?,
                 method: Method::Post,
                 token_provider: Some(&mut self.oauth_token_provider),
-                ..Default::default()
             },
         )?;
 
@@ -243,9 +241,8 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
             self.oauth_token_provider,
         );
 
-        Ok(self
-            .modify_ack_deadline(&handle, &Duration::from_secs(0))
-            .context("failed to nacknowledge task")?)
+        self.modify_ack_deadline(&handle, &Duration::from_secs(0))
+            .context("failed to nacknowledge task")
     }
 
     fn extend_task_deadline(&mut self, handle: &TaskHandle<T>, increment: &Duration) -> Result<()> {
@@ -257,9 +254,8 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
             self.oauth_token_provider,
         );
 
-        Ok(self
-            .modify_ack_deadline(handle, increment)
-            .context("failed to extend deadline on task")?)
+        self.modify_ack_deadline(handle, increment)
+            .context("failed to extend deadline on task")
     }
 }
 
@@ -289,7 +285,6 @@ impl<T: Task> GcpPubSubTaskQueue<T> {
                 )?,
                 method: Method::Post,
                 token_provider: Some(&mut self.oauth_token_provider),
-                ..Default::default()
             },
         )?;
 


### PR DESCRIPTION
These were throwing warnings in clippy. Getting rid of them might make clippy outputs easier to read.