### PR TITLE
Terraform changes to allow for integration testing

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -103,6 +103,7 @@ apply-bootstrap: prep ## Have terraform bring up the minimal resources needed to
 		-var-file="$(VARS)" \
 		-target=module.manifest \
 		-target=module.fake_server_resources \
+		-target=module.portal_server_resources
 		-target=module.gke
 	echo "If that succeeded, run 'terraform output --json | (cd ../deploy-tool/ ; go run main.go )'"
 
@@ -114,7 +115,8 @@ destroy-bootstrap: prep ## Have terraform destroy the resources brought up by ap
 		-refresh=true \
 		-var-file="$(VARS)" \
 		-target=module.manifest \
-		-target=module.fake_server_resources
+		-target=module.fake_server_resources \
+		-target=module.portal_server_resources \
 		-target=module.gke
 
 .PHONY: apply-target

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -508,7 +508,6 @@ output "singleton_ingestor" {
     batch_signing_key_name      = module.fake_server_resources[0].batch_signing_key_name
   } : {}
 }
-
 output "own_manifest_base_url" {
   value = module.manifest.base_url
 }
@@ -518,5 +517,5 @@ output "use_test_pha_decryption_key" {
 }
 
 output "has_test_environment" {
-  value = lookup(var.test_peer_environment, "env_with_ingestor", "") == var.environment
+  value = length(module.fake_server_resources) != 0
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -452,19 +452,29 @@ resource "google_service_account_iam_binding" "data_share_processors_to_sum_part
 }
 
 module "fake_server_resources" {
-  count                        = local.is_env_with_ingestor ? 1 : 0
-  source                       = "./modules/fake_server_resources"
+  count                  = local.is_env_with_ingestor ? 1 : 0
+  source                 = "./modules/fake_server_resources"
+  manifest_bucket        = module.manifest.bucket
+  gcp_region             = var.gcp_region
+  environment            = var.environment
+  ingestor_pairs         = local.locality_ingestor_pairs
+  peer_manifest_base_url = var.peer_share_processor_manifest_base_url
+  own_manifest_base_url  = module.manifest.base_url
+  pushgateway            = var.pushgateway
+  container_registry     = var.container_registry
+  facilitator_image      = var.facilitator_image
+  facilitator_version    = var.facilitator_version
+
+  depends_on = [module.gke]
+}
+
+module "portal_server_resources" {
+  count                        = local.deployment_has_ingestor ? 1 : 0
+  source                       = "./modules/portal_server_resources"
   manifest_bucket              = module.manifest.bucket
   gcp_region                   = var.gcp_region
   environment                  = var.environment
   sum_part_bucket_writer_email = google_service_account.sum_part_bucket_writer.email
-  ingestor_pairs               = local.locality_ingestor_pairs
-  peer_manifest_base_url       = var.peer_share_processor_manifest_base_url
-  own_manifest_base_url        = module.manifest.base_url
-  pushgateway                  = var.pushgateway
-  container_registry           = var.container_registry
-  facilitator_image            = var.facilitator_image
-  facilitator_version          = var.facilitator_version
 
   depends_on = [module.gke]
 }

--- a/terraform/modules/fake_server_resources/fake_server_resources.tf
+++ b/terraform/modules/fake_server_resources/fake_server_resources.tf
@@ -50,8 +50,6 @@ variable "facilitator_version" {
   type = string
 }
 
-
-
 # For our purposes, a fake portal server is simply a bucket where we can write
 # sum parts, as well as a correctly formed global manifest advertising that
 # bucket's name.
@@ -232,7 +230,7 @@ resource "kubernetes_deployment" "integration-tester" {
   for_each = var.ingestor_pairs
 
   metadata {
-    name      = "integration-tester-${each.value.ingestor}"
+    name      = "integration-tester-${each.value.locality}-${each.value.ingestor}"
     namespace = kubernetes_namespace.tester.metadata[0].name
   }
 

--- a/terraform/modules/fake_server_resources/fake_server_resources.tf
+++ b/terraform/modules/fake_server_resources/fake_server_resources.tf
@@ -10,10 +10,6 @@ variable "manifest_bucket" {
   type = string
 }
 
-variable "sum_part_bucket_writer_email" {
-  type = string
-}
-
 variable "peer_manifest_base_url" {
   type = string
 }
@@ -50,47 +46,6 @@ variable "facilitator_version" {
   type = string
 }
 
-# For our purposes, a fake portal server is simply a bucket where we can write
-# sum parts, as well as a correctly formed global manifest advertising that
-# bucket's name.
-resource "google_storage_bucket" "sum_part_output" {
-  name     = "prio-${var.environment}-sum-part-output"
-  location = var.gcp_region
-  # Force deletion of bucket contents on bucket destroy. Bucket contents would
-  # be re-created by a subsequent deploy so no reason to keep them around.
-  force_destroy = true
-  # Disable per-object ACLs. Everything we put in here is meant to be world-
-  # readable and this is also in line with Google's recommendation:
-  # https://cloud.google.com/storage/docs/uniform-bucket-level-access
-  uniform_bucket_level_access = true
-}
-
-# Enable the sum part bucket writer GCP SA to write output
-resource "google_storage_bucket_iam_binding" "write_sum_parts" {
-  bucket = google_storage_bucket.sum_part_output.name
-  # Allow ourselves to write to sum part outputs
-  role = "roles/storage.objectAdmin"
-  members = [
-    "serviceAccount:${var.sum_part_bucket_writer_email}"
-  ]
-}
-
-# Create a portal server global manifest and advertise it from our manifest
-# bucket. Note that the manifest bucket name and the relative path in this
-# resource's name field must match the portal_server_manifest_base_url value in
-# this env's .tfvars!
-resource "google_storage_bucket_object" "portal_server_global_manifest" {
-  name         = "portal-server/global-manifest.json"
-  bucket       = var.manifest_bucket
-  content_type = "application/json"
-  content = jsonencode({
-    format = 1
-    # We're cheating here by listing the same bucket twice, but the other env
-    # will consult a totally different portal server global manifest.
-    facilitator-sum-part-bucket = "gs://${google_storage_bucket.sum_part_output.name}"
-    pha-sum-part-bucket         = "gs://${google_storage_bucket.sum_part_output.name}"
-  })
-}
 
 resource "kubernetes_namespace" "tester" {
   metadata {

--- a/terraform/modules/portal_server_resources/portal_server_resources.tf
+++ b/terraform/modules/portal_server_resources/portal_server_resources.tf
@@ -1,0 +1,57 @@
+variable "environment" {
+  type = string
+}
+
+variable "gcp_region" {
+  type = string
+}
+
+variable "manifest_bucket" {
+  type = string
+}
+
+variable "sum_part_bucket_writer_email" {
+  type = string
+}
+
+# For our purposes, a fake portal server is simply a bucket where we can write
+# sum parts, as well as a correctly formed global manifest advertising that
+# bucket's name.
+resource "google_storage_bucket" "sum_part_output" {
+  name     = "prio-${var.environment}-sum-part-output"
+  location = var.gcp_region
+  # Force deletion of bucket contents on bucket destroy. Bucket contents would
+  # be re-created by a subsequent deploy so no reason to keep them around.
+  force_destroy = true
+  # Disable per-object ACLs. Everything we put in here is meant to be world-
+  # readable and this is also in line with Google's recommendation:
+  # https://cloud.google.com/storage/docs/uniform-bucket-level-access
+  uniform_bucket_level_access = true
+}
+
+# Enable the sum part bucket writer GCP SA to write output
+resource "google_storage_bucket_iam_binding" "write_sum_parts" {
+  bucket = google_storage_bucket.sum_part_output.name
+  # Allow ourselves to write to sum part outputs
+  role = "roles/storage.objectAdmin"
+  members = [
+    "serviceAccount:${var.sum_part_bucket_writer_email}"
+  ]
+}
+
+# Create a portal server global manifest and advertise it from our manifest
+# bucket. Note that the manifest bucket name and the relative path in this
+# resource's name field must match the portal_server_manifest_base_url value in
+# this env's .tfvars!
+resource "google_storage_bucket_object" "portal_server_global_manifest" {
+  name         = "portal-server/global-manifest.json"
+  bucket       = var.manifest_bucket
+  content_type = "application/json"
+  content = jsonencode({
+    format = 1
+    # We're cheating here by listing the same bucket twice, but the other env
+    # will consult a totally different portal server global manifest.
+    facilitator-sum-part-bucket = "gs://${google_storage_bucket.sum_part_output.name}"
+    pha-sum-part-bucket         = "gs://${google_storage_bucket.sum_part_output.name}"
+  })
+}

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -51,7 +51,7 @@ cluster_settings = {
   machine_type       = "e2-standard-2"
 }
 peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
-portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
+portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
 test_peer_environment = {
   env_with_ingestor            = "staging-facil"
   env_without_ingestor         = "staging-pha"

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -51,7 +51,7 @@ cluster_settings = {
   machine_type       = "e2-standard-2"
 }
 peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
-portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
+portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
 test_peer_environment = {
   env_with_ingestor            = "staging-facil"
   env_without_ingestor         = "staging-pha"


### PR DESCRIPTION
- Fixes the Makefile
- Adds a new target called `portal_server_resources`.
- Changes when and how `has_test_environment` is set to true. Effectively this doesn't change the behavior of `has_test_environment`. But makes it dependent on the `fake_server_resources` module, which is what we want to get the output to update when doing `apply bootstrap`.


# Portal Server Resources 

This is a new module that creates the portal server. When the "deployment" (full dual-testing peer environments) are being deployed, this will create a fake "portal server/collector" for the aggregations of facil and pha. This isn't the **best** solution because ideally these would live inside the one environment (usually facil) that has the integration-tester set.

However, trying to get to that ideal solution through terraform seems difficult as a deployment would end up having to have an extra step just to make that work. Or it would involve manually going in and adding permission for the PHA aggregators to be able to write to the portal server. These didn't seem like ideal solutions when writing this PR, but there will be an open issue on how to improve that.
