### PR TITLE
Allow us to define what kind of machines and node count for GKE

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -167,12 +167,13 @@ variable "victorops_routing_key" {
   description = "VictorOps/Splunk OnCall routing key for prometheus-alertmanager"
   default     = "bogus-routing-key"
 }
+
 variable "cluster_settings" {
   type = object({
-    initial_node_count : number
-    min_node_count : number
-    max_node_count : number
-    machine_type : string
+    initial_node_count = number
+    min_node_count     = number
+    max_node_count     = number
+    machine_type       = string
   })
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,11 +24,6 @@ variable "aws_profile" {
   default = "leuswest2"
 }
 
-variable "machine_type" {
-  type    = string
-  default = "e2.small"
-}
-
 variable "localities" {
   type = list(string)
 }
@@ -172,6 +167,14 @@ variable "victorops_routing_key" {
   description = "VictorOps/Splunk OnCall routing key for prometheus-alertmanager"
   default     = "bogus-routing-key"
 }
+variable "cluster_settings" {
+  type = object({
+    initial_node_count : number
+    min_node_count : number
+    max_node_count : number
+    machine_type : string
+  })
+}
 
 terraform {
   backend "gcs" {}
@@ -282,14 +285,14 @@ module "manifest" {
 }
 
 module "gke" {
-  source          = "./modules/gke"
-  environment     = var.environment
-  resource_prefix = "prio-${var.environment}"
-  gcp_region      = var.gcp_region
-  gcp_project     = var.gcp_project
-  machine_type    = var.machine_type
-  network         = google_compute_network.network.self_link
-  base_subnet     = local.cluster_subnet_block
+  source           = "./modules/gke"
+  environment      = var.environment
+  resource_prefix  = "prio-${var.environment}"
+  gcp_region       = var.gcp_region
+  gcp_project      = var.gcp_project
+  cluster_settings = var.cluster_settings
+  network          = google_compute_network.network.self_link
+  base_subnet      = local.cluster_subnet_block
 
   depends_on = [
     google_project_service.compute,

--- a/terraform/modules/gke/gke.tf
+++ b/terraform/modules/gke/gke.tf
@@ -16,10 +16,10 @@ variable "gcp_project" {
 
 variable "cluster_settings" {
   type = object({
-    initial_node_count : number
-    min_node_count : number
-    max_node_count : number
-    machine_type : string
+    initial_node_count = number
+    min_node_count     = number
+    max_node_count     = number
+    machine_type       = string
   })
 }
 

--- a/terraform/modules/gke/gke.tf
+++ b/terraform/modules/gke/gke.tf
@@ -14,8 +14,13 @@ variable "gcp_project" {
   type = string
 }
 
-variable "machine_type" {
-  type = string
+variable "cluster_settings" {
+  type = object({
+    initial_node_count : number
+    min_node_count : number
+    max_node_count : number
+    machine_type : string
+  })
 }
 
 resource "google_container_cluster" "cluster" {
@@ -84,15 +89,15 @@ resource "google_container_node_pool" "worker_nodes" {
   name               = "${var.resource_prefix}-node-pool"
   location           = var.gcp_region
   cluster            = google_container_cluster.cluster.name
-  initial_node_count = 4
+  initial_node_count = var.cluster_settings.initial_node_count
   autoscaling {
-    min_node_count = 4
-    max_node_count = 5
+    min_node_count = var.cluster_settings.min_node_count
+    max_node_count = var.cluster_settings.max_node_count
   }
   node_config {
     disk_size_gb = "25"
     image_type   = "COS_CONTAINERD"
-    machine_type = var.machine_type
+    machine_type = var.cluster_settings.machine_type
     oauth_scopes = [
       "storage-ro",
       "logging-write",

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -1,7 +1,6 @@
 environment     = "prod-us"
 gcp_region      = "us-west1"
 gcp_project     = "prio-prod-us"
-machine_type    = "e2-standard-8"
 localities      = ["ta-ta", "us-ct", "us-md", "us-va", "us-wa", "us-ca"]
 aws_region      = "us-west-1"
 manifest_domain = "isrg-prio.org"
@@ -68,6 +67,12 @@ ingestors = {
       }
     }
   }
+}
+cluster_settings = {
+  initial_node_count : 4
+  min_node_count : 4
+  max_node_count : 5
+  machine_type : "e2-standard-8"
 }
 peer_share_processor_manifest_base_url    = "en-analytics.cancer.gov"
 portal_server_manifest_base_url           = "manifest.enpa-pha.io"

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -69,10 +69,10 @@ ingestors = {
   }
 }
 cluster_settings = {
-  initial_node_count : 4
-  min_node_count : 4
-  max_node_count : 5
-  machine_type : "e2-standard-8"
+  initial_node_count = 4
+  min_node_count     = 1
+  max_node_count     = 5
+  machine_type       = "e2-standard-8"
 }
 peer_share_processor_manifest_base_url    = "en-analytics.cancer.gov"
 portal_server_manifest_base_url           = "manifest.enpa-pha.io"

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -45,10 +45,10 @@ ingestors = {
   }
 }
 cluster_settings = {
-  initial_node_count : 2
-  min_node_count : 2
-  max_node_count : 3
-  machine_type : "e2-standard-4"
+  initial_node_count = 2
+  min_node_count     = 1
+  max_node_count     = 3
+  machine_type       = "e2-standard-2"
 }
 peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
 portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -1,7 +1,6 @@
 environment     = "staging-facil"
 gcp_region      = "us-west1"
 gcp_project     = "prio-staging-300104"
-machine_type    = "e2-standard-8"
 localities      = ["narnia", "gondor", "asgard"]
 aws_region      = "us-west-1"
 manifest_domain = "isrg-prio.org"
@@ -44,6 +43,12 @@ ingestors = {
       }
     }
   }
+}
+cluster_settings = {
+  initial_node_count : 2
+  min_node_count : 2
+  max_node_count : 3
+  machine_type : "e2-standard-4"
 }
 peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
 portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -1,7 +1,6 @@
 environment     = "staging-pha"
 gcp_region      = "us-west1"
 gcp_project     = "prio-staging-300104"
-machine_type    = "e2-standard-8"
 localities      = ["narnia", "gondor", "asgard"]
 aws_region      = "us-west-1"
 manifest_domain = "isrg-prio.org"
@@ -44,6 +43,12 @@ ingestors = {
       }
     }
   }
+}
+cluster_settings = {
+  initial_node_count : 4
+  min_node_count : 4
+  max_node_count : 5
+  machine_type : "e2-standard-4"
 }
 peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
 portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -45,10 +45,10 @@ ingestors = {
   }
 }
 cluster_settings = {
-  initial_node_count : 4
-  min_node_count : 4
-  max_node_count : 5
-  machine_type : "e2-standard-4"
+  initial_node_count = 2
+  min_node_count     = 1
+  max_node_count     = 3
+  machine_type       = "e2-standard-2"
 }
 peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
 portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"


### PR DESCRIPTION
We're spinning up a LOT of nodes and big machines for dev environments and staging, we don't need to do this. This PR surfaces the variables used when constructing the GKE environment.