### PR TITLE
workflow-manager: set success metric

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,13 +62,24 @@ variable "portal_server_manifest_base_url" {
 }
 
 variable "test_peer_environment" {
-  type        = map(string)
-  default     = {}
+  type = object({
+    env_with_ingestor            = string
+    env_without_ingestor         = string
+    localities_with_sample_maker = list(string)
+  })
+  default = {
+    env_with_ingestor            = ""
+    env_without_ingestor         = ""
+    localities_with_sample_maker = []
+  }
   description = <<DESCRIPTION
 Describes a pair of data share processor environments set up to test against
 each other. One environment, named in "env_with_ingestor", hosts a fake
-ingestion server. The other, named in "env_without_ingestor", does not. This
-variable should not be specified in production deployments.
+ingestion servers, but only for the localities enumerated in
+"localities_with_sample_makers", which should be a subset of the ones in
+"localities". The other environment, named in "env_without_ingestor", has no
+fake ingestion servers. This variable should not be specified in production
+deployments.
 DESCRIPTION
 }
 

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -88,10 +88,6 @@ variable "sum_part_bucket_service_account_email" {
   type = string
 }
 
-variable "is_env_with_ingestor" {
-  type = bool
-}
-
 variable "test_peer_ingestion_bucket" {
   type = string
 }
@@ -130,6 +126,10 @@ variable "intake_worker_count" {
 
 variable "aggregate_worker_count" {
   type = number
+}
+
+variable "create_sample_maker" {
+  type = bool
 }
 
 data "aws_caller_identity" "current" {}
@@ -532,7 +532,7 @@ locals {
   # This sample maker acts as an ingestion server in our test setup. It only
   # gets created in one of the two envs, and writes to both env's ingestion
   # buckets.
-  sample_makers = var.is_env_with_ingestor ? ["kittens-seen", "dogs-petted"] : []
+  sample_makers = var.create_sample_maker ? ["kittens-seen", "dogs-petted"] : []
 }
 
 resource "kubernetes_cron_job" "sample_maker" {

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -48,8 +48,9 @@ ingestors = {
 peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
 portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
 test_peer_environment = {
-  env_with_ingestor    = "staging-facil"
-  env_without_ingestor = "staging-pha"
+  env_with_ingestor            = "staging-facil"
+  env_without_ingestor         = "staging-pha"
+  localities_with_sample_maker = ["narnia", "gondor"]
 }
 is_first                 = false
 use_aws                  = false

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -48,8 +48,9 @@ ingestors = {
 peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
 portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
 test_peer_environment = {
-  env_with_ingestor    = "staging-facil"
-  env_without_ingestor = "staging-pha"
+  env_with_ingestor            = "staging-facil"
+  env_without_ingestor         = "staging-pha"
+  localities_with_sample_maker = ["narnia", "gondor"]
 }
 is_first                 = true
 use_aws                  = true

--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -288,12 +288,12 @@ func main() {
 			log.Err(err).Str("aggregation ID", aggregationID).Msgf("Failed to schedule aggregation tasks: %s", err)
 			return
 		}
-
-		workflowManagerLastSuccess.SetToCurrentTime()
-		endTime := time.Now()
-
-		workflowManagerRuntime.Set(endTime.Sub(startTime).Seconds())
 	}
+
+	workflowManagerLastSuccess.SetToCurrentTime()
+
+	endTime := time.Now()
+	workflowManagerRuntime.Set(endTime.Sub(startTime).Seconds())
 
 	log.Info().Msg("done")
 }


### PR DESCRIPTION
After the 2021/2/18 production deploy, we encountered alerts because the
`workflow_manager_last_success_seconds` metric was not being set in
`ta-ta-apple`, `ta-ta-g-enpa` or `us-va-g-enpa`. This is because no data
comes into those instances, and so no aggregation IDs are discovered in
their ingestion buckets, and due to a bug introduced by #370, the metric
was being set only if there were tasks to schedule. We had the same
problem with the `workflow_manager_runtime_seconds` metric, which would
get set too many times during a run of `workflow-manager` (though the
last value that would get set was correct).

We now also configure the staging environment to _not_ create a
`sample-maker` cronjob in one of the three localities it creates, so
that going forward, our staging environment can reproduce the issue we
saw in production.