### PR TITLE
terraform: deploy us-nm locality in prod-us

### DIFF
--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -1,7 +1,7 @@
 environment     = "prod-us"
 gcp_region      = "us-west1"
 gcp_project     = "prio-prod-us"
-localities      = ["ta-ta", "us-ct", "us-md", "us-va", "us-wa", "us-ca", "us-ut", "us-wi", "us-ma"]
+localities      = ["ta-ta", "us-ct", "us-md", "us-va", "us-wa", "us-ca", "us-ut", "us-wi", "us-ma", "us-nm"]
 aws_region      = "us-west-1"
 manifest_domain = "isrg-prio.org"
 managed_dns_zone = {
@@ -68,6 +68,12 @@ ingestors = {
         peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
+      us-nm = {
+        intake_worker_count                    = 5
+        aggregate_worker_count                 = 3
+        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+      }
     }
   }
   g-enpa = {
@@ -124,6 +130,12 @@ ingestors = {
         portal_server_manifest_base_url        = "manifest.enpa-pha.io"
       }
       us-ma = {
+        intake_worker_count                    = 3
+        aggregate_worker_count                 = 3
+        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+      }
+      us-nm = {
         intake_worker_count                    = 3
         aggregate_worker_count                 = 3
         peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"


### PR DESCRIPTION
Capacity planning rationale: New Mexico's population of approximately
2.1 million should be manageable with a CT-sized deployment.