### PR TITLE
facilitator: use long timeouts on GCS uploads

### DIFF
--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -224,7 +224,12 @@ impl StreamingTransferWriter {
                 "failed to parse upload_session_uri url: {}",
                 &upload_session_uri
             ))?,
-            agent: AgentBuilder::new().timeout(Duration::from_secs(10)).build(),
+            // We set an unusually long timeout for uploads to GCS, per Google's
+            // recommendation:
+            // https://cloud.google.com/storage/docs/best-practices#uploading
+            agent: AgentBuilder::new()
+                .timeout(Duration::from_secs(120))
+                .build(),
         })
     }
 


### PR DESCRIPTION
This commit increases the timeout used for GCS uploads to 120 seconds
from 10 seconds. 10 seconds appeared to suffice for uploading to GCS
from within GCP, but log analysis shows that NCI intake jobs were
sometimes failing because of this timeout, in a way that your humble
commit author believes was ultimately causing the aggregation failures
we have been seeing.