### PR TITLE
facilitator: retries on SQS and STS requests

### DIFF
--- a/facilitator/src/task/sqs.rs
+++ b/facilitator/src/task/sqs.rs
@@ -9,7 +9,7 @@ use std::{convert::TryFrom, marker::PhantomData, str::FromStr, time::Duration};
 use tokio::runtime::Runtime;
 
 use crate::{
-    aws_credentials::{basic_runtime, DefaultCredentialsProvider},
+    aws_credentials::{basic_runtime, retry_request, DefaultCredentialsProvider},
     task::{Task, TaskHandle, TaskQueue},
 };
 
@@ -43,24 +43,24 @@ impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
 
         let client = self.sqs_client()?;
 
-        let request = ReceiveMessageRequest {
-            // Dequeue one task at a time
-            max_number_of_messages: Some(1),
-            queue_url: self.queue_url.clone(),
-            // Long polling. SQS allows us to wait up to 20 seconds.
-            // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling
-            wait_time_seconds: Some(20),
-            // Visibility timeout configures how long SQS will wait for message
-            // deletion by this client before making a message visible again to
-            // other queue consumers. We set it to 600s = 10 minutes.
-            visibility_timeout: Some(600),
-            ..Default::default()
-        };
+        let response = retry_request("dequeue SQS message", || {
+            let request = ReceiveMessageRequest {
+                // Dequeue one task at a time
+                max_number_of_messages: Some(1),
+                queue_url: self.queue_url.clone(),
+                // Long polling. SQS allows us to wait up to 20 seconds.
+                // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling
+                wait_time_seconds: Some(20),
+                // Visibility timeout configures how long SQS will wait for message
+                // deletion by this client before making a message visible again to
+                // other queue consumers. We set it to 600s = 10 minutes.
+                visibility_timeout: Some(600),
+                ..Default::default()
+            };
 
-        let response = self
-            .runtime
-            .block_on(client.receive_message(request))
-            .context("failed to dequeue message from SQS")?;
+            self.runtime.block_on(client.receive_message(request))
+        })
+        .context("failed to dequeue message from SQS")?;
 
         let received_messages = match response.messages {
             Some(ref messages) => messages,
@@ -104,15 +104,16 @@ impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
 
         let client = self.sqs_client()?;
 
-        let request = DeleteMessageRequest {
-            queue_url: self.queue_url.clone(),
-            receipt_handle: task.acknowledgment_id.clone(),
-        };
+        let response = retry_request("delete/acknowledge message in SQS", || {
+            let request = DeleteMessageRequest {
+                queue_url: self.queue_url.clone(),
+                receipt_handle: task.acknowledgment_id.clone(),
+            };
+            self.runtime.block_on(client.delete_message(request))
+        })
+        .context("failed to delete/acknowledge message in SQS");
 
-        Ok(self
-            .runtime
-            .block_on(client.delete_message(request))
-            .context("failed to delete/acknowledge message in SQS")?)
+        response
     }
 
     fn nacknowledge_task(&mut self, task: TaskHandle<T>) -> Result<()> {
@@ -179,15 +180,17 @@ impl<T: Task> AwsSqsTaskQueue<T> {
             visibility_timeout
         ))?;
 
-        let request = ChangeMessageVisibilityRequest {
-            queue_url: self.queue_url.clone(),
-            receipt_handle: task.acknowledgment_id.clone(),
-            visibility_timeout: timeout,
-        };
+        let response = retry_request("changing message visibility", || {
+            let request = ChangeMessageVisibilityRequest {
+                queue_url: self.queue_url.clone(),
+                receipt_handle: task.acknowledgment_id.clone(),
+                visibility_timeout: timeout,
+            };
+            self.runtime
+                .block_on(client.change_message_visibility(request))
+        })
+        .context("failed to change message visibility message in SQS");
 
-        Ok(self
-            .runtime
-            .block_on(client.change_message_visibility(request))
-            .context("failed to change message visibility message in SQS")?)
+        response
     }
 }


### PR DESCRIPTION
Analysis of NCI logs shows that requests to SQS can sometimes fail
because of DNS lookup failures. Further, S3 requests sometimes fail in
the credentials phase due to DNS failures, which doesn't get caught by
existing retry mechanisms because of how Rusoto bubbles up errors (see
comment in `aws_credentials.rs::retry_request`). We now will retry both
SQS client requests, and check for a CredentialsError that _probably_
wraps an HttpDispatchError so we can retry requests to STS.
Additionally, to ensure we can accurately detect the failure when using
the webidp_provider (which is what NCI does), we short circuit the chain
of providers in `ChainProvider::chain_provider_credentials`.