### PR TITLE
facilitator: build on default (Debian) Rust image

### DIFF
--- a/facilitator/Dockerfile
+++ b/facilitator/Dockerfile
@@ -1,11 +1,4 @@
-FROM rust:1.46-alpine as builder
-
-RUN apk add libc-dev openssl-dev && apk update
-
-# This is required so OpenSSL links properly. OpenSSL is required by reqwest, as used by
-# prometheus with the `push` option.
-# https://users.rust-lang.org/t/sigsegv-with-program-linked-against-openssl-in-an-alpine-container/52172
-ENV RUSTFLAGS='-C target-feature=-crt-static'
+FROM rust:1.46 as builder
 
 # Attempt to install a nonexistent package. This triggers
 # updating the crates.io index separately from building the
@@ -35,7 +28,6 @@ COPY ./avro-schema ./avro-schema
 COPY ./facilitator ./facilitator
 
 ARG BUILD_INFO=unspecified
-ENV OPENSSL_STATIC=true
 
 # This cargo build command must match the one above, or the build cache will not be reused.
 RUN cargo build --manifest-path ./facilitator/Cargo.toml

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -374,7 +374,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     let args: Vec<String> = std::env::args().collect();
     info!(
-        "starting {} version {}. Args: [{}]",
+        "starting {} version {}, built from Debian. Args: [{}]",
         args[0],
         option_env!("BUILD_INFO").unwrap_or("(BUILD_INFO unavailable)"),
         args[1..].join(" "),


### PR DESCRIPTION
NCI was seeing DNS failures which I think could be caused by Alpine's
musl DNS resolver. Here we build the facilitator container with the
default Rust image, which is Debian based, which uses libc.

https://stackoverflow.com/questions/65181012/does-alpine-have-known-dns-issue-within-kubernetes