### PR TITLE
terraform: provision 8 us-ut-apple intake workers

### DIFF
--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -51,7 +51,7 @@ ingestors = {
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-ut = {
-        intake_worker_count                    = 5
+        intake_worker_count                    = 8
         aggregate_worker_count                 = 3
         peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"


### PR DESCRIPTION
We got paged on 2021/3/10 because the `us-ut/intake-batch-apple`
deployment wasn't keeping up with the incoming tasks because of a spike
in traffic. I resolved that by manually scaling the deployment up to 8
workers, from 5. We observed another similar spike in incoming ingestion
batches around 4 AM PST 2021/3/11, so I want to keep the 8 workers until
we get around to autoscaling the workers (#484).