### PR TITLE
terraform: restore prod-us deployment replicas

### DIFF
--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -18,20 +18,20 @@ ingestors = {
         aggregate_worker_count = 1
       }
       us-ct = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count    = 5
+        aggregate_worker_count = 3
       }
       us-md = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count    = 5
+        aggregate_worker_count = 3
       }
       us-va = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count    = 5
+        aggregate_worker_count = 3
       }
       us-wa = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count    = 5
+        aggregate_worker_count = 3
       }
     }
   }
@@ -43,20 +43,20 @@ ingestors = {
         aggregate_worker_count = 1
       }
       us-ct = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-md = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-va = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-wa = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
     }
   }


### PR DESCRIPTION
The theory about duplicate message delivery turned out to be wrong, and
scaling down our worker deployments just led to unnecessary pages
overnight. This commit restores prod-us intake-batch and aggregate
worker pools to their previous sizes, effectively reverting
36e8e62a50aa4db592f5b00443cd3e81ed74c89a.