### PR TITLE
Turn on us-ca in prod-us

### DIFF
--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -42,7 +42,7 @@ groups:
         more than 95% of the time in the last 8 hours"
   - alert: task_queue_growth
     expr: stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{subscription_id!~".*-dead-letter"} > 0
-    for: 2h
+    for: 3h
     labels:
       severity: page
       environment: ${environment}

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -2,7 +2,7 @@ environment     = "prod-us"
 gcp_region      = "us-west1"
 gcp_project     = "prio-prod-us"
 machine_type    = "e2-standard-8"
-localities      = ["ta-ta", "us-ct", "us-md", "us-va", "us-wa"]
+localities      = ["ta-ta", "us-ct", "us-md", "us-va", "us-wa", "us-ca"]
 aws_region      = "us-west-1"
 manifest_domain = "isrg-prio.org"
 managed_dns_zone = {
@@ -33,6 +33,10 @@ ingestors = {
         intake_worker_count    = 5
         aggregate_worker_count = 3
       }
+      us-ca = {
+        intake_worker_count    = 25
+        aggregate_worker_count = 7
+      }
     }
   }
   g-enpa = {
@@ -56,6 +60,10 @@ ingestors = {
       }
       us-wa = {
         intake_worker_count    = 3
+        aggregate_worker_count = 3
+      }
+      us-ca = {
+        intake_worker_count    = 15
         aggregate_worker_count = 3
       }
     }


### PR DESCRIPTION
Configures prod-us/us-ca deployment, and adjusts the `task_queue_growth` alert to reduce spurious pages. See commit messages for capacity planning rationale and additional commentary.