### PR TITLE
facilitator: better error on decryption failure

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -1646,9 +1646,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "prio"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c293e32d9ab6c9afadf14e14d76df204f17618f4b74b38fa2adb18b352fbf2"
+checksum = "3a2d8d68c9a3ad7a7b5a5c02bfb21f0b8c1e8ba42dc36179d80765df6cc18d3e"
 dependencies = [
  "aes-ctr",
  "aes-gcm",

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4.11"
 p256 = "0.8.0-pre.1"
 pem = "0.8"
 pkix = "0.1.1"
-prio = "0.2"
+prio = "0.4.0"
 prometheus = "0.12"
 rand = "0.8"
 ring = { version = "0.16.20", features = ["std"] }

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -1129,6 +1129,7 @@ fn generate_sample(sub_matches: &ArgMatches) -> Result<(), anyhow::Error> {
         value_t!(sub_matches.value_of("epsilon"), f64)?,
         value_t!(sub_matches.value_of("batch-start-time"), i64)?,
         value_t!(sub_matches.value_of("batch-end-time"), i64)?,
+        None,
         &mut peer_transport,
         &mut facilitator_transport,
     )?;

--- a/facilitator/src/idl.rs
+++ b/facilitator/src/idl.rs
@@ -4,7 +4,7 @@ use avro_rs::{
     types::{Record, Value},
     Reader, Schema, Writer,
 };
-use prio::{finite_field::Field, server::VerificationMessage};
+use prio::{field::Field32, server::VerificationMessage};
 use serde::{Deserialize, Serialize};
 use std::{
     convert::TryFrom,
@@ -745,14 +745,14 @@ impl Packet for ValidationPacket {
     }
 }
 
-impl TryFrom<&ValidationPacket> for VerificationMessage {
+impl TryFrom<&ValidationPacket> for VerificationMessage<Field32> {
     type Error = TryFromIntError;
 
     fn try_from(p: &ValidationPacket) -> Result<Self, Self::Error> {
         Ok(VerificationMessage {
-            f_r: Field::from(u32::try_from(p.f_r)?),
-            g_r: Field::from(u32::try_from(p.g_r)?),
-            h_r: Field::from(u32::try_from(p.h_r)?),
+            f_r: Field32::from(u32::try_from(p.f_r)?),
+            g_r: Field32::from(u32::try_from(p.g_r)?),
+            h_r: Field32::from(u32::try_from(p.h_r)?),
         })
     }
 }
@@ -774,10 +774,10 @@ pub struct SumPart {
 }
 
 impl SumPart {
-    pub fn sum(&self) -> Result<Vec<Field>, TryFromIntError> {
+    pub fn sum(&self) -> Result<Vec<Field32>, TryFromIntError> {
         self.sum
             .iter()
-            .map(|i| Ok(Field::from(u32::try_from(*i)?)))
+            .map(|i| Ok(Field32::from(u32::try_from(*i)?)))
             .collect::<Result<Vec<_>, _>>()
     }
 }

--- a/facilitator/src/test_utils.rs
+++ b/facilitator/src/test_utils.rs
@@ -20,6 +20,7 @@ pub const DEFAULT_INGESTOR_PRIVATE_KEY: &str =
     "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQggoa08rQR90Asvhy5b\
     WIgFBDeGaO8FnVEF3PVpNVmDGChRANCAAQ2mZfm4UC73PkWsYz3Uub6UTIAFQCPGxo\
     uP1O1PlmntOpfLYdvyZDCuenAzv1oCfyToolNArNjwo/+harNn1fs";
+
 // We have selected PEM armored, ASN.1 encoded PKIX SubjectPublicKeyInfo
 // structures as the means of exchanging public keys with peer servers. However,
 // no Rust crate that we have found gives us an easy way to obtain a PKIX SPKI
@@ -46,14 +47,26 @@ pub const DEFAULT_PHA_SUBJECT_PUBLIC_KEY_INFO: &str =
     "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEIKh3MccE1cdSF4pnEb+U0MmGYfko\
     QzOl2aiaJ6D9ZudqDdGiyA9YSUq3yia56nYJh5mk+HlzTX+AufoNR2bfrg==";
 
-pub const DEFAULT_PACKET_ENCRYPTION_CSR: &str = "MIHuMIGVAgEAMDMxMTAvBgNVBAMTKHVzLWN0LnByb\
-2QtdXMuY2VydGlmaWNhdGVzLmlzcmctcHJpby5vcmcwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAA\
-Tp7xFbJGwHeMlAW8W0cQ57qCPIBT5NBr2jR8a+Z1/QzQJRtJvR2pqbaJhWKw7y9ogp/TmcsaX+o\
-P74+SSGwrEYoAAwCgYIKoZIzj0EAwIDSAAwRQIgLSekh4unn6fLv9O9K4Lr6VxGEpLSqFz259+Lrk\
-7lwOkCIQCOzNvxwSb+iVFxJkaxUnxGYp2J+/2OnDGsKpyWY/wdhg==";
+pub const DEFAULT_PACKET_ENCRYPTION_CSR: &str =
+    "MIHuMIGVAgEAMDMxMTAvBgNVBAMTKHVzLWN0LnByb2QtdXMuY2VydGlmaWNhdGVzL\
+    mlzcmctcHJpby5vcmcwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATp7xFbJGwHeMl\
+    AW8W0cQ57qCPIBT5NBr2jR8a+Z1/QzQJRtJvR2pqbaJhWKw7y9ogp/TmcsaX+oP74+\
+    SSGwrEYoAAwCgYIKoZIzj0EAwIDSAAwRQIgLSekh4unn6fLv9O9K4Lr6VxGEpLSqFz\
+    259+Lrk7lwOkCIQCOzNvxwSb+iVFxJkaxUnxGYp2J+/2OnDGsKpyWY/wdhg==";
 
-pub const DEFAULT_PACKET_ENCRYPTION_CERTIFICATE_SIGNING_REQUEST: &str = "-----BEGIN CERTIFICATE REQUEST-----\nMIHyMIGZAgEAMDcxNTAzBgNVBAMTLG5hcm5pYS5hbWlyLWZhY2lsLmNlcnRpZmlj\nYXRlcy5pc3JnLXByaW8ub3JnMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEImPq\nnZJKMV0RUt4liCn/pzj1YEs8G13wvHNyqQ8HVmvjc7fj29K4vq5wkEXRK6QGD6UO\nAZ9LiBsRN9cniLwysaAAMAoGCCqGSM49BAMCA0gAMEUCIQCqjVbLAabHDELRztvB\nZyzYemEzJoMqTRObEjpryr5gsgIgYAx8mMlBkI/GVJqCHvyBzMwRaz1hoQHme56H\nvjjDWyI=\n-----END CERTIFICATE REQUEST-----\n";
-pub const DEFAULT_PACKET_ENCRYPTION_CERTIFICATE_SIGNING_REQUEST_PRIVATE_KEY: &str = "BCJj6p2SSjFdEVLeJYgp/6c49WBLPBtd8LxzcqkPB1Zr43O349vSuL6ucJBF0SukBg+lDgGfS4gbETfXJ4i8MrHwu3/ts6VHR1/U9EIkHEFnEDZQ30r3NVASbEeJjd0/Ug==";
+pub const DEFAULT_PACKET_ENCRYPTION_CERTIFICATE_SIGNING_REQUEST: &str =
+    "-----BEGIN CERTIFICATE REQUEST-----\n\
+    MIHyMIGZAgEAMDcxNTAzBgNVBAMTLG5hcm5pYS5hbWlyLWZhY2lsLmNlcnRpZmlj\n\
+    YXRlcy5pc3JnLXByaW8ub3JnMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEImPq\n\
+    nZJKMV0RUt4liCn/pzj1YEs8G13wvHNyqQ8HVmvjc7fj29K4vq5wkEXRK6QGD6UO\n\
+    AZ9LiBsRN9cniLwysaAAMAoGCCqGSM49BAMCA0gAMEUCIQCqjVbLAabHDELRztvB\n\
+    ZyzYemEzJoMqTRObEjpryr5gsgIgYAx8mMlBkI/GVJqCHvyBzMwRaz1hoQHme56H\n\
+    vjjDWyI=\n\
+    -----END CERTIFICATE REQUEST-----\n";
+
+pub const DEFAULT_PACKET_ENCRYPTION_CERTIFICATE_SIGNING_REQUEST_PRIVATE_KEY: &str =
+    "BCJj6p2SSjFdEVLeJYgp/6c49WBLPBtd8LxzcqkPB1Zr43O349vSuL6ucJBF0SukB\
+    g+lDgGfS4gbETfXJ4i8MrHwu3/ts6VHR1/U9EIkHEFnEDZQ30r3NVASbEeJjd0/Ug==";
 
 pub fn default_packet_encryption_certificate_signing_request(
 ) -> PacketEncryptionCertificateSigningRequest {

--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -105,6 +105,7 @@ fn aggregation_including_invalid_batch() {
             0.11,
             100,
             100,
+            None,
             &mut pha_output,
             &mut facilitator_output,
         )
@@ -396,6 +397,7 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         0.11,
         100,
         100,
+        None,
         &mut pha_output,
         &mut facilitator_output,
     )
@@ -410,6 +412,7 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         0.11,
         100,
         100,
+        None,
         &mut pha_output,
         &mut facilitator_output,
     )


### PR DESCRIPTION
Adopts the updated `libprio-rs` API to better discriminate between
failures of `prio::server::Server::generate_verification_message` so
that a better error message can be logged if an input share is rejected
due to a packet encryption key mismatch.

Resolves #550