### PR TITLE
terraform: support multiple peer DSPs

### DIFF
--- a/terraform/modules/fake_server_resources/fake_server_resources.tf
+++ b/terraform/modules/fake_server_resources/fake_server_resources.tf
@@ -10,10 +10,6 @@ variable "manifest_bucket" {
   type = string
 }
 
-variable "peer_manifest_base_url" {
-  type = string
-}
-
 variable "own_manifest_base_url" {
   type = string
 }
@@ -27,6 +23,7 @@ variable "ingestor_pairs" {
     ingestor_manifest_base_url : string
     intake_worker_count : string
     aggregate_worker_count : string
+    peer_share_processor_manifest_base_url : string
   }))
 }
 
@@ -45,7 +42,6 @@ variable "facilitator_image" {
 variable "facilitator_version" {
   type = string
 }
-
 
 resource "kubernetes_namespace" "tester" {
   metadata {
@@ -229,7 +225,7 @@ resource "kubernetes_deployment" "integration-tester" {
             "--locality-name", each.value.locality,
             "--kube-namespace", kubernetes_namespace.tester.metadata[0].name,
             "--ingestor-manifest-base-url", "https://${each.value.ingestor_manifest_base_url}",
-            "--pha-manifest-base-url", "https://${var.peer_manifest_base_url}",
+            "--pha-manifest-base-url", "https://${each.value.peer_share_processor_manifest_base_url}",
             "--facilitator-manifest-base-url", "https://${var.own_manifest_base_url}",
             "--aggregation-id", "kittens-seen",
             "--packet-count", "10",

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -12,58 +12,86 @@ ingestors = {
   apple = {
     manifest_base_url = "exposure-notification.apple.com/manifest"
     localities = {
+      # ta-ta is reserved for integration testing with NCI and MITRE's staging
+      # instances
       ta-ta = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count                    = 1
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "test-en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.int.enpa-pha.io"
       }
       us-ct = {
-        intake_worker_count    = 5
-        aggregate_worker_count = 3
+        intake_worker_count                    = 5
+        aggregate_worker_count                 = 3
+        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-md = {
-        intake_worker_count    = 5
-        aggregate_worker_count = 3
+        intake_worker_count                    = 5
+        aggregate_worker_count                 = 3
+        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-va = {
-        intake_worker_count    = 5
-        aggregate_worker_count = 3
+        intake_worker_count                    = 5
+        aggregate_worker_count                 = 3
+        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-wa = {
-        intake_worker_count    = 5
-        aggregate_worker_count = 3
+        intake_worker_count                    = 5
+        aggregate_worker_count                 = 3
+        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-ca = {
-        intake_worker_count    = 25
-        aggregate_worker_count = 7
+        intake_worker_count                    = 25
+        aggregate_worker_count                 = 7
+        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
     }
   }
   g-enpa = {
     manifest_base_url = "storage.googleapis.com/prio-manifests"
     localities = {
+      # ta-ta is reserved for integration testing with NCI and MITRE's staging
+      # instances
       ta-ta = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count                    = 1
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "test-en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.int.enpa-pha.io"
       }
       us-ct = {
-        intake_worker_count    = 3
-        aggregate_worker_count = 3
+        intake_worker_count                    = 3
+        aggregate_worker_count                 = 3
+        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-md = {
-        intake_worker_count    = 3
-        aggregate_worker_count = 3
+        intake_worker_count                    = 3
+        aggregate_worker_count                 = 3
+        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-va = {
-        intake_worker_count    = 3
-        aggregate_worker_count = 3
+        intake_worker_count                    = 3
+        aggregate_worker_count                 = 3
+        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-wa = {
-        intake_worker_count    = 3
-        aggregate_worker_count = 3
+        intake_worker_count                    = 3
+        aggregate_worker_count                 = 3
+        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-ca = {
-        intake_worker_count    = 15
-        aggregate_worker_count = 3
+        intake_worker_count                    = 15
+        aggregate_worker_count                 = 3
+        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
     }
   }
@@ -74,8 +102,6 @@ cluster_settings = {
   max_node_count     = 5
   machine_type       = "e2-standard-8"
 }
-peer_share_processor_manifest_base_url    = "en-analytics.cancer.gov"
-portal_server_manifest_base_url           = "manifest.enpa-pha.io"
 is_first                                  = false
 use_aws                                   = false
 aggregation_period                        = "8h"

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -13,16 +13,22 @@ ingestors = {
     manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests/singleton-ingestor"
     localities = {
       narnia = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count                    = 1
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
+        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
       }
       gondor = {
-        intake_worker_count    = 2
-        aggregate_worker_count = 1
+        intake_worker_count                    = 2
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
+        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
       }
       asgard = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count                    = 1
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
+        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
       }
     }
   }
@@ -30,16 +36,22 @@ ingestors = {
     manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests/singleton-ingestor"
     localities = {
       narnia = {
-        intake_worker_count    = 2
-        aggregate_worker_count = 1
+        intake_worker_count                    = 2
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
+        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
       }
       gondor = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count                    = 1
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
+        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
       }
       asgard = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count                    = 1
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
+        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
       }
     }
   }
@@ -50,8 +62,6 @@ cluster_settings = {
   max_node_count     = 3
   machine_type       = "e2-standard-2"
 }
-peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
-portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
 test_peer_environment = {
   env_with_ingestor            = "staging-facil"
   env_without_ingestor         = "staging-pha"

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -13,16 +13,22 @@ ingestors = {
     manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests/singleton-ingestor"
     localities = {
       narnia = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count                    = 1
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
+        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
       }
       gondor = {
-        intake_worker_count    = 2
-        aggregate_worker_count = 1
+        intake_worker_count                    = 2
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
+        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
       }
       asgard = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count                    = 1
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
+        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
       }
     }
   }
@@ -30,16 +36,22 @@ ingestors = {
     manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests/singleton-ingestor"
     localities = {
       narnia = {
-        intake_worker_count    = 2
-        aggregate_worker_count = 1
+        intake_worker_count                    = 2
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
+        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
       }
       gondor = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count                    = 1
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
+        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
       }
       asgard = {
-        intake_worker_count    = 1
-        aggregate_worker_count = 1
+        intake_worker_count                    = 1
+        aggregate_worker_count                 = 1
+        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
+        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
       }
     }
   }
@@ -50,8 +62,6 @@ cluster_settings = {
   max_node_count     = 3
   machine_type       = "e2-standard-2"
 }
-peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
-portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
 test_peer_environment = {
   env_with_ingestor            = "staging-facil"
   env_without_ingestor         = "staging-pha"


### PR DESCRIPTION
We can now configure manifest base URLs for the peer data share
processor and portal server on a per-locality basis. Specifically, this
enables us to configure the `ta-ta` locality in production to exchange
data with the staging/test environments operated by our colleagues at
the NCI and MITRE.

Resolves #60

This isn't deployable right now because test-en-analytics.cancer.gov isn't available. NCI is currently rebuilding their test env. We also now repeat some amount of information in each locality. It'd be nice to be able to specify default peer and portal server manifest base URLs to avoid repetition, but I opted to do what would yield the simplest Terraform, since our modules are already kind of complicated.