### PR TITLE
Sync main with bugfixes on release/0.6.2-nci

### DIFF
--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -30,6 +30,7 @@ prometheus = "0.12"
 rand = "0.8"
 ring = { version = "0.16.20", features = ["std"] }
 rusoto_core = { version = "^0.46", default_features = false, features = ["rustls"] }
+rusoto_mock = { version = "^0.46", default_features = false, features = ["rustls"] }
 rusoto_s3 = { version = "^0.46", default_features = false, features = ["rustls"] }
 rusoto_sqs = { version = "^0.46", default_features = false, features = ["rustls"] }
 rusoto_sts = { version = "^0.46", default_features = false, features = ["rustls"] }
@@ -47,5 +48,4 @@ warp = "^0.3"
 [dev-dependencies]
 assert_matches = "1.5.0"
 mockito = "0.29.0"
-rusoto_mock = { version = "^0.46", default_features = false, features = ["rustls"] }
 serde_test = "1.0"

--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -1,160 +1,208 @@
-use anyhow::Result;
-use rusoto_core::{
-    credential::EnvironmentProvider,
-    credential::{
-        AutoRefreshingProvider, AwsCredentials, ContainerProvider, CredentialsError,
-        InstanceMetadataProvider, ProfileProvider, ProvideAwsCredentials,
-    },
+use crate::{
+    config::Identity,
+    http::{prepare_request_without_agent, Method, RequestParameters},
 };
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use rusoto_core::credential::{
+    AutoRefreshingProvider, AwsCredentials, CredentialsError, DefaultCredentialsProvider,
+    ProvideAwsCredentials, Secret, Variable,
+};
+use rusoto_mock::MockCredentialsProvider;
 use rusoto_sts::WebIdentityProvider;
-use std::{boxed::Box, time::Duration};
+use std::{
+    boxed::Box,
+    convert::From,
+    env,
+    fmt::{self, Display},
+    sync::Arc,
+};
 use tokio::runtime::{Builder, Runtime};
+use url::Url;
 
 /// Constructs a basic runtime suitable for use in our single threaded context
 pub(crate) fn basic_runtime() -> Result<Runtime> {
     Ok(Builder::new_current_thread().enable_all().build()?)
 }
 
-// ------------- Everything below here was copied from rusoto/credential/src/lib.rs in the rusoto repo ---------------------------
-// -------------------------------------------------------------------------------------------------------------------------------
-
-/// Wraps a `ChainProvider` in an `AutoRefreshingProvider`.
-///
-/// The underlying `ChainProvider` checks multiple sources for credentials, and the `AutoRefreshingProvider`
-/// refreshes the credentials automatically when they expire.
-///
-/// # Warning
-///
-/// This provider allows the [`credential_process`][credential_process] option in the AWS config
-/// file (`~/.aws/config`), a method of sourcing credentials from an external process. This can
-/// potentially be dangerous, so proceed with caution. Other credential providers should be
-/// preferred if at all possible. If using this option, you should make sure that the config file
-/// is as locked down as possible using security best practices for your operating system.
-///
-/// [credential_process]: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
+/// The Provider enum allows us to generically handle different scenarios for
+/// authenticating to AWS APIs, while still having a concrete value that
+/// implements provideAwsCredentials and which can easily be used with Rusoto's
+/// various client objects. It also provides a convenient place to implement
+/// std::fmt::Display, allowing facilitator's AWS clients to log something
+/// useful about the identity they use.
+/// There are a number of ways to shave this yak. We could have used the newtype
+/// pattern on each ProvideAwsCredentials implementation we use, but that would
+/// make it hard to figure out the appropriate return type for a factory method
+/// or function. We could have used Box<dyn ProvideAwsCredentials>, but trait
+/// objects are harder to use with Rusoto's API clients, especially since we
+/// need the credential provider to implement Clone. This approach makes it easy
+/// to eliminate boilerplate in facilitator.rs while also integrating gracefully
+/// with rusoto_s3::S3Client and rusoto_sqs::SqsClient, at the cost of some
+/// repetitive match arms in some of the enum's methods.
 #[derive(Clone)]
-pub struct DefaultCredentialsProvider(AutoRefreshingProvider<ChainProvider>);
+pub enum Provider {
+    /// Rusoto's default credentials provider, which attempts to source
+    /// AWS credentials from environment variables or ~/.aws/credentials.
+    /// Suitable for use when running on a development environment or most AWS
+    /// contexts.
+    /// https://github.com/rusoto/rusoto/blob/master/AWS-CREDENTIALS.md
+    Default(DefaultCredentialsProvider),
+    /// A Rusoto WebIdentityProvider configured to obtain AWS credentials from
+    /// the Google Kubernetes Engine metadata service. Should only be used when
+    /// running within GKE.
+    WebIdentityWithOidc(AutoRefreshingProvider<WebIdentityProvider>),
+    /// A Rusoto WebIdentityProvider configured via environment variables set by
+    /// AWS Elastic Kubernetes Service. Should only be used when running within
+    /// EKS (+Fargate?).
+    WebIdentityFromKubernetesEnvironment(AutoRefreshingProvider<WebIdentityProvider>),
+    /// Rusoto's mock credentials provider, wrapped in an Arc to provide
+    /// Send + Sync. Should only be used in tests.
+    Mock(Arc<MockCredentialsProvider>),
+}
 
-impl DefaultCredentialsProvider {
-    /// Creates a new thread-safe `DefaultCredentialsProvider`.
-    pub fn new() -> Result<DefaultCredentialsProvider, CredentialsError> {
-        let inner = AutoRefreshingProvider::new(ChainProvider::new())?;
-        Ok(DefaultCredentialsProvider(inner))
+impl Provider {
+    /// Instantiates an appropriate Provider based on the provided configuration
+    /// values
+    pub fn new(identity: Identity, use_default_provider: bool) -> Result<Self> {
+        match (use_default_provider, identity) {
+            (true, _) => Self::new_default(),
+            (_, Some(identity)) => Self::new_web_identity_with_oidc(identity),
+            (_, None) => Self::new_web_identity_from_kubernetes_environment(),
+        }
+    }
+
+    fn new_default() -> Result<Self> {
+        Ok(Self::Default(DefaultCredentialsProvider::new().context(
+            "failed to create default AWS credentials provider",
+        )?))
+    }
+
+    /// Instantiates a mock credentials provider.
+    pub fn new_mock() -> Self {
+        Self::Mock(Arc::new(MockCredentialsProvider))
+    }
+
+    fn new_web_identity_from_kubernetes_environment() -> Result<Self> {
+        Ok(Self::WebIdentityFromKubernetesEnvironment(
+            AutoRefreshingProvider::new(WebIdentityProvider::from_k8s_env()).context(
+                "failed to create autorefreshing web identity provider from kubernetes environment",
+            )?,
+        ))
+    }
+
+    // We use workload identity to map GCP service accounts to Kubernetes
+    // service accounts and make an auth token for the GCP account available to
+    // containers in the GKE metadata service. Sadly we can't use the Kubernetes
+    // feature to automount a service account token, because that would provide
+    // the token for the *Kubernetes* service account, not the GCP one.
+    // See terraform/modules/gke/gke.tf and terraform/modules/kuberenetes/kubernetes.tf
+    fn metadata_service_token_url() -> Url {
+        Url::parse("http://metadata.google.internal:80/computeMetadata/v1/instance/service-accounts/default/identity")
+            .expect("could not parse token metadata api url")
+    }
+
+    fn new_web_identity_with_oidc(iam_role: &str) -> Result<Self> {
+        // When running in GKE, the token used to authenticate to AWS S3 is
+        // available from the instance metadata service.
+        // See terraform/modules/kubernetes/kubernetes.tf for discussion.
+        // This dynamic variable lets us provide a callback for fetching tokens,
+        // allowing Rusoto to automatically get new credentials if they expire
+        // (which they do every hour).
+        let oidc_token_variable = Variable::dynamic(|| {
+            let aws_account_id = env::var("AWS_ACCOUNT_ID").map_err(|e| {
+                CredentialsError::new(format!(
+                    "could not read AWS account ID from environment: {}",
+                    e
+                ))
+            })?;
+
+            // We use ureq for this request because it is designed to use purely
+            // synchronous Rust. Ironically, we are in the context of an async
+            // runtime when this callback is invoked, but because the closure is
+            // not declared async, we cannot use .await to work with Futures.
+            let mut url = Self::metadata_service_token_url();
+
+            url.query_pairs_mut()
+                .append_pair("audience", &format!("sts.amazonaws.com/{}", aws_account_id))
+                .finish();
+
+            let mut request = prepare_request_without_agent(RequestParameters {
+                url,
+                method: Method::Get,
+                ..Default::default()
+            })
+            .map_err(|e| CredentialsError::new(format!("failed to create request: {:?}", e)))?;
+
+            request = request.set("Metadata-Flavor", "Google");
+
+            let response = request.call().map_err(|e| {
+                CredentialsError::new(format!(
+                    "failed to fetch auth token from metadata service: {:?}",
+                    e
+                ))
+            })?;
+
+            let token = response.into_string().map_err(|e| {
+                CredentialsError::new(format!(
+                    "failed to fetch auth token from metadata service: {}",
+                    e
+                ))
+            })?;
+            Ok(Secret::from(token))
+        });
+
+        let provider = AutoRefreshingProvider::new(WebIdentityProvider::new(
+            oidc_token_variable,
+            // The AWS role that we are assuming is provided via environment
+            // variable. See terraform/modules/kubernetes/kubernetes.tf.
+            iam_role,
+            // The role ARN we assume is already bound to a specific facilitator
+            // instance, so we don't get much from further scoping the role
+            // assumption, unless we eventually introduce something like a job
+            // ID that could then show up in AWS-side logs.
+            // https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-role_session_name.html
+            Some(Variable::from_env_var_optional("AWS_ROLE_SESSION_NAME")),
+        ))
+        .context("failed to create auto refreshing credentials provider")?;
+
+        Ok(Self::WebIdentityWithOidc(provider))
+    }
+}
+
+impl Display for Provider {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Default(_) => write!(f, "ambient AWS credentials"),
+            Self::WebIdentityWithOidc(p) => {
+                // std::fmt::Error does not allow wrapping an error so we must
+                // discard whatever Variable.resolve() might return. In
+                // practice, it will always be Variable::static and so no error
+                // is possible.
+                let role_arn = p.get_ref().role_arn.resolve().map_err(|_| fmt::Error)?;
+                write!(f, "{} via OIDC web identity", role_arn)
+            }
+            Self::WebIdentityFromKubernetesEnvironment(p) => {
+                let role_arn = p.get_ref().role_arn.resolve().map_err(|_| fmt::Error)?;
+                write!(
+                    f,
+                    "{} via web identity from Kubernetes environment",
+                    role_arn
+                )
+            }
+            Self::Mock(_) => write!(f, "mock credentials"),
+        }
     }
 }
 
 #[async_trait]
-impl ProvideAwsCredentials for DefaultCredentialsProvider {
+impl ProvideAwsCredentials for Provider {
     async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
-        self.0.credentials().await
-    }
-}
-
-/// Provides AWS credentials from multiple possible sources using a priority order.
-///
-/// The following sources are checked in order for credentials when calling `credentials`:
-///
-/// 1. Environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`
-/// 2. `credential_process` command in the AWS config file, usually located at `~/.aws/config`.
-/// 3. AWS credentials file. Usually located at `~/.aws/credentials`.
-/// 4. IAM instance profile. Will only work if running on an EC2 instance with an instance profile/role.
-///
-/// If the sources are exhausted without finding credentials, an error is returned.
-///
-/// The provider has a default timeout of 30 seconds. While it should work well for most setups,
-/// you can change the timeout using the `set_timeout` method.
-///
-/// # Example
-///
-///
-/// # Warning
-///
-/// This provider allows the [`credential_process`][credential_process] option in the AWS config
-/// file (`~/.aws/config`), a method of sourcing credentials from an external process. This can
-/// potentially be dangerous, so proceed with caution. Other credential providers should be
-/// preferred if at all possible. If using this option, you should make sure that the config file
-/// is as locked down as possible using security best practices for your operating system.
-///
-/// [credential_process]: https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
-#[derive(Debug, Clone)]
-pub struct ChainProvider {
-    environment_provider: EnvironmentProvider,
-    instance_metadata_provider: InstanceMetadataProvider,
-    container_provider: ContainerProvider,
-    profile_provider: Option<ProfileProvider>,
-    webidp_provider: WebIdentityProvider,
-}
-
-impl ChainProvider {
-    /// Set the timeout on the provider to the specified duration.
-    #[allow(dead_code)]
-    pub fn set_timeout(&mut self, duration: Duration) {
-        self.instance_metadata_provider.set_timeout(duration);
-        self.container_provider.set_timeout(duration);
-    }
-}
-
-async fn chain_provider_credentials(
-    provider: ChainProvider,
-) -> Result<AwsCredentials, CredentialsError> {
-    if let Ok(creds) = provider.environment_provider.credentials().await {
-        return Ok(creds);
-    }
-    if let Some(ref profile_provider) = provider.profile_provider {
-        if let Ok(creds) = profile_provider.credentials().await {
-            return Ok(creds);
+        match self {
+            Self::Default(p) => p.credentials().await,
+            Self::WebIdentityWithOidc(p) => p.credentials().await,
+            Self::WebIdentityFromKubernetesEnvironment(p) => p.credentials().await,
+            Self::Mock(p) => p.credentials().await,
         }
-    }
-    if let Ok(creds) = provider.container_provider.credentials().await {
-        return Ok(creds);
-    }
-    if let Ok(creds) = provider.webidp_provider.credentials().await {
-        return Ok(creds);
-    }
-    if let Ok(creds) = provider.instance_metadata_provider.credentials().await {
-        return Ok(creds);
-    }
-    Err(CredentialsError::new(
-        "Couldn't find AWS credentials in environment, credentials file, or IAM role.",
-    ))
-}
-
-use async_trait::async_trait;
-
-#[async_trait]
-impl ProvideAwsCredentials for ChainProvider {
-    async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {
-        chain_provider_credentials(self.clone()).await
-    }
-}
-
-impl ChainProvider {
-    /// Create a new `ChainProvider` using a `ProfileProvider` with the default settings.
-    pub fn new() -> ChainProvider {
-        ChainProvider {
-            environment_provider: EnvironmentProvider::default(),
-            profile_provider: ProfileProvider::new().ok(),
-            instance_metadata_provider: InstanceMetadataProvider::new(),
-            container_provider: ContainerProvider::new(),
-            webidp_provider: WebIdentityProvider::from_k8s_env(),
-        }
-    }
-
-    /// Create a new `ChainProvider` using the provided `ProfileProvider`.
-    #[allow(dead_code)]
-    pub fn with_profile_provider(profile_provider: ProfileProvider) -> ChainProvider {
-        ChainProvider {
-            environment_provider: EnvironmentProvider::default(),
-            profile_provider: Some(profile_provider),
-            instance_metadata_provider: InstanceMetadataProvider::new(),
-            container_provider: ContainerProvider::new(),
-            webidp_provider: WebIdentityProvider::from_k8s_env(),
-        }
-    }
-}
-
-impl Default for ChainProvider {
-    fn default() -> Self {
-        Self::new()
     }
 }

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -3,7 +3,7 @@ use ring::{digest, signature::EcdsaKeyPair};
 use std::io::Write;
 
 pub mod aggregation;
-mod aws_credentials;
+pub mod aws_credentials;
 pub mod batch;
 pub mod config;
 mod gcp_oauth;

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -1,6 +1,6 @@
 use crate::aws_credentials;
 use crate::{
-    aws_credentials::basic_runtime,
+    aws_credentials::{basic_runtime, retry_request},
     config::S3Path,
     transport::{Transport, TransportWriter},
     Error,
@@ -8,8 +8,8 @@ use crate::{
 use anyhow::{Context, Result};
 use derivative::Derivative;
 use hyper_rustls::HttpsConnector;
-use log::{debug, info};
-use rusoto_core::{ByteStream, Region, RusotoError, RusotoResult};
+use log::info;
+use rusoto_core::{ByteStream, Region};
 use rusoto_s3::{
     AbortMultipartUploadRequest, CompleteMultipartUploadRequest, CompletedMultipartUpload,
     CompletedPart, CreateMultipartUploadRequest, GetObjectRequest, S3Client, UploadPartRequest, S3,
@@ -25,43 +25,8 @@ use tokio::{
     runtime::Runtime,
 };
 
-/// We attempt AWS API requests up to three times (i.e., two retries)
-const MAX_ATTEMPT_COUNT: i32 = 3;
-
 /// ClientProvider allows mocking out a client for testing.
 type ClientProvider = Box<dyn Fn(&Region, aws_credentials::Provider) -> Result<S3Client>>;
-
-/// Calls the provided closure, retrying up to MAX_ATTEMPT_COUNT times if it
-/// fails with RusotoError::HttpDispatch, which indicates a problem sending the
-/// request such as the connection getting closed under us.
-fn retry_request<F, T, E>(action: &str, mut f: F) -> RusotoResult<T, E>
-where
-    F: FnMut() -> RusotoResult<T, E>,
-    E: std::fmt::Debug,
-{
-    let mut attempts = 0;
-    loop {
-        match f() {
-            Err(RusotoError::HttpDispatch(err)) => {
-                attempts += 1;
-                if attempts >= MAX_ATTEMPT_COUNT {
-                    break Err(RusotoError::HttpDispatch(err));
-                }
-                info!(
-                    "failed to {} (will retry {} more times): {}",
-                    action,
-                    MAX_ATTEMPT_COUNT - attempts,
-                    err
-                );
-            }
-            Err(err) => {
-                debug!("encountered non retryable error: {:?}", err);
-                break Err(err);
-            }
-            result => break result,
-        }
-    }
-}
 
 /// Implementation of Transport that reads and writes objects from Amazon S3.
 #[derive(Derivative)]


### PR DESCRIPTION
NCI has been running a `facilitator` forked from tag 0.6.2 for some time now, and I have been making targeted hotfixes on `release/0.6.2-nci` to minimize risk to NCI's deployment. This PR brings `main` to a state where it can safely be deployed to NCI and eventually MITRE's AWS deployments. See the individual commit messages for details on what changed and the motivation.