### PR TITLE
facilitator: relax GCS read timeout

### DIFF
--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -71,7 +71,9 @@ impl GCSTransport {
                 identity.map(|x| x.to_string()),
                 key_file_reader,
             )?,
-            agent: AgentBuilder::new().timeout(Duration::from_secs(10)).build(),
+            agent: AgentBuilder::new()
+                .timeout(Duration::from_secs(120))
+                .build(),
         })
     }
 }


### PR DESCRIPTION
We have observed some failures in aggregations that are caused by
timeouts when *reading* from GCS (this on top of previously observed
timeouts when *writing*). This commit extrends read timeouts to 2
minutes.