### PR TITLE
terraform: split task queue growth alerts

### DIFF
--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -40,16 +40,26 @@ groups:
       description: "aggregate worker instance {{ $labels.kubernetes_namespace}}-
         {{ $labels.kubernetes_name }} in environment ${environment} is failing
         more than 95% of the time in the last 8 hours"
-  - alert: task_queue_growth
-    expr: stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{subscription_id!~".*-dead-letter"} > 0
-    for: 3h
+  - alert: intake_task_queue_growth
+    expr: stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{subscription_id!~".*-dead-letter",subscription_id=~".*-intake"} > 0
+    for: 30m
     labels:
       severity: page
       environment: ${environment}
     annotations:
       summary: "PubSub subscription {{ $labels.subscription_id }} not emptying"
       description: "PubSub subscription {{ $labels.subscription_id }} in
-      environment ${environment} has had undelivered messages for 2 hours"
+      environment ${environment} has had undelivered messages for 30 minutes"
+  - alert: aggregate_task_queue_growth
+    expr: stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{subscription_id!~".*-dead-letter",subscription_id=~".*-aggregate"} > 0
+    for: 5h
+    labels:
+      severity: page
+      environment: ${environment}
+    annotations:
+      summary: "PubSub subscription {{ $labels.subscription_id }} not emptying"
+      description: "PubSub subscription {{ $labels.subscription_id }} in
+      environment ${environment} has had undelivered messages for 5 hours"
   - alert: dead_letter_queue
     expr: stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{subscription_id=~".*-dead-letter"} > 0
     for: 5m


### PR DESCRIPTION
We now define two separate alerts for task queue growth, one for intake
queues and one for aggregations. The rationale is that aggregation tasks
generally take much, much longer than intake tasks, especially in
localities which submit a lot of data like `us-ca`. We now alert if any
intake task queue is non-empty for more than 30 minutes: since
workflow-manager runs and schedules new intakes every 10 minutes, we
expect those queues to empty more frequently. We alert if aggregations
take longer than 6 hours, a figure informed by historical performance of
us-ca-apple aggregation tasks.

This is implemented by matching on the suffix of the `subscription_id`
label of the Stackdriver PubSub metric. I would prefer to match on
someting more explicit, but I can't obviously see how: I tried adding a
label to the GCP PubSub subscription, but as far as I can tell, GCP
labels aren't reflected in Stackdriver time series, and in turn do not
appear on time series exported to Prometheus.