### PR TITLE
facilitator: add structured log fields

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -1723,6 +1723,7 @@ fn transport_for_path(
                     matches.value_of(entity.suffix("-use-default-aws-credentials-provider")),
                     bool
                 )?,
+                "s3",
             )?;
             Ok(Box::new(S3Transport::new(path, credentials_provider)))
         }
@@ -1788,6 +1789,7 @@ fn intake_task_queue_from_args(
                     matches.value_of("task-queue-use-default-aws-credentials-provider"),
                     bool
                 )?,
+                "sqs",
             )?;
             Ok(Box::new(AwsSqsTaskQueue::new(
                 sqs_region,
@@ -1834,6 +1836,7 @@ fn aggregation_task_queue_from_args(
                     matches.value_of("task-queue-use-default-aws-credentials-provider"),
                     bool
                 )?,
+                "sqs",
             )?;
             Ok(Box::new(AwsSqsTaskQueue::new(
                 sqs_region,


### PR DESCRIPTION
Extends `log::Record` so we can also log Rust module path, source file,
source line and ThreadId in log messages, if they are available. Also
adds some `debug!` logs around handling of various Oauth tokens to make
it easier to tell when a credential has expired.