### PR TITLE
facilitator: structured error handling

### DIFF
--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -129,7 +129,7 @@ impl<'a> BatchIntaker<'a> {
             |mut packet_writer| loop {
                 let packet = match IngestionDataSharePacket::read(&mut ingestion_packet_reader) {
                     Ok(p) => p,
-                    Err(Error::EofError) => return Ok(()),
+                    Err(Error::Eof) => return Ok(()),
                     Err(e) => return Err(e.into()),
                 };
 
@@ -205,10 +205,10 @@ impl<'a> BatchIntaker<'a> {
             &peer_header_signature,
             &self.peer_validation_batch_signing_key.identifier,
         )?;
-        self.own_validation_batch.put_signature(
+        Ok(self.own_validation_batch.put_signature(
             &own_header_signature,
             &self.own_validation_batch_signing_key.identifier,
-        )
+        )?)
     }
 }
 

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -191,10 +191,10 @@ pub fn generate_ingestion_sample(
                 &facilitator_batch_signing_key_ref.key,
             )?;
 
-            facilitator_ingestion_batch.put_signature(
+            Ok(facilitator_ingestion_batch.put_signature(
                 &facilitator_header_signature,
                 &facilitator_batch_signing_key_ref.identifier,
-            )
+            )?)
         })?;
 
     let pha_header_signature = pha_ingestion_batch.put_header(

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -348,7 +348,7 @@ impl Write for StreamingTransferWriter {
         self.buffer.extend_from_slice(buf);
         while self.buffer.len() >= self.minimum_upload_chunk_size {
             self.upload_chunk(false)
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, Error::AnyhowError(e)))?;
+                .map_err(|e| io::Error::new(io::ErrorKind::Other, Error::Anyhow(e)))?;
         }
 
         Ok(buf.len())

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -421,9 +421,8 @@ impl Write for MultipartUploadWriter {
         // enough content.
         self.buffer.extend_from_slice(buf);
         if self.buffer.len() >= self.minimum_upload_part_size {
-            self.upload_part().map_err(|e| {
-                std::io::Error::new(std::io::ErrorKind::Other, Error::AnyhowError(e))
-            })?;
+            self.upload_part()
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, Error::Anyhow(e)))?;
         }
 
         Ok(buf.len())

--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -312,10 +312,7 @@ fn aggregation_including_invalid_batch() {
     .generate_sum_part(&batch_uuids_and_dates, || {})
     .unwrap_err();
 
-    match err {
-        Error::BadPeerValidationBatch(_) => (),
-        _ => assert!(false, "unexpected error {:?}", err),
-    };
+    assert!(matches!(err, Error::BadPeerValidationBatch(_)));
 
     let err = BatchAggregator::new(
         instance_name,
@@ -332,10 +329,7 @@ fn aggregation_including_invalid_batch() {
     .generate_sum_part(&batch_uuids_and_dates, || {})
     .unwrap_err();
 
-    match err {
-        Error::BadPeerValidationBatch(_) => (),
-        _ => assert!(false, "unexpected error {:?}", err),
-    };
+    assert!(matches!(err, Error::BadPeerValidationBatch(_)));
 }
 
 fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usize>) {


### PR DESCRIPTION
This change is the start of more rigorous error handling in
`facilitator`, making better use of Rust enums to classify errors. We
introduce several new variants to the `Error` enum to specifically
capture errors around parsing or validating Avro batches. This enables
`BatchAggregator` to report when a failure is due to invalid data, in
which case we do not want to retry. We also can now tell when a failure
was due to bad data from a peer (report this but don't alert) or from
ourselves (do alert).
    
Over time, we should eliminate most if not all uses of `anyhow!` and the
`.context()` method from `Anyhow::Context` in favour of introducing
specific variants on `crate::Error`, and have all module interfaces
return `Result<T, crate::Error>` rather than the implicit `Result<T,
anyhow::Error>`.
    
See https://nick.groenen.me/posts/rust-error-handling/ for stimulating
discussion of library vs. application error handling in Rust and that
intersects with usage of `thiserror` vs. `anyhow`.
