### PR TITLE
terraform: reduce apply noise

### DIFF
--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -315,6 +315,12 @@ resource "kubernetes_cron_job" "workflow_manager" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      spec[0].job_template[0].metadata[0].annotations["environment"]
+    ]
+  }
 }
 
 resource "kubernetes_service" "intake_batch" {
@@ -338,6 +344,12 @@ resource "kubernetes_service" "intake_batch" {
       app      = "intake-batch-worker"
       ingestor = var.ingestor
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations["cloud.google.com/neg"]
+    ]
   }
 }
 
@@ -441,6 +453,12 @@ resource "kubernetes_service" "aggregate" {
       app      = "aggregate-worker"
       ingestor = var.ingestor
     }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations["cloud.google.com/neg"]
+    ]
   }
 }
 

--- a/terraform/modules/monitoring/monitoring.tf
+++ b/terraform/modules/monitoring/monitoring.tf
@@ -98,6 +98,10 @@ resource "google_compute_region_disk" "prometheus_server" {
   replica_zones = [data.google_compute_zones.available.names[0], data.google_compute_zones.available.names[1]]
   size          = var.prometheus_server_persistent_disk_size_gb
   region        = var.gcp_region
+
+  lifecycle {
+    ignore_changes = [labels]
+  }
 }
 
 # Create a Kubernetes persistent volume representing the GCP disk


### PR DESCRIPTION
Some of the resources created in Terraform can have metadata or label
attributes set at runtime by GKE. This results in `terraform apply`
performing benign but unnecessary modifications to some resources.
Typically, Terraform will remove some label that GKE will then later
automatically re-apply. However, these benign modifications pollute the
output of `terraform plan` and `apply` with irrelevant noise, which
makes it harder for an operator to pick out the real changes being
applied.

This commit adds a few `lifecycle` blocks to instruct `terraform` to
ignore certain changes:
 - "environment" annotation on `workflow-manager` job template
 - "cloud.google.com/neg" annotation on intake and aggregate k8s
   services
 - labels on the GCE persistent disk that backs Prometheus