### PR TITLE
facilitator: multi-threaded aggregation

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -553,6 +553,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "ecdsa"
 version = "0.11.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +629,7 @@ dependencies = [
  "chrono",
  "clap",
  "derivative",
+ "dyn-clone",
  "elliptic-curve",
  "env_logger 0.8.3",
  "http",
@@ -1648,9 +1655,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "prio"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c293e32d9ab6c9afadf14e14d76df204f17618f4b74b38fa2adb18b352fbf2"
+checksum = "dfedfce2709d0fce3daf8ad4e86433726a77dafcc562837952b350af38b65589"
 dependencies = [
  "aes-ctr",
  "aes-gcm",

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -12,6 +12,7 @@ base64 = "0.13.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2.33.3"
 derivative = "2.1.1"
+dyn-clone = "1.0.4"
 elliptic-curve = { version = "0.9.5", features = ["pem"] }
 env_logger = "0.8.3"
 http = "^0.2"
@@ -25,7 +26,7 @@ log = "0.4.11"
 p256 = "0.8.0-pre"
 pem = "0.8"
 pkix = "0.1.1"
-prio = "0.2"
+prio = "0.3"
 prometheus = "0.12"
 rand = "0.8"
 ring = { version = "0.16.20", features = ["std"] }

--- a/facilitator/README.md
+++ b/facilitator/README.md
@@ -44,6 +44,14 @@ AWS SNS/SQS support is experimental and has not been validated. To use it, pass 
 
 To support new task queues, simply add an implementation of the `TaskQueue` trait, defined in `src/task.rs`. Then, add the necessary argument handling and initialization logic to `src/bin/facilitator.rs`.
 
+## Configuration
+
+### `aggregate-worker` thread count
+
+The `aggregate` and `aggregate-worker` subcommands can be configured to spawn multiple worker threads that will sum over batches in an aggregation in parallel before reducing each batch's sum into a sum part that is transmitted to the portal server. By default, a single thread is used. Set either the `--thread-count` command line argument or the `THREAD_COUNT` environment variable (e.g., in a Kubernetes `ConfigMap`) to an integer value to spawn the corresponding number of threads.
+
+To make best use of a multithreaded `aggregate-worker` in Kubernetes, make sure to configure the CPU and memory limits appropriately so that multiple cores can be allocated. For instance, a CPU request of `0.1` and a CPU limit of `3` might work well for four worker threads, keeping in mind that since Prio batch processing involves a lot of network I/O, we would not expect four worker threads on four cores to see consistently high CPU utilization.
+
 ## References
 
 [Prio Data Share Batch IDL](https://docs.google.com/document/d/1L06dpE7OcC4CXho2UswrfHrnWKtbA9aSSmO_5o7Ku6I/edit#heading=h.3kq1yexquq2g)

--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -31,7 +31,7 @@ pub(crate) fn basic_runtime() -> Result<Runtime> {
 
 /// The Provider enum allows us to generically handle different scenarios for
 /// authenticating to AWS APIs, while still having a concrete value that
-/// implements provideAwsCredentials and which can easily be used with Rusoto's
+/// implements ProvideAwsCredentials and which can easily be used with Rusoto's
 /// various client objects. It also provides a convenient place to implement
 /// std::fmt::Display, allowing facilitator's AWS clients to log something
 /// useful about the identity they use.
@@ -44,6 +44,13 @@ pub(crate) fn basic_runtime() -> Result<Runtime> {
 /// to eliminate boilerplate in facilitator.rs while also integrating gracefully
 /// with rusoto_s3::S3Client and rusoto_sqs::SqsClient, at the cost of some
 /// repetitive match arms in some of the enum's methods.
+///
+/// A note on thread safety and sharing Providers: each variant of this enum
+/// wraps an implementation of ProvideAwsCredentials which in turn uses an
+/// Arc<Mutex<>> to share the cached credentials across cloned instances. That
+/// means that even if a single instance of Provider is .clone()d many times and
+/// provided to multiple threads, they will efficiently share a single cached
+/// credential.
 #[derive(Clone)]
 pub enum Provider {
     /// Rusoto's default credentials provider, which attempts to source

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -113,8 +113,8 @@ pub struct BatchReader<'a, H, P> {
 
     // These next two fields are not real and are used because not using H and P
     // in the struct definition is an error.
-    phantom_header: PhantomData<*const H>,
-    phantom_packet: PhantomData<*const P>,
+    phantom_header: PhantomData<H>,
+    phantom_packet: PhantomData<P>,
 }
 
 impl<'a, H: Header, P: Packet> BatchReader<'a, H, P> {
@@ -219,8 +219,8 @@ pub struct BatchWriter<'a, H, P> {
     batch: Batch,
     transport: &'a mut dyn Transport,
     packet_schema: Schema,
-    phantom_header: PhantomData<*const H>,
-    phantom_packet: PhantomData<*const P>,
+    phantom_header: PhantomData<H>,
+    phantom_packet: PhantomData<P>,
 }
 
 impl<'a, H: Header, P: Packet> BatchWriter<'a, H, P> {

--- a/facilitator/src/gcp_oauth.rs
+++ b/facilitator/src/gcp_oauth.rs
@@ -2,27 +2,49 @@ use anyhow::{anyhow, Context, Result};
 use chrono::{prelude::Utc, DateTime, Duration};
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use serde::{Deserialize, Serialize};
-use std::{fmt, io::Read};
+use std::{
+    fmt,
+    io::Read,
+    sync::{Arc, RwLock},
+};
 use ureq::{Agent, Response};
+use url::Url;
 
 use crate::http::{
     create_agent, prepare_request, send_json_request, Method, OauthTokenProvider,
     RequestParameters, StaticOauthTokenProvider,
 };
-use url::Url;
 
-fn default_oauth_token_url() -> Url {
-    Url::parse("http://metadata.google.internal:80/computeMetadata/v1/instance/service-accounts/default/token",)
-    .expect("unable to parse metadata.google.internal url")
+const DEFAULT_METADATA_BASE_URL: &str = "http://metadata.google.internal:80";
+const DEFAULT_TOKEN_PATH: &str = "/computeMetadata/v1/instance/service-accounts/default/token";
+const DEFAULT_IAM_BASE_URL: &str = "https://iamcredentials.googleapis.com";
+
+fn default_oauth_token_url(base: &str) -> Url {
+    let mut request_url = Url::parse(base).expect("unable to parse metadata.google.internal url");
+    request_url.set_path(DEFAULT_TOKEN_PATH);
+    request_url
 }
 
 // API reference:
 // https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
-fn access_token_url_for_service_account(service_account_to_impersonate: &str) -> Result<Url> {
-    let request_url = format!("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}:generateAccessToken",
-            service_account_to_impersonate);
+fn access_token_url_for_service_account(
+    base: &str,
+    service_account_to_impersonate: &str,
+) -> Result<Url> {
+    let request_url = format!(
+        "{}{}",
+        base,
+        access_token_path_for_service_account(service_account_to_impersonate)
+    );
 
     Url::parse(&request_url).context(format!("failed to parse: {}", request_url))
+}
+
+fn access_token_path_for_service_account(service_account_to_impersonate: &str) -> String {
+    format!(
+        "/v1/projects/-/serviceAccounts/{}:generateAccessToken",
+        service_account_to_impersonate
+    )
 }
 
 /// Represents the claims encoded into JWTs when using a service account key
@@ -37,6 +59,7 @@ struct Claims {
 }
 
 /// A wrapper around an Oauth token and its expiration date.
+#[derive(Clone)]
 struct OauthToken {
     token: String,
     expiration: DateTime<Utc>,
@@ -71,7 +94,7 @@ struct GenerateAccessTokenResponse {
 
 /// This is the subset of a GCP service account key file that we need to parse
 /// to construct a signed JWT.
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 struct ServiceAccountKeyFile {
     /// The PEM-armored base64 encoding of the ASN.1 encoding of the account's
     /// RSA private key.
@@ -88,6 +111,12 @@ struct ServiceAccountKeyFile {
 /// one for a GCP service account mapped to a Kubernetes service account, or the
 /// one found in a JSON key file) and an Oauth token used to impersonate another
 /// service account.
+///
+/// A note on thread safety: this struct stores any Oauth tokens it obtains in
+/// an Arc+Mutex, so an instance of GcpOauthTokenProvider may be .clone()d
+/// liberally and shared across threads, and credentials obtained from the GCP
+/// credentials API will be shared efficiently and safely.
+#[derive(Clone)]
 pub(crate) struct GcpOauthTokenProvider {
     /// The Oauth scope for which tokens should be requested.
     scope: String,
@@ -101,15 +130,19 @@ pub(crate) struct GcpOauthTokenProvider {
     /// This field is None after instantiation and is Some after the first
     /// successful request for a token for the default service account, though
     /// the contained token may be expired.
-    default_account_token: Option<OauthToken>,
+    default_account_token: Arc<RwLock<Option<OauthToken>>>,
     /// This field is None after instantiation and is Some after the first
     /// successful request for a token for the impersonated service account,
     /// though the contained token may be expired. This will always be None if
     /// account_to_impersonate is None.
-    impersonated_account_token: Option<OauthToken>,
+    impersonated_account_token: Arc<RwLock<Option<OauthToken>>>,
     /// The Agent will be used when making HTTP requests to GCP APIs to fetch
     /// Oauth tokens.
     agent: Agent,
+    /// Base URL at which to access GKE metadata service
+    metadata_service_base_url: &'static str,
+    /// Base URL at which to access GCP IAM service
+    iam_service_base_url: &'static str,
 }
 
 impl fmt::Debug for GcpOauthTokenProvider {
@@ -125,11 +158,21 @@ impl fmt::Debug for GcpOauthTokenProvider {
             )
             .field(
                 "default_account_token",
-                &self.default_account_token.as_ref().map(|_| "redacted"),
+                &self
+                    .default_account_token
+                    .read()
+                    .unwrap()
+                    .as_ref()
+                    .map(|_| "redacted"),
             )
             .field(
                 "impersonated_account_token",
-                &self.default_account_token.as_ref().map(|_| "redacted"),
+                &self
+                    .default_account_token
+                    .read()
+                    .unwrap()
+                    .as_ref()
+                    .map(|_| "redacted"),
             )
             .finish()
     }
@@ -157,7 +200,7 @@ impl GcpOauthTokenProvider {
         scope: &str,
         account_to_impersonate: Option<String>,
         key_file_reader: Option<Box<dyn Read>>,
-    ) -> Result<GcpOauthTokenProvider> {
+    ) -> Result<Self> {
         let key_file: Option<ServiceAccountKeyFile> = match key_file_reader {
             Some(reader) => {
                 serde_json::from_reader(reader).context("failed to deserialize JSON key file")?
@@ -170,9 +213,11 @@ impl GcpOauthTokenProvider {
             scope: scope.to_owned(),
             default_service_account_key_file: key_file,
             account_to_impersonate,
-            default_account_token: None,
-            impersonated_account_token: None,
+            default_account_token: Arc::new(RwLock::new(None)),
+            impersonated_account_token: Arc::new(RwLock::new(None)),
             agent,
+            metadata_service_base_url: DEFAULT_METADATA_BASE_URL,
+            iam_service_base_url: DEFAULT_IAM_BASE_URL,
         })
     }
 
@@ -181,11 +226,13 @@ impl GcpOauthTokenProvider {
     /// The returned value is an owned reference because the token owned by this
     /// struct could change while the caller is still holding the returned token
     fn ensure_default_account_token(&mut self) -> Result<String> {
-        if let Some(token) = &self.default_account_token {
+        if let Some(token) = &*self.default_account_token.read().unwrap() {
             if !token.expired() {
                 return Ok(token.token.clone());
             }
         }
+
+        let mut default_account_token = self.default_account_token.write().unwrap();
 
         let http_response = match &self.default_service_account_key_file {
             Some(key_file) => self.account_token_with_key_file(&key_file)?,
@@ -200,7 +247,7 @@ impl GcpOauthTokenProvider {
             return Err(anyhow!("unexpected token type {}", response.token_type));
         }
 
-        self.default_account_token = Some(OauthToken {
+        *default_account_token = Some(OauthToken {
             token: response.access_token.clone(),
             expiration: Utc::now() + Duration::seconds(response.expires_in),
         });
@@ -215,8 +262,7 @@ impl GcpOauthTokenProvider {
         let mut request = prepare_request(
             &self.agent,
             RequestParameters {
-                url: default_oauth_token_url(),
-                method: Method::Get,
+                url: default_oauth_token_url(self.metadata_service_base_url),
                 ..Default::default()
             },
         )?;
@@ -286,19 +332,23 @@ impl GcpOauthTokenProvider {
             return Err(anyhow!("no service account to impersonate was provided"));
         }
 
-        if let Some(token) = &self.impersonated_account_token {
+        if let Some(token) = &*self.impersonated_account_token.read().unwrap() {
             if !token.expired() {
                 return Ok(token.token.clone());
             }
         }
 
+        let default_token = self.ensure_default_account_token()?;
+        let mut impersonated_account_token = self.impersonated_account_token.write().unwrap();
         let service_account_to_impersonate = self.account_to_impersonate.clone().unwrap();
 
-        let default_token = self.ensure_default_account_token()?;
         let request = prepare_request(
             &self.agent,
             RequestParameters {
-                url: access_token_url_for_service_account(&service_account_to_impersonate)?,
+                url: access_token_url_for_service_account(
+                    self.iam_service_base_url,
+                    &service_account_to_impersonate,
+                )?,
                 method: Method::Post,
                 token_provider: Some(&mut StaticOauthTokenProvider::from(default_token)),
             },
@@ -318,11 +368,172 @@ impl GcpOauthTokenProvider {
         let response = http_response
             .into_json::<GenerateAccessTokenResponse>()
             .context("failed to deserialize response from IAM API")?;
-        self.impersonated_account_token = Some(OauthToken {
+        *impersonated_account_token = Some(OauthToken {
             token: response.access_token.clone(),
             expiration: response.expire_time,
         });
 
         Ok(response.access_token)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use mockito::{mock, Matcher};
+    use serde_json::json;
+    use std::io::Cursor;
+
+    use crate::config::leak_string;
+
+    #[test]
+    fn get_default_token() {
+        let mocked_get = mock("GET", DEFAULT_TOKEN_PATH)
+            .match_header("Metadata-Flavor", "Google")
+            .with_status(200)
+            .with_body(
+                r#"{
+  "access_token": "fake-token",
+  "scope": "fake-scope",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+"#,
+            )
+            .expect_at_most(1)
+            .create();
+
+        let mut provider = GcpOauthTokenProvider::new("fake-scope", None, None).unwrap();
+        provider.metadata_service_base_url = leak_string(mockito::server_url());
+        provider.iam_service_base_url = leak_string(mockito::server_url());
+
+        assert_matches!(provider.ensure_default_account_token(), Ok(token) => {
+            assert_eq!(token, "fake-token")
+        });
+
+        // Should fail because provider.account_to_impersonate = None
+        assert_matches!(
+            provider.ensure_impersonated_service_account_oauth_token(),
+            Err(_)
+        );
+
+        // Get the token again and we should not see any more network requests
+        assert_matches!(provider.ensure_default_account_token(), Ok(token) => {
+            assert_eq!(token, "fake-token")
+        });
+
+        mocked_get.assert();
+    }
+
+    #[test]
+    fn get_impersonated_token() {
+        let mocked_get_default = mock("GET", DEFAULT_TOKEN_PATH)
+            .match_header("Metadata-Flavor", "Google")
+            .with_status(200)
+            .with_body(
+                r#"{
+  "access_token": "fake-default-token",
+  "scope": "fake-scope",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+"#,
+            )
+            .expect_at_most(1)
+            .create();
+
+        let access_token_path: &str =
+            &access_token_path_for_service_account("fake-service-account");
+        let mocked_post_impersonated = mock("POST", access_token_path)
+            .match_header("Authorization", "Bearer fake-default-token")
+            .match_body(Matcher::Json(json!({"scope": ["fake-scope"] })))
+            .with_status(200)
+            .with_body(
+                r#"
+{
+    "accessToken": "fake-impersonated-token",
+    "expireTime": "2099-10-02T15:01:23Z"
+}
+"#,
+            )
+            .expect_at_most(1)
+            .create();
+
+        let mut provider = GcpOauthTokenProvider::new(
+            "fake-scope",
+            Some("fake-service-account".to_string()),
+            None,
+        )
+        .unwrap();
+        provider.metadata_service_base_url = leak_string(mockito::server_url());
+        provider.iam_service_base_url = leak_string(mockito::server_url());
+
+        assert_matches!(provider.ensure_impersonated_service_account_oauth_token(), Ok(token) => {
+            assert_eq!(token, "fake-impersonated-token")
+        });
+
+        // Get the token again and we should not see any more network requests
+        assert_matches!(provider.ensure_impersonated_service_account_oauth_token(), Ok(token) => {
+            assert_eq!(token, "fake-impersonated-token")
+        });
+
+        mocked_get_default.assert();
+        mocked_post_impersonated.assert();
+    }
+
+    #[test]
+    fn get_token_with_key_file() {
+        let key_file = format!(
+            r#"{{
+    "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAoEwmsVUxIOyq775Bmh2jPb6jtMR8BhWtLuT0O2YgrRMGkx6p\nLd9/svdZVs1AicgMOkv6FkLsXphFobJOyVU8E5E7d1Nk5YZKOdgDltYWtuL4hpAo\nTi2PaCqNDKM1JUG2ffIwNAUAkLoI3+7/aqNnc8pax9dSXknDKtK5Bn4KY0N4JFdo\nKXxGJG2jqnguI0hsOGdIpw1UtcQm/1KCMm5SiQcKwRD4gAyAKzkl8jiZzgo46JCK\nDRWFTjxC4TWjpD3t8CEZggWmaRB69cMXvrWzvKJTtno/ldI8cskhELJXEuvZ59p3\n5YVdHgV9+HycfGkLndei5yubeu9cpOi6moUXHwIDAQABAoIBACBd3/40lnvwbb+E\n6hglXd3MzZ9lgSl1XQe4ATyxLW3lBpHUQhLaKx3G5gop3Zs0gouO5cty7elX08+H\ngnMSu9Ozoo9AjoHt8LTnUio1xlZdVBNPrmPCvU8qMFrZ5ZRFRYT+zw7h57BRcBNP\nXdF5dx0hQd1SM/aH7FmMPQH7lztdhWNehmqVwtMTGq84uOWH+EqCM7bcTCJsG93E\nTMPFTcoUGTmpTo98gNSt/kTTf3zktfmTFL6CiwLaXaXl9LQc8XgTG+QZeOYkxk9g\nkzE7fn3r6f7N/Hfc2ZutIsFEC7VMX+cUwfKZLsQNeIWvszQOsPVXoQVbjKN9XEQP\nU5/oaXkCgYEAz2IhlQEvdMUfR+CX93vAJRHjEQ2lTkMTKSRYyVccaDfF/csurDtc\nS9MASiSojHtkiKPyudJxnBK7OMZHPxPx2VZVdfz/XFXEZ+jG6CkgE7suWa/4XJGm\nIVcPpMeR0mYQhzbF2HDHRow62ZPwPeflGOuTwtqnhakI2ehmBNfgG/sCgYEAxeA3\niAlTCgnlkXdb7Rj/KPFYZSgoOTxOZqcbVZzQJ1hlEPNICDH62lhwNREkLM9TWzgo\nJb6SUNvpCBaRGMkkLbr2Qfmm6ms/m2osylBfP/xMnCqHeO2XABxtCvOVseYFdCuL\nbGpe65Q+bwPpsdQvCj1AcanNxclZhl1+NWXcxC0CgYAc194p1jdee0glfBRGxHxt\n63X0WjyCjQuuLjL3FdmKmS89ZDQCmmL03Mzugvi6STMrWfoZZC6O8X/+nn0sRb7e\nZoaOWXi+w+MEPLjlc0rV07PXn4TggxVjD7PKTEN4yt9DnxeXSeA9bKWGu2+vfIA9\nng44DKc+DMuBWzRNOiUeXwKBgDcdQppjbnunUgf4ZORfSALRZjuWuc1nXLb+6IAq\nE1hCKLRV7sRJl4NliqtdQOQyQxdvRs9sizh2aCvWjUeIDsml/51UugclJCxXoG4h\ngMZDsdr1hZJLKvne8QhR3GoWlYJL9qOV5SZcvh8Rye+8F/YUJXUDRMtIT+U6+UJK\nQvlpAoGBAKff7Y0NethwzBEJJl9QGOstwgnsQKrqcDhj7wNX1PKa7r4zu6WdWSF8\n2/Hor4D6eW5dNFHhQgC4u/z9JgikHfeCaAgRPMJXxsKWnECP/i++NpiGdhXdtei7\njbxbE/VdW03+iXZyrnDNFAFAsRR+XgjeYheAUVLelg9qBjM7jYNf\n-----END RSA PRIVATE KEY-----",
+    "private_key_id": "fake-key-id",
+    "client_email": "fake@fake.fake",
+    "token_uri": "{}/fake-token-uri"
+}}
+"#,
+            mockito::server_url()
+        );
+
+        // We intentionally don't check the body here: if we did, we would have
+        // to re-implement most of account_token_with_key_file to construct the
+        // expected body, and all that does is prove we can copy code rather
+        // than prove that account_token_with_key_file is correct.
+        let mocked_post = mock("POST", "/fake-token-uri")
+            .with_status(200)
+            .with_body(
+                r#"{
+  "access_token": "fake-token",
+  "scope": "fake-scope",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+"#,
+            )
+            .expect_at_most(1)
+            .create();
+
+        let mut provider =
+            GcpOauthTokenProvider::new("fake-scope", None, Some(Box::new(Cursor::new(key_file))))
+                .unwrap();
+        provider.metadata_service_base_url = leak_string(mockito::server_url());
+        provider.iam_service_base_url = leak_string(mockito::server_url());
+
+        assert_matches!(provider.ensure_default_account_token(), Ok(token) => {
+            assert_eq!(token, "fake-token")
+        });
+
+        // Should fail because provider.account_to_impersonate = None
+        assert_matches!(
+            provider.ensure_impersonated_service_account_oauth_token(),
+            Err(_)
+        );
+
+        // Get the token again and we should not see any more requests
+        assert_matches!(provider.ensure_default_account_token(), Ok(token) => {
+            assert_eq!(token, "fake-token")
+        });
+
+        mocked_post.assert();
     }
 }

--- a/facilitator/src/http.rs
+++ b/facilitator/src/http.rs
@@ -44,7 +44,7 @@ pub(crate) fn prepare_request_without_agent(parameters: RequestParameters<'_>) -
     prepare_request(&create_agent(), parameters)
 }
 
-/// Defines a behavior responsible for produing bearer authorization tokens
+/// Defines a behavior responsible for producing bearer authorization tokens
 pub(crate) trait OauthTokenProvider: Debug {
     /// Returns a valid bearer authroization token
     fn ensure_oauth_token(&mut self) -> Result<String>;

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -18,6 +18,7 @@ pub mod sample;
 pub mod task;
 pub mod test_utils;
 pub mod transport;
+mod work_queue;
 
 pub const DATE_FORMAT: &str = "%Y/%m/%d/%H/%M";
 

--- a/facilitator/src/metrics.rs
+++ b/facilitator/src/metrics.rs
@@ -51,7 +51,7 @@ fn handle_scrape() -> Result<Vec<u8>> {
 }
 
 /// A group of collectors for intake tasks.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct IntakeMetricsCollector {
     pub intake_tasks_started: IntCounter,
     pub intake_tasks_finished: IntCounterVec,
@@ -79,7 +79,8 @@ impl IntakeMetricsCollector {
     }
 }
 
-#[derive(Debug)]
+/// A group of collectors for aggregation tasks.
+#[derive(Clone, Debug)]
 pub struct AggregateMetricsCollector {
     pub aggregate_tasks_started: IntCounter,
     pub aggregate_tasks_finished: IntCounterVec,

--- a/facilitator/src/task.rs
+++ b/facilitator/src/task.rs
@@ -2,11 +2,14 @@ mod pubsub;
 mod sqs;
 
 use anyhow::Result;
+use dyn_clone::{clone_trait_object, DynClone};
+use log::error;
 use serde::Deserialize;
 use std::{
     fmt,
     fmt::{Debug, Display},
-    time::Duration,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
 };
 use uuid::Uuid;
 
@@ -14,7 +17,7 @@ pub use pubsub::GcpPubSubTaskQueue;
 pub use sqs::AwsSqsTaskQueue;
 
 /// A queue of tasks to be executed
-pub trait TaskQueue<T: Task>: Debug {
+pub trait TaskQueue<T: Task>: Debug + DynClone + Send + Sync + 'static {
     /// Get a task to execute. If a task to run is found, returns Ok(Some(T)).
     /// If a task is successfully checked for but there is no work available,
     /// returns Ok(None). Returns Err(e) if something goes wrong.
@@ -34,37 +37,36 @@ pub trait TaskQueue<T: Task>: Debug {
 
     /// Signal to the task queue that more time is needed to handle the task.
     fn extend_task_deadline(&mut self, handle: &TaskHandle<T>, increment: &Duration) -> Result<()>;
+}
 
-    /// Extend the deadline for the provided task if enough time has elapsed
-    /// since the start of handling the task to require an extension. Returns
-    /// Ok(()) if either the task deadline does not need extension or if the
-    /// deadline was successfully extended, or an error if something goes wrong
-    /// extending the deadline.
-    fn maybe_extend_task_deadline(
-        &mut self,
-        handle: &TaskHandle<T>,
-        elapsed: &Duration,
-    ) -> Result<()> {
-        // We assume that 10 minutes is a reasonable deadline increment
-        // regardless of queue implementation or what the task is. In the future
-        // this could be a tunable parameter on facilitator.
-        let deadline_increment = Duration::from_secs(600);
+clone_trait_object!(<T: Task> TaskQueue<T>);
 
-        // Extend the deadline when we get to 90% of the increment, to reduce
-        // the risk of a task being redelivered by the queue if a call to
-        // extend_task_deadline happens to take unusually long.
-        if elapsed >= &Duration::from_secs_f64(0.9 * Duration::from_secs(600).as_secs_f64()) {
-            return self.extend_task_deadline(handle, &deadline_increment);
-        }
-        Ok(())
+impl<T: Task> TaskQueue<T> for Box<dyn TaskQueue<T>> {
+    fn dequeue(&mut self) -> Result<Option<TaskHandle<T>>> {
+        (**self).dequeue()
+    }
+
+    fn acknowledge_task(&mut self, handle: TaskHandle<T>) -> Result<()> {
+        (**self).acknowledge_task(handle)
+    }
+
+    fn nacknowledge_task(&mut self, handle: TaskHandle<T>) -> Result<()> {
+        (**self).nacknowledge_task(handle)
+    }
+
+    fn extend_task_deadline(&mut self, handle: &TaskHandle<T>, increment: &Duration) -> Result<()> {
+        (**self).extend_task_deadline(handle, increment)
     }
 }
 
 /// Represents a task that can be assigned to a worker
-pub trait Task: Debug + Display + Sized + serde::de::DeserializeOwned {}
+pub trait Task:
+    Debug + Display + PartialEq + Clone + Send + Sized + Sync + serde::de::DeserializeOwned + 'static
+{
+}
 
 /// Represents an intake batch task to be executed
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct IntakeBatchTask {
     /// The trace identifier for the intake
@@ -95,7 +97,7 @@ impl Display for IntakeBatchTask {
 }
 
 /// Represents an aggregation task to be executed
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct AggregationTask {
     /// The trace identifier for the aggregation
@@ -132,7 +134,7 @@ impl Display for AggregationTask {
 }
 
 /// Represents a batch included in an aggregation
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub struct Batch {
     /// The identifier of the batch. Typically a UUID.
@@ -144,7 +146,7 @@ pub struct Batch {
 
 /// A TaskHandle wraps a Task along with whatever metadata is needed by a
 /// TaskQueue implementation
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TaskHandle<T: Task> {
     /// The acknowledgment ID for the task
     acknowledgment_id: String,
@@ -155,5 +157,257 @@ pub struct TaskHandle<T: Task> {
 impl<T: Task> Display for TaskHandle<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ack ID: {}\ntask: {}", self.acknowledgment_id, self.task)
+    }
+}
+
+/// Watchdogs allow workers processing long-running tasks to indicate that they
+/// are still making progress.
+pub trait Watchdog: Clone + Send + Sync + 'static {
+    /// Indicate to the watchdog that progress is being made on some work.
+    fn send_heartbeat(&self);
+}
+
+/// A Watchdog that does nothing.
+#[derive(Clone)]
+pub struct NoOpWatchdog {}
+
+impl Watchdog for NoOpWatchdog {
+    fn send_heartbeat(&self) {}
+}
+
+/// An object that returns some perception of the current time.
+pub trait Clock: Clone + Send + Sync + 'static {
+    fn now(&self) -> Instant;
+}
+
+/// A Clock that returns the current time according to std::time::Instant::now.
+#[derive(Clone)]
+pub struct RealClock {}
+
+impl Clock for RealClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+}
+
+/// A watchdog that periodically extends the deadline on a TaskHandle in a
+/// TaskQueue.
+#[derive(Debug, Clone)]
+pub struct TaskQueueWatchdog<T, Q, C>
+where
+    T: Task,
+    Q: TaskQueue<T> + Clone,
+    C: Clock,
+{
+    task_handle: TaskHandle<T>,
+    previous_deadline_extension: Arc<Mutex<Instant>>,
+    task_queue: Arc<Mutex<Q>>,
+    clock: C,
+}
+
+impl<T, Q> TaskQueueWatchdog<T, Q, RealClock>
+where
+    T: Task,
+    Q: TaskQueue<T> + Clone,
+{
+    /// Create a new watchdog to periodically extend the deadline on the
+    /// provided task handle, in the provided task queue.
+    pub fn new(task_handle: TaskHandle<T>, task_queue: Arc<Mutex<Q>>) -> Self {
+        Self::new_with_previous_deadline_extension(
+            task_handle,
+            &Instant::now(),
+            task_queue,
+            RealClock {},
+        )
+    }
+}
+
+impl<T, Q, C> TaskQueueWatchdog<T, Q, C>
+where
+    T: Task,
+    Q: TaskQueue<T> + Clone,
+    C: Clock,
+{
+    // Allows construction of a TaskQueueWatchdog with a client controlled Clock
+    // for testing.
+    fn new_with_previous_deadline_extension(
+        task_handle: TaskHandle<T>,
+        instant: &Instant,
+        task_queue: Arc<Mutex<Q>>,
+        clock: C,
+    ) -> Self {
+        Self {
+            task_handle,
+            previous_deadline_extension: Arc::new(Mutex::new(instant.clone())),
+            task_queue,
+            clock,
+        }
+    }
+}
+
+impl<T, Q, C> Watchdog for TaskQueueWatchdog<T, Q, C>
+where
+    T: Task,
+    Q: TaskQueue<T> + Clone,
+    C: Clock,
+{
+    fn send_heartbeat(&self) {
+        // We assume that 10 minutes is a reasonable deadline increment
+        // regardless of queue implementation or what the task is (it is also
+        // maximum deadline extension allowed by GCP PubSub). In the future this
+        // could be a tunable parameter on facilitator.
+        let deadline_increment = Duration::from_secs(600);
+        let mut previous_deadline_extension = self.previous_deadline_extension.lock().unwrap();
+
+        let now = self.clock.now();
+        let elapsed = now - *previous_deadline_extension;
+
+        // Extend the deadline when we get to 90% of the increment, to reduce
+        // the risk of a task being redelivered by the queue if a call to
+        // extend_task_deadline happens to take unusually long.
+        if elapsed < Duration::from_secs_f64(0.9 * deadline_increment.as_secs_f64()) {
+            return;
+        }
+
+        // There's not much we can do if the deadline extension fails so just
+        // log the error.
+        if let Err(error) = self
+            .task_queue
+            .lock()
+            .unwrap()
+            .extend_task_deadline(&self.task_handle, &deadline_increment)
+        {
+            error!("{}", error);
+            return;
+        }
+
+        *previous_deadline_extension = now;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+
+    #[derive(Clone, Debug)]
+    struct MockTaskQueue<T: Task> {
+        extended_task: Option<TaskHandle<T>>,
+    }
+
+    impl<T: Task> TaskQueue<T> for MockTaskQueue<T> {
+        fn dequeue(&mut self) -> Result<Option<TaskHandle<T>>> {
+            unimplemented!()
+        }
+
+        fn acknowledge_task(&mut self, _handle: TaskHandle<T>) -> Result<()> {
+            unimplemented!()
+        }
+
+        fn nacknowledge_task(&mut self, _handle: TaskHandle<T>) -> Result<()> {
+            unimplemented!()
+        }
+
+        /// Signal to the task queue that more time is needed to handle the task.
+        fn extend_task_deadline(
+            &mut self,
+            handle: &TaskHandle<T>,
+            _increment: &Duration,
+        ) -> Result<()> {
+            self.extended_task = Some(handle.clone());
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct MockClock {
+        now: Instant,
+    }
+
+    impl Clock for MockClock {
+        fn now(&self) -> Instant {
+            self.now.clone()
+        }
+    }
+
+    #[test]
+    fn task_queue_watchdog_interval() {
+        let task_handle = TaskHandle {
+            acknowledgment_id: "fake-ack-id".to_string(),
+            task: AggregationTask {
+                trace_id: None,
+                aggregation_id: "fake-agg-id".to_string(),
+                aggregation_start: "2006/01/02/15/04".to_string(),
+                aggregation_end: "2006/01/02/15/05".to_string(),
+                batches: vec![],
+            },
+        };
+
+        let task_queue: Arc<Mutex<MockTaskQueue<AggregationTask>>> =
+            Arc::new(Mutex::new(MockTaskQueue {
+                extended_task: None,
+            }));
+
+        let now = Instant::now();
+
+        // Exactly at the time of last extension; nothing should happen
+        let mut watchdog = TaskQueueWatchdog::new_with_previous_deadline_extension(
+            task_handle.clone(),
+            &now,
+            task_queue.clone(),
+            MockClock { now },
+        );
+
+        watchdog.send_heartbeat();
+        assert_matches!((*task_queue.lock().unwrap()).extended_task, None);
+        assert_eq!(*watchdog.previous_deadline_extension.lock().unwrap(), now);
+
+        // Advance clock by less than deadline increment; nothing should happen
+        watchdog.clock = MockClock {
+            now: now + Duration::from_secs(300),
+        };
+        watchdog.send_heartbeat();
+        assert_matches!((*task_queue.lock().unwrap()).extended_task, None);
+        assert_eq!(*watchdog.previous_deadline_extension.lock().unwrap(), now);
+
+        // Advance clock to 90% of deadline increment; watchdog should fire
+        watchdog.clock = MockClock {
+            now: now + Duration::from_secs(540),
+        };
+        watchdog.send_heartbeat();
+        assert_matches!(
+            &(*task_queue.lock().unwrap()).extended_task,
+            Some(handle) => {
+                assert_eq!(&task_handle, handle);
+            }
+        );
+        assert_eq!(
+            *watchdog.previous_deadline_extension.lock().unwrap(),
+            now + Duration::from_secs(540)
+        );
+
+        // Advance watchdog clock by less than deadline increment; nothing
+        // should happen
+        watchdog.clock = MockClock {
+            now: now + Duration::from_secs(800),
+        };
+
+        watchdog.send_heartbeat();
+        assert_eq!(
+            *watchdog.previous_deadline_extension.lock().unwrap(),
+            now + Duration::from_secs(540)
+        );
+
+        // Advance watchdog clock past next deadline increment; watchdog should
+        // fire
+        watchdog.clock = MockClock {
+            now: now + Duration::from_secs(1200),
+        };
+
+        watchdog.send_heartbeat();
+        assert_eq!(
+            *watchdog.previous_deadline_extension.lock().unwrap(),
+            now + Duration::from_secs(1200)
+        );
     }
 }

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -93,13 +93,13 @@ struct GcpPubSubMessage {
 }
 
 /// A task queue backed by Google Cloud PubSub
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GcpPubSubTaskQueue<T: Task> {
     pubsub_api_endpoint: String,
     gcp_project_id: String,
     subscription_id: String,
     oauth_token_provider: GcpOauthTokenProvider,
-    phantom_task: PhantomData<*const T>,
+    phantom_task: PhantomData<T>,
     agent: Agent,
 }
 

--- a/facilitator/src/task/sqs.rs
+++ b/facilitator/src/task/sqs.rs
@@ -6,7 +6,6 @@ use rusoto_sqs::{
     ChangeMessageVisibilityRequest, DeleteMessageRequest, ReceiveMessageRequest, Sqs, SqsClient,
 };
 use std::{convert::TryFrom, marker::PhantomData, str::FromStr, time::Duration};
-use tokio::runtime::Runtime;
 
 use crate::aws_credentials;
 use crate::{
@@ -15,15 +14,14 @@ use crate::{
 };
 
 /// A task queue backed by AWS SQS
-#[derive(Derivative)]
+#[derive(Clone, Derivative)]
 #[derivative(Debug)]
 pub struct AwsSqsTaskQueue<T: Task> {
     region: Region,
     queue_url: String,
-    runtime: Runtime,
     #[derivative(Debug = "ignore")]
     credentials_provider: aws_credentials::Provider,
-    phantom_task: PhantomData<*const T>,
+    phantom_task: PhantomData<T>,
 }
 
 impl<T: Task> AwsSqsTaskQueue<T> {
@@ -33,12 +31,10 @@ impl<T: Task> AwsSqsTaskQueue<T> {
         credentials_provider: aws_credentials::Provider,
     ) -> Result<Self> {
         let region = Region::from_str(region).context("invalid AWS region")?;
-        let runtime = basic_runtime()?;
 
         Ok(AwsSqsTaskQueue {
             region,
             queue_url: queue_url.to_owned(),
-            runtime,
             credentials_provider,
             phantom_task: PhantomData,
         })
@@ -53,6 +49,7 @@ impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
         );
 
         let client = self.sqs_client()?;
+        let runtime = basic_runtime()?;
 
         let response = retry_request("dequeue SQS message", || {
             let request = ReceiveMessageRequest {
@@ -70,7 +67,7 @@ impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
                 ..Default::default()
             };
 
-            self.runtime.block_on(client.receive_message(request))
+            runtime.block_on(client.receive_message(request))
         })
         .context("failed to dequeue message from SQS")?;
 
@@ -115,13 +112,14 @@ impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
         );
 
         let client = self.sqs_client()?;
+        let runtime = basic_runtime()?;
 
         retry_request("delete/acknowledge message in SQS", || {
             let request = DeleteMessageRequest {
                 queue_url: self.queue_url.clone(),
                 receipt_handle: task.acknowledgment_id.clone(),
             };
-            self.runtime.block_on(client.delete_message(request))
+            runtime.block_on(client.delete_message(request))
         })
         .context("failed to delete/acknowledge message in SQS")
     }
@@ -176,6 +174,7 @@ impl<T: Task> AwsSqsTaskQueue<T> {
         visibility_timeout: &Duration,
     ) -> Result<()> {
         let client = self.sqs_client()?;
+        let runtime = basic_runtime()?;
 
         let timeout = i64::try_from(visibility_timeout.as_secs()).context(format!(
             "timeout value {:?} cannot be encoded into ChangeMessageVisibilityRequest",
@@ -188,8 +187,7 @@ impl<T: Task> AwsSqsTaskQueue<T> {
                 receipt_handle: task.acknowledgment_id.clone(),
                 visibility_timeout: timeout,
             };
-            self.runtime
-                .block_on(client.change_message_visibility(request))
+            runtime.block_on(client.change_message_visibility(request))
         })
         .context("failed to change message visibility message in SQS")
     }

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -44,7 +44,7 @@ fn gcp_upload_object_url(storage_api_url: &str, bucket: &str) -> Result<Url> {
 /// struct can either use the default service account from the metadata service,
 /// or can impersonate another GCP service account if one is provided to
 /// GCSTransport::new.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GCSTransport {
     path: GCSPath,
     oauth_token_provider: GcpOauthTokenProvider,

--- a/facilitator/src/transport/local.rs
+++ b/facilitator/src/transport/local.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 /// A transport implementation backed by the local filesystem.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LocalFileTransport {
     directory: PathBuf,
 }

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -26,60 +26,73 @@ use tokio::{
 };
 
 /// ClientProvider allows mocking out a client for testing.
-type ClientProvider = Box<dyn Fn(&Region, aws_credentials::Provider) -> Result<S3Client>>;
+pub trait ClientProvider: Sized + Clone + Send {
+    fn provide_client(
+        &self,
+        region: &Region,
+        credentials_provider: &aws_credentials::Provider,
+    ) -> Result<S3Client>;
+}
+
+#[derive(Clone)]
+pub struct ClientProviderImpl {}
+
+impl ClientProvider for ClientProviderImpl {
+    fn provide_client(
+        &self,
+        region: &Region,
+        credentials_provider: &aws_credentials::Provider,
+    ) -> Result<S3Client> {
+        // Rusoto uses Hyper which uses connection pools. The default
+        // timeout for those connections is 90 seconds[1]. Amazon S3's
+        // API closes idle client connections after 20 seconds[2]. If we
+        // use a default client via S3Client::new, this mismatch causes
+        // uploads to fail when Hyper tries to re-use a connection that
+        // has been idle too long. Until this is fixed in Rusoto[3], we
+        // construct our own HTTP request dispatcher whose underlying
+        // hyper::Client is configured to timeout idle connections after
+        // 10 seconds.
+        //
+        // [1]: https://docs.rs/hyper/0.13.8/hyper/client/struct.Builder.html#method.pool_idle_timeout
+        // [2]: https://aws.amazon.com/premiumsupport/knowledge-center/s3-socket-connection-timeout-error/
+        // [3]: https://github.com/rusoto/rusoto/issues/1686
+        let mut builder = hyper::Client::builder();
+        builder.pool_idle_timeout(Duration::from_secs(10));
+        let connector = HttpsConnector::with_native_roots();
+        let http_client = rusoto_core::HttpClient::from_builder(builder, connector);
+
+        Ok(S3Client::new_with(
+            http_client,
+            credentials_provider.clone(),
+            region.clone(),
+        ))
+    }
+}
 
 /// Implementation of Transport that reads and writes objects from Amazon S3.
-#[derive(Derivative)]
+#[derive(Clone, Derivative)]
 #[derivative(Debug)]
-pub struct S3Transport {
+pub struct S3Transport<P: ClientProvider> {
     path: S3Path,
     #[derivative(Debug = "ignore")]
     credentials_provider: aws_credentials::Provider,
     // client_provider allows injection of mock S3Client for testing purposes
     #[derivative(Debug = "ignore")]
-    client_provider: ClientProvider,
+    client_provider: P,
 }
 
-impl S3Transport {
+impl S3Transport<ClientProviderImpl> {
     pub fn new(path: S3Path, credentials_provider: aws_credentials::Provider) -> Self {
-        S3Transport::new_with_client(
-            path,
-            credentials_provider,
-            Box::new(
-                |region: &Region, credentials_provider: aws_credentials::Provider| {
-                    // Rusoto uses Hyper which uses connection pools. The default
-                    // timeout for those connections is 90 seconds[1]. Amazon S3's
-                    // API closes idle client connections after 20 seconds[2]. If we
-                    // use a default client via S3Client::new, this mismatch causes
-                    // uploads to fail when Hyper tries to re-use a connection that
-                    // has been idle too long. Until this is fixed in Rusoto[3], we
-                    // construct our own HTTP request dispatcher whose underlying
-                    // hyper::Client is configured to timeout idle connections after
-                    // 10 seconds.
-                    //
-                    // [1]: https://docs.rs/hyper/0.13.8/hyper/client/struct.Builder.html#method.pool_idle_timeout
-                    // [2]: https://aws.amazon.com/premiumsupport/knowledge-center/s3-socket-connection-timeout-error/
-                    // [3]: https://github.com/rusoto/rusoto/issues/1686
-                    let mut builder = hyper::Client::builder();
-                    builder.pool_idle_timeout(Duration::from_secs(10));
-                    let connector = HttpsConnector::with_native_roots();
-                    let http_client = rusoto_core::HttpClient::from_builder(builder, connector);
-
-                    Ok(S3Client::new_with(
-                        http_client,
-                        credentials_provider,
-                        region.clone(),
-                    ))
-                },
-            ),
-        )
+        S3Transport::new_with_client(path, credentials_provider, ClientProviderImpl {})
     }
+}
 
+impl<P: ClientProvider> S3Transport<P> {
     fn new_with_client(
         path: S3Path,
         credentials_provider: aws_credentials::Provider,
-        client_provider: ClientProvider,
-    ) -> Self {
+        client_provider: P,
+    ) -> S3Transport<P> {
         S3Transport {
             path: path.ensure_directory_prefix(),
             credentials_provider,
@@ -88,7 +101,7 @@ impl S3Transport {
     }
 }
 
-impl Transport for S3Transport {
+impl<P: ClientProvider> Transport for S3Transport<P> {
     fn path(&self) -> String {
         self.path.to_string()
     }
@@ -96,7 +109,9 @@ impl Transport for S3Transport {
     fn get(&mut self, key: &str) -> Result<Box<dyn Read>> {
         info!("get {}/{} as {}", self.path, key, self.credentials_provider);
         let runtime = basic_runtime()?;
-        let client = (self.client_provider)(&self.path.region, self.credentials_provider.clone())?;
+        let client = self
+            .client_provider
+            .provide_client(&self.path.region, &self.credentials_provider)?;
 
         let get_output = retry_request("get s3 object", || {
             runtime.block_on(client.get_object(GetObjectRequest {
@@ -120,7 +135,8 @@ impl Transport for S3Transport {
             // Set buffer size to 5 MB, which is the minimum required by Amazon
             // https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
             5_242_880,
-            (self.client_provider)(&self.path.region, self.credentials_provider.clone())?,
+            self.client_provider
+                .provide_client(&self.path.region, &self.credentials_provider)?,
         )?;
         Ok(Box::new(writer))
     }
@@ -594,6 +610,56 @@ mod tests {
         writer.complete_upload().unwrap_err();
     }
 
+    // Rusoto's MockRequestDispatcher and MultipleMockRequestDispatcher do not
+    // implement Clone so we must provide something that does, from which we can
+    // instantiate the mock dispatchers.
+    #[derive(Clone)]
+    struct MockRequest<F: Fn(&SignedRequest) + Send + Sync + Clone + 'static> {
+        status: u16,
+        request_checker: F,
+        header: Option<(&'static str, &'static str)>,
+        body: Option<&'static str>,
+    }
+
+    #[derive(Clone)]
+    struct MockClientProvider<F: Fn(&SignedRequest) + Send + Sync + Clone + 'static> {
+        requests: Vec<MockRequest<F>>,
+    }
+
+    impl<F: Fn(&SignedRequest) + Send + Sync + Clone + 'static> ClientProvider
+        for MockClientProvider<F>
+    {
+        fn provide_client(
+            &self,
+            region: &Region,
+            credentials_provider: &aws_credentials::Provider,
+        ) -> Result<S3Client> {
+            let mock_dispatchers: Vec<MockRequestDispatcher> = self
+                .requests
+                .iter()
+                .map(|r| {
+                    let mut mock_dispatcher = MockRequestDispatcher::with_status(r.status)
+                        .with_request_checker(r.request_checker.clone());
+
+                    if let Some(header) = r.header {
+                        mock_dispatcher = mock_dispatcher.with_header(header.0, header.1);
+                    }
+                    if let Some(body) = r.body {
+                        mock_dispatcher = mock_dispatcher.with_body(body);
+                    }
+
+                    mock_dispatcher
+                })
+                .collect();
+
+            Ok(S3Client::new_with(
+                MultipleMockRequestDispatcher::new(mock_dispatchers),
+                credentials_provider.clone(),
+                region.clone(),
+            ))
+        }
+    }
+
     #[test]
     fn roundtrip_s3_transport() {
         log_init();
@@ -603,21 +669,17 @@ mod tests {
             key: "".into(),
         };
 
-        let client_provider = Box::new(
-            |region: &Region, credentials_provider: aws_credentials::Provider| {
-                Ok(S3Client::new_with(
-                    // Failed GetObject request
-                    MockRequestDispatcher::with_status(404)
-                        .with_request_checker(is_get_object_request),
-                    credentials_provider,
-                    region.clone(),
-                ))
-            },
-        );
         let mut transport = S3Transport::new_with_client(
             s3_path.clone(),
             aws_credentials::Provider::new_mock(),
-            client_provider,
+            MockClientProvider {
+                requests: vec![MockRequest {
+                    status: 404,
+                    request_checker: is_get_object_request,
+                    header: None,
+                    body: None,
+                }],
+            },
         );
 
         let ret = transport.get(TEST_KEY);
@@ -626,18 +688,17 @@ mod tests {
         let mut transport = S3Transport::new_with_client(
             s3_path.clone(),
             aws_credentials::Provider::new_mock(),
-            Box::new(
-                |region: &Region, credentials_provider: aws_credentials::Provider| {
-                    Ok(S3Client::new_with(
-                        // Successful GetObject request
-                        MockRequestDispatcher::with_status(200)
-                            .with_request_checker(is_get_object_request)
-                            .with_body("fake-content"),
-                        credentials_provider,
-                        region.clone(),
-                    ))
-                },
-            ),
+            MockClientProvider {
+                requests: vec![
+                    // Successful GetObject request
+                    MockRequest {
+                        status: 200,
+                        request_checker: is_get_object_request,
+                        header: None,
+                        body: Some("fake-content"),
+                    },
+                ],
+            },
         );
 
         let mut reader = transport
@@ -647,51 +708,65 @@ mod tests {
         reader.read_to_end(&mut content).expect("failed to read");
         assert_eq!(Vec::from("fake-content"), content);
 
-        let mut transport = S3Transport::new_with_client(
-            s3_path,
-            aws_credentials::Provider::new_mock(),
-            Box::new(
-                |region: &Region, credentials_provider: aws_credentials::Provider| {
-                    let requests = vec![
-                        // Response to CreateMultipartUpload
-                        MockRequestDispatcher::with_status(200)
-                            .with_body(
-                                r#"<?xml version="1.0" encoding="UTF-8"?>
+        let requests = vec![
+            // Response to CreateMultipartUpload
+            MockRequest {
+                status: 200,
+                request_checker: is_create_multipart_upload_request
+                    as for<'r> fn(&'r SignedRequest),
+                header: None,
+                body: Some(
+                    r#"<?xml version="1.0" encoding="UTF-8"?>
 <InitiateMultipartUploadResult>
    <Bucket>fake-bucket</Bucket>
    <Key>fake-key</Key>
    <UploadId>upload-id</UploadId>
 </InitiateMultipartUploadResult>"#,
-                            )
-                            .with_request_checker(is_create_multipart_upload_request),
-                        // Well formed response to UploadPart
-                        MockRequestDispatcher::with_status(200)
-                            .with_request_checker(is_upload_part_request)
-                            .with_header("ETag", "fake-etag"),
-                        // Well formed response to CompleteMultipartUpload
-                        MockRequestDispatcher::with_status(200)
-                            .with_request_checker(is_complete_multipart_upload_request)
-                            .with_body(
-                                r#"<?xml version="1.0" encoding="UTF-8"?>
+                ),
+            },
+            // Well formed response to UploadPart
+            MockRequest {
+                status: 200,
+                request_checker: is_upload_part_request,
+                header: Some(("Etag", "fake-etag")),
+                body: Some(
+                    r#"<?xml version="1.0" encoding="UTF-8"?>
 <CompleteMultipartUploadResult>
    <Location>string</Location>
    <Bucket>fake-bucket</Bucket>
    <Key>fake-key</Key>
    <ETag>fake-etag</ETag>
 </CompleteMultipartUploadResult>"#,
-                            ),
-                        // Response to AbortMultipartUpload, expected because of
-                        // cancel_upload call
-                        MockRequestDispatcher::with_status(204)
-                            .with_request_checker(is_abort_multipart_upload_request),
-                    ];
-                    Ok(S3Client::new_with(
-                        MultipleMockRequestDispatcher::new(requests),
-                        credentials_provider,
-                        region.clone(),
-                    ))
-                },
-            ),
+                ),
+            },
+            // Well formed response to CompleteMultipartUpload
+            MockRequest {
+                status: 200,
+                request_checker: is_complete_multipart_upload_request,
+                header: None,
+                body: Some(
+                    r#"<?xml version="1.0" encoding="UTF-8"?>
+<CompleteMultipartUploadResult>
+   <Location>string</Location>
+   <Bucket>fake-bucket</Bucket>
+   <Key>fake-key</Key>
+   <ETag>fake-etag</ETag>
+</CompleteMultipartUploadResult>"#,
+                ),
+            },
+            // Response to AbortMultipartUpload, expected because of
+            // cancel_upload call
+            MockRequest {
+                status: 204,
+                request_checker: is_abort_multipart_upload_request,
+                header: None,
+                body: None,
+            },
+        ];
+        let mut transport = S3Transport::new_with_client(
+            s3_path,
+            aws_credentials::Provider::new_mock(),
+            MockClientProvider { requests },
         );
 
         let mut writer = transport.put(TEST_KEY).unwrap();

--- a/facilitator/src/work_queue.rs
+++ b/facilitator/src/work_queue.rs
@@ -1,0 +1,126 @@
+use anyhow::{anyhow, Result};
+use std::sync::{Arc, Mutex};
+
+/// A queue of jobs that may be shared across multiple consumer threads. The
+/// producer must have the entire list of jobs in hand when creating the
+/// WorkQueue; adding new jobs to an existing WorkQueue is not supported.
+///
+/// A note on thread safety: this struct stores important data in Arc+Mutex so
+/// it may be clone()d and shared across threads liberally, allowing multiple
+/// consumers to safely and efficiently dequeue jobs and send results to a
+/// single WorkQueue.
+#[derive(Debug, Clone)]
+pub(crate) struct WorkQueue<T, R> {
+    // The list of jobs, wrapped in an std::sync::Mutex and std::sync::Arc for
+    // thread safety. Most work queue implementations would use an
+    // std::collections::VecDeque to allow new jobs to be pushed to the back of
+    // the queue, but since we require clients to have all the jobs in hand
+    // when they call WorkQueue::new(), we can just use a plain Vec and save an
+    // allocation and copy.
+    jobs: Arc<Mutex<Vec<T>>>,
+    results: Arc<Mutex<Vec<R>>>,
+}
+
+impl<T, R> WorkQueue<T, R> {
+    /// Creates a new WorkQueue from the provided list of jobs
+    pub(crate) fn new(jobs: Vec<T>) -> Self {
+        WorkQueue {
+            jobs: Arc::new(Mutex::new(jobs)),
+            results: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Returns a job from the queue, or None if the queue is empty.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the mutex protecting the job queue is poisoned.
+    pub(crate) fn dequeue_job(&mut self) -> Option<T> {
+        self.jobs.lock().unwrap().pop()
+    }
+
+    /// Send job results to the queue. Clients need not call this 1:1 with
+    /// dequeue_job, if they can reasonably represent there results of multiple
+    /// jobs in one R.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the mutex protecting the results is poisoned.
+    pub(crate) fn send_results(&mut self, result: R) {
+        self.results.lock().unwrap().push(result)
+    }
+
+    /// Get the results from this work queue's completed jobs, consuming the
+    /// work queue. Callers should ensure that all other references to the
+    /// WorkQueue have been dropped before calling this method (i.e., make sure
+    /// any clones of this instance have been dropped).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if there are jobs left in the queue, or if the Arc
+    /// protecting the results cannot be unwrapped because there are outstanding
+    /// strong references.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the Mutex protecting the results is poisoned.
+    pub(crate) fn results(self) -> Result<Vec<R>> {
+        if !self.jobs.lock().unwrap().is_empty() {
+            return Err(anyhow!("cannot get results before all jobs are dequeued"));
+        }
+        let mutex = Arc::try_unwrap(self.results)
+            .map_err(|_| anyhow!("failed to unwrap Arc (outstanding strong reference to work queue in a worker thread?)"))?;
+        Ok(mutex.into_inner().unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use std::thread::{self, JoinHandle};
+
+    #[test]
+    fn dequeue_jobs() {
+        let work_queue: WorkQueue<Vec<u32>, u32> =
+            WorkQueue::new(vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]]);
+        let mut thread_handles: Vec<JoinHandle<()>> = Vec::new();
+
+        for _ in 0..2 {
+            let mut queue_clone = work_queue.clone();
+            let handle = thread::spawn(move || loop {
+                match queue_clone.dequeue_job() {
+                    Some(job) => queue_clone.send_results(job.iter().sum()),
+                    None => break (),
+                }
+            });
+            thread_handles.push(handle);
+        }
+
+        for handle in thread_handles {
+            handle.join().unwrap();
+        }
+
+        let results = work_queue.results().unwrap();
+
+        assert_eq!(results.iter().sum::<u32>(), 45);
+    }
+
+    #[test]
+    fn dequeue_error() {
+        let work_queue: WorkQueue<std::result::Result<(), &'static str>, ()> =
+            WorkQueue::new(vec![Ok(()), Err("fake error")]);
+
+        let mut queue_clone = work_queue.clone();
+        let thread_handle: JoinHandle<Result<(), &'static str>> = thread::spawn(move || loop {
+            assert_matches!(queue_clone.dequeue_job(), Some(job) => {
+                match job {
+                    Ok(()) => queue_clone.send_results(()),
+                    Err(e) => break Err(e),
+                }
+            });
+        });
+
+        assert_matches!(thread_handle.join(), Ok(Err("fake error")));
+    }
+}

--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -1,10 +1,11 @@
 use chrono::NaiveDateTime;
 use facilitator::{
-    aggregation::BatchAggregator,
+    aggregation::{BatchAggregator, SumInput},
     batch::{Batch, BatchReader},
     idl::{InvalidPacket, Packet, SumPart},
     intake::BatchIntaker,
     sample::{generate_ingestion_sample, SampleOutput},
+    task::{NoOpWatchdog, Watchdog},
     test_utils::{
         default_facilitator_packet_encryption_public_key, default_facilitator_signing_private_key,
         default_facilitator_signing_public_key, default_ingestor_private_key,
@@ -19,9 +20,23 @@ use facilitator::{
     Error,
 };
 use prio::{encrypt::PrivateKey, util::reconstruct_shares};
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex},
+};
 use tempfile::TempDir;
 use uuid::Uuid;
+
+#[derive(Clone)]
+struct IncrementingWatchdog {
+    count: Arc<Mutex<u64>>,
+}
+
+impl Watchdog for IncrementingWatchdog {
+    fn send_heartbeat(&self) {
+        (*self.count.lock().unwrap()) += 1;
+    }
+}
 
 #[test]
 fn end_to_end() {
@@ -47,7 +62,7 @@ fn aggregation_including_invalid_batch() {
 
     let instance_name = "fake-instance";
     let aggregation_name = "fake-aggregation-1";
-    let date = NaiveDateTime::from_timestamp(2234567890, 654321);
+    let time = NaiveDateTime::from_timestamp(2234567890, 654321);
     let start_date = NaiveDateTime::from_timestamp(1234567890, 654321);
     let end_date = NaiveDateTime::from_timestamp(3234567890, 654321);
 
@@ -87,19 +102,31 @@ fn aggregation_including_invalid_batch() {
     //   - batch 4: facilitator will insert the wrong packet file digest into
     //     the header of the peer validation batch sent to PHA
     let batch_uuids_and_dates = vec![
-        (Uuid::new_v4(), date),
-        (Uuid::new_v4(), date),
-        (Uuid::new_v4(), date),
-        (Uuid::new_v4(), date),
+        SumInput {
+            uuid: Uuid::new_v4(),
+            time,
+        },
+        SumInput {
+            uuid: Uuid::new_v4(),
+            time,
+        },
+        SumInput {
+            uuid: Uuid::new_v4(),
+            time,
+        },
+        SumInput {
+            uuid: Uuid::new_v4(),
+            time,
+        },
     ];
 
     let mut reference_sums = vec![];
 
-    for (batch_uuid, _) in &batch_uuids_and_dates {
+    for sum_input in &batch_uuids_and_dates {
         let reference_sum = generate_ingestion_sample(
-            batch_uuid,
+            &sum_input.uuid,
             aggregation_name,
-            &date,
+            &sum_input.time,
             10,
             100,
             0.11,
@@ -195,7 +222,7 @@ fn aggregation_including_invalid_batch() {
 
     // Perform the intake over the batches, on the PHA and then facilitator,
     // tampering with signatures or batch headers as needed.
-    for (index, (uuid, _)) in batch_uuids_and_dates.iter().enumerate() {
+    for (index, sum_input) in batch_uuids_and_dates.iter().enumerate() {
         let pha_peer_validation_transport = if index == 2 {
             log::info!("pha using wrong key for peer validations");
             &mut pha_to_facilitator_validation_transport_wrong_key
@@ -206,8 +233,8 @@ fn aggregation_including_invalid_batch() {
         let mut pha_batch_intaker = BatchIntaker::new(
             "None",
             aggregation_name,
-            &uuid,
-            &date,
+            &sum_input.uuid,
+            &sum_input.time,
             &mut pha_ingest_transport,
             &mut pha_own_validation_transport,
             pha_peer_validation_transport,
@@ -218,8 +245,8 @@ fn aggregation_including_invalid_batch() {
         let mut facilitator_batch_intaker = BatchIntaker::new(
             "None",
             aggregation_name,
-            &uuid,
-            &date,
+            &sum_input.uuid,
+            &sum_input.time,
             &mut facilitator_ingest_transport,
             &mut facilitator_own_validation_transport,
             &mut facilitator_to_pha_validation_transport,
@@ -232,9 +259,11 @@ fn aggregation_including_invalid_batch() {
             facilitator_batch_intaker.set_use_bogus_packet_file_digest(true);
         }
 
-        pha_batch_intaker.generate_validation_share(|| {}).unwrap();
+        pha_batch_intaker
+            .generate_validation_share(&mut NoOpWatchdog {})
+            .unwrap();
         facilitator_batch_intaker
-            .generate_validation_share(|| {})
+            .generate_validation_share(&mut NoOpWatchdog {})
             .unwrap();
     }
 
@@ -299,7 +328,7 @@ fn aggregation_including_invalid_batch() {
     };
 
     // Perform the aggregation on PHA and facilitator
-    let err = BatchAggregator::new(
+    let mut batch_aggregator = BatchAggregator::new(
         "None",
         instance_name,
         aggregation_name,
@@ -311,14 +340,15 @@ fn aggregation_including_invalid_batch() {
         &mut pha_peer_validation_transport,
         &mut pha_aggregation_transport,
     )
-    .unwrap()
-    .generate_sum_part(&batch_uuids_and_dates, || {})
-    .unwrap_err();
-    // Ideally we would be able to match on a variant in an error enum to check
-    // what the failure was but for now check the error description
-    assert!(err.to_string().contains("packet file digest in header"));
+    .unwrap();
+    batch_aggregator.set_thread_count(4);
 
-    let err = BatchAggregator::new(
+    let err = batch_aggregator
+        .generate_sum_part(batch_uuids_and_dates.clone(), &NoOpWatchdog {})
+        .unwrap_err();
+    check_error(err);
+
+    let mut batch_aggregator = BatchAggregator::new(
         "None",
         instance_name,
         aggregation_name,
@@ -330,12 +360,27 @@ fn aggregation_including_invalid_batch() {
         &mut facilitator_peer_validation_transport,
         &mut facilitator_aggregation_transport,
     )
-    .unwrap()
-    .generate_sum_part(&batch_uuids_and_dates, || {})
-    .unwrap_err();
-    assert!(err
+    .unwrap();
+    batch_aggregator.set_thread_count(4);
+
+    let err = batch_aggregator
+        .generate_sum_part(batch_uuids_and_dates.clone(), &NoOpWatchdog {})
+        .unwrap_err();
+    check_error(err);
+}
+
+fn check_error(error: anyhow::Error) {
+    // Ideally we would be able to match on a variant in an error enum to check
+    // what the failure was but for now check the error description.
+    // Either of these errors could be returned depending on the order in which
+    // BatchAggregator sums batches, which is not deterministic.
+    let is_signing_key_error = error
         .to_string()
-        .contains("key identifier default-facilitator-signing-key not present in key map"));
+        .contains("key identifier default-facilitator-signing-key not present in key map");
+    let is_digest_mismatch_error = error
+        .to_string()
+        .contains("does not match actual packet file digest");
+    assert!(is_signing_key_error || is_digest_mismatch_error);
 }
 
 fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usize>) {
@@ -466,7 +511,6 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         batch_signing_key: default_facilitator_signing_private_key(),
     };
 
-    let mut intake_callback_count = 0;
     let mut batch_intaker = BatchIntaker::new(
         "None",
         &aggregation_name,
@@ -478,13 +522,17 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         true,
     )
     .unwrap();
+
+    let mut watchdog = IncrementingWatchdog {
+        count: Arc::new(Mutex::new(0)),
+    };
     batch_intaker.set_callback_cadence(2);
     batch_intaker
-        .generate_validation_share(|| intake_callback_count += 1)
+        .generate_validation_share(&mut watchdog)
         .unwrap();
 
     assert_eq!(
-        intake_callback_count,
+        *watchdog.count.lock().unwrap() as usize,
         (first_batch_packet_count - batch_1_reference_sum.pha_dropped_packets.len()) / 2
     );
 
@@ -499,7 +547,7 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         true,
     )
     .unwrap()
-    .generate_validation_share(|| {})
+    .generate_validation_share(&mut NoOpWatchdog {})
     .unwrap();
 
     BatchIntaker::new(
@@ -513,7 +561,7 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         false,
     )
     .unwrap()
-    .generate_validation_share(|| {})
+    .generate_validation_share(&mut NoOpWatchdog {})
     .unwrap();
 
     BatchIntaker::new(
@@ -527,10 +575,19 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         false,
     )
     .unwrap()
-    .generate_validation_share(|| {})
+    .generate_validation_share(&mut NoOpWatchdog {})
     .unwrap();
 
-    let batch_ids_and_dates = vec![(batch_1_uuid, date), (batch_2_uuid, date)];
+    let batch_ids_and_dates = vec![
+        SumInput {
+            uuid: batch_1_uuid,
+            time: date,
+        },
+        SumInput {
+            uuid: batch_2_uuid,
+            time: date,
+        },
+    ];
 
     let mut pha_pub_keys = HashMap::new();
     pha_pub_keys.insert(
@@ -560,7 +617,9 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         batch_signing_key: default_pha_signing_private_key(),
     };
 
-    let mut aggregation_callback_count = 0;
+    let watchdog = IncrementingWatchdog {
+        count: Arc::new(Mutex::new(0)),
+    };
     BatchAggregator::new(
         "None",
         instance_name,
@@ -574,10 +633,11 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         &mut pha_aggregation_transport,
     )
     .unwrap()
-    .generate_sum_part(&batch_ids_and_dates, || aggregation_callback_count += 1)
+    .generate_sum_part(batch_ids_and_dates.clone(), &watchdog)
     .unwrap();
-
-    assert_eq!(aggregation_callback_count, 2);
+    {
+        assert_eq!(*watchdog.count.lock().unwrap(), 2);
+    }
 
     let mut facilitator_aggregation_transport = SignableTransport {
         transport: Box::new(LocalFileTransport::new(
@@ -586,7 +646,6 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         batch_signing_key: default_facilitator_signing_private_key(),
     };
 
-    let mut aggregation_callback_count = 0;
     BatchAggregator::new(
         "None",
         instance_name,
@@ -600,10 +659,11 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         &mut facilitator_aggregation_transport,
     )
     .unwrap()
-    .generate_sum_part(&batch_ids_and_dates, || aggregation_callback_count += 1)
+    .generate_sum_part(batch_ids_and_dates.clone(), &watchdog)
     .unwrap();
-
-    assert_eq!(aggregation_callback_count, 2);
+    {
+        assert_eq!(*watchdog.count.lock().unwrap(), 4);
+    }
 
     let mut pha_aggregation_batch_reader: BatchReader<'_, SumPart, InvalidPacket> =
         BatchReader::new(

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -34,6 +34,7 @@ variable "ingestors" {
     localities = map(object({
       intake_worker_count                    = number
       aggregate_worker_count                 = number
+      aggregate_thread_count                 = number
       peer_share_processor_manifest_base_url = string
       portal_server_manifest_base_url        = string
     }))
@@ -360,6 +361,7 @@ locals {
       ingestor_manifest_base_url              = var.ingestors[pair[1]].manifest_base_url
       intake_worker_count                     = var.ingestors[pair[1]].localities[pair[0]].intake_worker_count
       aggregate_worker_count                  = var.ingestors[pair[1]].localities[pair[0]].aggregate_worker_count
+      aggregate_thread_count                  = var.ingestors[pair[1]].localities[pair[0]].aggregate_thread_count
       peer_share_processor_manifest_base_url  = var.ingestors[pair[1]].localities[pair[0]].peer_share_processor_manifest_base_url
       portal_server_manifest_base_url         = var.ingestors[pair[1]].localities[pair[0]].portal_server_manifest_base_url
     }
@@ -420,6 +422,7 @@ module "data_share_processors" {
   container_registry                             = var.container_registry
   intake_worker_count                            = each.value.intake_worker_count
   aggregate_worker_count                         = each.value.aggregate_worker_count
+  aggregate_thread_count                         = each.value.aggregate_thread_count
 }
 
 # The portal owns two sum part buckets (one for each data share processor) and

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -110,6 +110,10 @@ variable "aggregate_worker_count" {
   type = number
 }
 
+variable "aggregate_thread_count" {
+  type = number
+}
+
 # We need the ingestion server's manifest so that we can discover the GCP
 # service account it will use to upload ingestion batches. Some ingestors
 # (Apple) are singletons, and advertise a single global manifest which contains
@@ -410,6 +414,7 @@ module "kubernetes" {
   aggregate_queue                         = module.pubsub["aggregate"].queue
   intake_worker_count                     = var.intake_worker_count
   aggregate_worker_count                  = var.aggregate_worker_count
+  aggregate_thread_count                  = var.aggregate_thread_count
 }
 
 output "data_share_processor_name" {

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -17,36 +17,42 @@ ingestors = {
       ta-ta = {
         intake_worker_count                    = 1
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 1
         peer_share_processor_manifest_base_url = "test-en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.int.enpa-pha.io"
       }
       us-ct = {
         intake_worker_count                    = 5
         aggregate_worker_count                 = 3
+        aggregate_thread_count                 = 4
         peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-md = {
         intake_worker_count                    = 5
         aggregate_worker_count                 = 3
+        aggregate_thread_count                 = 4
         peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-va = {
         intake_worker_count                    = 5
         aggregate_worker_count                 = 3
+        aggregate_thread_count                 = 4
         peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-wa = {
         intake_worker_count                    = 5
         aggregate_worker_count                 = 3
+        aggregate_thread_count                 = 4
         peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-ca = {
         intake_worker_count                    = 25
         aggregate_worker_count                 = 7
+        aggregate_thread_count                 = 4
         peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
@@ -84,36 +90,42 @@ ingestors = {
       ta-ta = {
         intake_worker_count                    = 1
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 4
         peer_share_processor_manifest_base_url = "test-en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.int.enpa-pha.io"
       }
       us-ct = {
         intake_worker_count                    = 3
         aggregate_worker_count                 = 3
+        aggregate_thread_count                 = 4
         peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-md = {
         intake_worker_count                    = 3
         aggregate_worker_count                 = 3
+        aggregate_thread_count                 = 4
         peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-va = {
         intake_worker_count                    = 3
         aggregate_worker_count                 = 3
+        aggregate_thread_count                 = 4
         peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-wa = {
         intake_worker_count                    = 3
         aggregate_worker_count                 = 3
+        aggregate_thread_count                 = 4
         peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-ca = {
         intake_worker_count                    = 15
         aggregate_worker_count                 = 3
+        aggregate_thread_count                 = 4
         peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -15,18 +15,21 @@ ingestors = {
       narnia = {
         intake_worker_count                    = 1
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 2
         peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
         portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
       }
       gondor = {
         intake_worker_count                    = 2
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 2
         peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
         portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
       }
       asgard = {
         intake_worker_count                    = 1
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 2
         peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
         portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
       }
@@ -38,18 +41,21 @@ ingestors = {
       narnia = {
         intake_worker_count                    = 2
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 2
         peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
         portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
       }
       gondor = {
         intake_worker_count                    = 1
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 2
         peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
         portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
       }
       asgard = {
         intake_worker_count                    = 1
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 2
         peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
         portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
       }

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -15,18 +15,21 @@ ingestors = {
       narnia = {
         intake_worker_count                    = 1
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 2
         peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
         portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
       }
       gondor = {
         intake_worker_count                    = 2
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 2
         peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
         portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
       }
       asgard = {
         intake_worker_count                    = 1
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 2
         peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
         portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
       }
@@ -38,18 +41,21 @@ ingestors = {
       narnia = {
         intake_worker_count                    = 2
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 2
         peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
         portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
       }
       gondor = {
         intake_worker_count                    = 1
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 2
         peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
         portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
       }
       asgard = {
         intake_worker_count                    = 1
         aggregate_worker_count                 = 1
+        aggregate_thread_count                 = 2
         peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
         portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
       }


### PR DESCRIPTION
We observed that in NCI's production deployment, us-ca-apple
individual aggregation tasks are often taking more than eight hours to
run, which means that even adding more aggregation workers won't speed
things up. We schedule aggregations to run every eight hours, making it
impossible for NCI to keep up with incoming work.

To ameliorate this, this commit refactors the aggregation task handler
so that it can spawn multiple threads and sum over individual batches in
parallel. The threads are managed using the `WorkQueue` struct, which
implements a no-producer, multiple-consumer work queue. I say
"no-producer" because it doesn't support an "enqueue" method as you
might see in most pub/sub implementations, and instead expects the
entire list of jobs to be available at the creation of the `WorkQueue`.
In our use case, we know up front the list of jobs we want to execute in
parallel, and this allows us to greatly simplify the queue
implementation. For instance, we can use a simple `Vec` to store jobs
instead of requiring a `VecDeque` or some more complex data structure.

To allow safely sharing or sending resources across worker threads, we
rely heavily on structs implementing the `Clone` trait. Mostly this is a
simple matter of tagging existing definitions with `#[derive(Clone)]`,
but it required some extra gymnastics for `S3Client` and its associated
structs:

	- `ClientProvider` was refactored from a supertrait over
	  `std::ops::Fn` into a more conventional trait to make it
	  easier to reason about how to `Clone` it.
	- Because Rusoto's `MockRequestDispatcher` & Co. are not
	  `Clone` and have private fields, we had to introduce some
	  proxy objects that can be cloned.

To enable multithreaded aggregation, pass `--thread-count=<int>` to
`facilitator aggregate-worker`, or set the `THREAD_COUNT` environment
variable to an integer value (e.g., in a Kubernetes ConfigMap).