### PR TITLE
facilitator: use slog for structured logging

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -98,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
+name = "arc-swap"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d7d63395147b81a9e570bcc6243aaf71c017bd666d4909cfef0085bdda8d73"
+
+[[package]]
 name = "array_tool"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +427,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,20 +617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime 1.3.0",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
-dependencies = [
- "atty",
- "humantime 2.1.0",
+ "humantime",
  "log",
  "regex",
  "termcolor",
@@ -616,13 +630,13 @@ dependencies = [
  "anyhow",
  "assert_matches",
  "async-trait",
+ "atty",
  "avro-rs",
  "base64 0.13.0",
  "chrono",
  "clap",
  "derivative",
  "elliptic-curve",
- "env_logger 0.8.3",
  "http",
  "hyper",
  "hyper-rustls",
@@ -630,7 +644,6 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "kube-runtime",
- "log",
  "mockito",
  "p256",
  "pem",
@@ -647,6 +660,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
+ "slog",
+ "slog-async",
+ "slog-json",
+ "slog-scope",
+ "slog-term",
  "tempfile",
  "thiserror",
  "tokio",
@@ -996,12 +1014,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,7 +1140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61352ec23883402b7d30b3313c16cbabefb8907361c4eb669d990cbb87ceee5a"
 dependencies = [
  "array_tool",
- "env_logger 0.7.1",
+ "env_logger",
  "log",
  "serde",
  "serde_json",
@@ -2035,6 +2047,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2289,6 +2307,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
+name = "slog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+
+[[package]]
+name = "slog-async"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c60813879f820c85dbc4eabf3269befe374591289019775898d56a81a804fbdc"
+dependencies = [
+ "crossbeam-channel",
+ "slog",
+ "take_mut",
+ "thread_local",
+]
+
+[[package]]
+name = "slog-json"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddc0d2aff1f8f325ef660d9a0eb6e6dcd20b30b3f581a5897f58bf42d061c37a"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "slog",
+]
+
+[[package]]
+name = "slog-scope"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
+dependencies = [
+ "arc-swap",
+ "lazy_static",
+ "slog",
+]
+
+[[package]]
+name = "slog-term"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c1e7e5aab61ced6006149ea772770b84a0d16ce0f7885def313e4829946d76"
+dependencies = [
+ "atty",
+ "chrono",
+ "slog",
+ "term",
+ "thread_local",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,6 +2563,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,6 +2585,17 @@ dependencies = [
  "rand 0.8.3",
  "redox_syscall 0.2.4",
  "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
  "winapi",
 ]
 

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -7,13 +7,13 @@ version = "0.1.0"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
+atty = "0.2"
 avro-rs = { version = "0.13.0", features = ["snappy"] }
 base64 = "0.13.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2.33.3"
 derivative = "2.1.1"
 elliptic-curve = { version = "0.9.6", features = ["pem"] }
-env_logger = "0.8.3"
 http = "^0.2"
 hyper = "^0.14"
 hyper-rustls = "^0.22"
@@ -21,7 +21,6 @@ jsonwebtoken = "7"
 k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_20"] }
 kube = "0.52.0"
 kube-runtime = "0.52.0"
-log = "0.4.11"
 p256 = "0.8.0-pre.1"
 pem = "0.8"
 pkix = "0.1.1"
@@ -34,6 +33,11 @@ rusoto_mock = { version = "^0.46", default_features = false, features = ["rustls
 rusoto_s3 = { version = "^0.46", default_features = false, features = ["rustls"] }
 rusoto_sqs = { version = "^0.46", default_features = false, features = ["rustls"] }
 rusoto_sts = { version = "^0.46", default_features = false, features = ["rustls"] }
+slog = { version = "2.7.0", features = ["max_level_trace"] }
+slog-async = "2.6.0"
+slog-json = "2.3.0"
+slog-scope = "4.4.0"
+slog-term = "2.8.0"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.1.0"

--- a/facilitator/src/aggregation.rs
+++ b/facilitator/src/aggregation.rs
@@ -4,6 +4,10 @@ use crate::{
         IngestionDataSharePacket, IngestionHeader, InvalidPacket, Packet, SumPart,
         ValidationHeader, ValidationPacket,
     },
+    logging::{
+        EVENT_KEY_AGGREGATION_NAME, EVENT_KEY_INGESTION_PATH, EVENT_KEY_OWN_VALIDATION_PATH,
+        EVENT_KEY_PACKET_UUID, EVENT_KEY_PEER_VALIDATION_PATH, EVENT_KEY_TRACE_ID,
+    },
     metrics::AggregateMetricsCollector,
     transport::{SignableTransport, VerifiableAndDecryptableTransport, VerifiableTransport},
     BatchSigningKey, Error,
@@ -11,11 +15,11 @@ use crate::{
 use anyhow::{anyhow, Context, Result};
 use avro_rs::Reader;
 use chrono::NaiveDateTime;
-use log::info;
 use prio::{
     field::Field32,
     server::{Server, VerificationMessage},
 };
+use slog::{info, o, Logger};
 use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom,
@@ -37,6 +41,7 @@ pub struct BatchAggregator<'a> {
     share_processor_signing_key: &'a BatchSigningKey,
     total_individual_clients: i64,
     metrics_collector: Option<&'a AggregateMetricsCollector>,
+    logger: Logger,
 }
 
 impl<'a> BatchAggregator<'a> {
@@ -53,7 +58,15 @@ impl<'a> BatchAggregator<'a> {
         own_validation_transport: &'a mut VerifiableTransport,
         peer_validation_transport: &'a mut VerifiableTransport,
         aggregation_transport: &'a mut SignableTransport,
+        parent_logger: &Logger,
     ) -> Result<BatchAggregator<'a>> {
+        let logger = parent_logger.new(o!(
+            EVENT_KEY_TRACE_ID => trace_id.to_owned(),
+            EVENT_KEY_AGGREGATION_NAME => aggregation_name.to_owned(),
+            EVENT_KEY_INGESTION_PATH => ingestion_transport.transport.transport.path(),
+            EVENT_KEY_OWN_VALIDATION_PATH => own_validation_transport.transport.path(),
+            EVENT_KEY_PEER_VALIDATION_PATH => peer_validation_transport.transport.path(),
+        ));
         Ok(BatchAggregator {
             trace_id,
             is_first,
@@ -77,6 +90,7 @@ impl<'a> BatchAggregator<'a> {
             share_processor_signing_key: &aggregation_transport.batch_signing_key,
             total_individual_clients: 0,
             metrics_collector: None,
+            logger,
         })
     }
 
@@ -87,19 +101,15 @@ impl<'a> BatchAggregator<'a> {
     /// Compute the sum part for all the provided batch IDs and write it out to
     /// the aggregation transport. The provided callback is invoked after each
     /// batch is aggregated.
-    pub fn generate_sum_part<F: FnMut()>(
+    pub fn generate_sum_part<F>(
         &mut self,
         batch_ids: &[(Uuid, NaiveDateTime)],
         mut callback: F,
-    ) -> Result<()> {
-        info!(
-            "trace id {} processing intake from {}, own validity from {}, peer validity from {} and saving sum parts to {}",
-            self.trace_id,
-            self.ingestion_transport.transport.transport.path(),
-            self.own_validation_transport.transport.path(),
-            self.peer_validation_transport.transport.path(),
-            self.aggregation_batch.path(),
-        );
+    ) -> Result<()>
+    where
+        F: FnMut(&Logger),
+    {
+        info!(self.logger, "processing aggregation task");
         let mut invalid_uuids = Vec::new();
         let mut included_batch_uuids = Vec::new();
 
@@ -120,7 +130,7 @@ impl<'a> BatchAggregator<'a> {
         for batch_id in batch_ids {
             self.aggregate_share(&batch_id.0, &batch_id.1, &mut servers, &mut invalid_uuids)?;
             included_batch_uuids.push(batch_id.0);
-            callback();
+            callback(&self.logger);
         }
 
         // TODO(timg) what exactly do we write out when there are no invalid
@@ -245,16 +255,14 @@ impl<'a> BatchAggregator<'a> {
         // Make sure all the parameters in the headers line up
         if !peer_validation_header.check_parameters(&own_validation_header) {
             return Err(anyhow!(
-                "trace id {} validation headers do not match. Peer: {:?}\nOwn: {:?}",
-                self.trace_id,
+                "validation headers do not match. Peer: {:?}\nOwn: {:?}",
                 peer_validation_header,
                 own_validation_header
             ));
         }
         if !ingestion_header.check_parameters(&peer_validation_header) {
             return Err(anyhow!(
-                "trace id {} ingestion header does not match peer validation header. Ingestion: {:?}\nPeer:{:?}",
-                self.trace_id,
+                "ingestion header does not match peer validation header. Ingestion: {:?}\nPeer:{:?}",
                 ingestion_header,
                 peer_validation_header
             ));
@@ -283,8 +291,12 @@ impl<'a> BatchAggregator<'a> {
         // Keep track of the ingestion packets we have seen so we can reject
         // duplicates.
         let mut processed_ingestion_packets = HashSet::new();
-
         let mut ingestion_packet_reader = ingestion_batch.packet_file_reader(&ingestion_header)?;
+
+        // Borrowing distinct parts of a struct works, but not under closures:
+        // https://github.com/rust-lang/rust/issues/53488
+        // The workaround is to borrow or copy fields outside the closure.
+        let logger = &self.logger;
 
         loop {
             let ingestion_packet =
@@ -296,7 +308,10 @@ impl<'a> BatchAggregator<'a> {
 
             // Ignore duplicate packets
             if processed_ingestion_packets.contains(&ingestion_packet.uuid) {
-                info!("ignoring duplicate packet {}", ingestion_packet.uuid);
+                info!(
+                    logger, "ignoring duplicate packet";
+                    EVENT_KEY_PACKET_UUID => ingestion_packet.uuid.to_string()
+                );
                 continue;
             }
 
@@ -307,6 +322,7 @@ impl<'a> BatchAggregator<'a> {
                 &peer_validation_packets,
                 "peer",
                 invalid_uuids,
+                logger,
             );
             let peer_validation_packet: &ValidationPacket = match peer_validation_packet {
                 Some(p) => p,
@@ -318,6 +334,7 @@ impl<'a> BatchAggregator<'a> {
                 &own_validation_packets,
                 "own",
                 invalid_uuids,
+                logger,
             );
             let own_validation_packet: &ValidationPacket = match own_validation_packet {
                 Some(p) => p,
@@ -337,8 +354,8 @@ impl<'a> BatchAggregator<'a> {
                     Ok(valid) => {
                         if !valid {
                             info!(
-                                "trace id {} rejecting packet {} due to invalid proof",
-                                self.trace_id, peer_validation_packet.uuid
+                                logger, "rejecting packet due to invalid proof";
+                                EVENT_KEY_PACKET_UUID => peer_validation_packet.uuid.to_string(),
                             );
                             invalid_uuids.push(peer_validation_packet.uuid);
                         }
@@ -389,10 +406,14 @@ fn get_validation_packet<'a>(
     validation_packets: &'a HashMap<Uuid, ValidationPacket>,
     kind: &str,
     invalid_uuids: &mut Vec<Uuid>,
+    logger: &Logger,
 ) -> Option<&'a ValidationPacket> {
     match validation_packets.get(uuid) {
         None => {
-            info!("no {} validation packet for {}", kind, uuid);
+            info!(
+                logger, "no {} validation packet", kind;
+                EVENT_KEY_PACKET_UUID => uuid.to_string()
+            );
             invalid_uuids.push(*uuid);
             None
         }

--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use log::{debug, info};
 use rusoto_core::{
     credential::{
         AutoRefreshingProvider, AwsCredentials, CredentialsError, DefaultCredentialsProvider,
@@ -14,6 +13,7 @@ use rusoto_core::{
 };
 use rusoto_mock::MockCredentialsProvider;
 use rusoto_sts::WebIdentityProvider;
+use slog_scope::{debug, info};
 use std::{
     boxed::Box,
     convert::From,

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -13,6 +13,7 @@ use ring::{
     rand::SystemRandom,
     signature::{EcdsaKeyPair, Signature, UnparsedPublicKey},
 };
+use slog_scope::warn;
 use std::{
     collections::HashMap,
     io::{Cursor, Read},
@@ -185,7 +186,7 @@ impl<'a, H: Header, P: Packet> BatchReader<'a, H, P> {
                     .inc();
             }
             if self.permit_malformed_batch {
-                log::warn!("{}", message);
+                warn!("{}", message);
             } else {
                 return Err(anyhow!("{}", message));
             }
@@ -234,7 +235,7 @@ impl<'a, H: Header, P: Packet> BatchReader<'a, H, P> {
                     .inc();
             }
             if self.permit_malformed_batch {
-                log::warn!("{}", message);
+                warn!("{}", message);
             } else {
                 return Err(anyhow!("{}", message));
             }

--- a/facilitator/src/gcp_oauth.rs
+++ b/facilitator/src/gcp_oauth.rs
@@ -1,8 +1,8 @@
 use anyhow::{anyhow, Context, Result};
 use chrono::{prelude::Utc, DateTime, Duration};
 use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
-use log::debug;
 use serde::{Deserialize, Serialize};
+use slog_scope::debug;
 use std::{fmt, io::Read};
 use ureq::{Agent, Response};
 use url::Url;

--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -7,13 +7,13 @@ use crate::{
 };
 use anyhow::{anyhow, ensure, Context, Result};
 use chrono::NaiveDateTime;
-use log::{debug, info};
 use prio::{
     encrypt::{PrivateKey, PublicKey},
     field::Field32,
     server::{Server, ServerError},
 };
 use ring::signature::UnparsedPublicKey;
+use slog_scope::{debug, info};
 use std::{collections::HashMap, convert::TryFrom, iter::Iterator};
 use uuid::Uuid;
 

--- a/facilitator/src/logging.rs
+++ b/facilitator/src/logging.rs
@@ -1,24 +1,69 @@
-use env_logger::fmt::Formatter;
-use log::{Level, Record};
+use anyhow::{anyhow, Result};
+use atty::{self, Stream};
 use serde::Serialize;
-use std::{io::Write, thread};
+use slog::{o, Drain, FnValue, Level, LevelFilter, Logger, PushFnValue};
+use slog_async;
+use slog_json::Json;
+use slog_scope::{self, GlobalLoggerGuard};
+use slog_term::{FullFormat, PlainSyncDecorator, TermDecorator, TestStdoutWriter};
+use std::{
+    convert::From,
+    fmt::{self, Display, Formatter},
+    io::{stderr, Stderr},
+    str::FromStr,
+    thread,
+};
+
+/// An event key is a key that could be encountered in the fields of a
+/// structured log message.
+type EventKey = &'static str;
+
+/// The trace ID of the event
+pub const EVENT_KEY_TRACE_ID: EventKey = "trace_id";
+/// The task handle structure
+pub const EVENT_KEY_TASK_HANDLE: EventKey = "task_handle";
+/// The name of the aggregation
+pub(crate) const EVENT_KEY_AGGREGATION_NAME: EventKey = "aggregation_name";
+/// The storage path from which ingestion batches are read/written
+pub(crate) const EVENT_KEY_INGESTION_PATH: EventKey = "ingestion_path";
+/// The storage path from which own validation batches are read/written
+pub(crate) const EVENT_KEY_OWN_VALIDATION_PATH: EventKey = "own_validation_path";
+/// The storage path from which peer validation batches are read/written
+pub(crate) const EVENT_KEY_PEER_VALIDATION_PATH: EventKey = "peer_validation_path";
+/// The UUID of a packet that something happened to
+pub(crate) const EVENT_KEY_PACKET_UUID: EventKey = "packet_uuid";
 
 /// Severity maps `log::Level` to Google Cloud Platform's notion of Severity.
 /// https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "UPPERCASE")]
 enum Severity {
+    Critical,
     Debug,
     Info,
     Warning,
     Error,
 }
 
-impl Severity {
-    fn from_log_level(level: Level) -> Severity {
-        match level {
+impl Display for Severity {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let string = match self {
+            Severity::Critical => "CRITICAL",
+            Severity::Debug => "DEBUG",
+            Severity::Info => "INFO",
+            Severity::Warning => "WARNING",
+            Severity::Error => "ERROR",
+        };
+        write!(f, "{}", string)
+    }
+}
+
+impl From<Level> for Severity {
+    fn from(slog_level: Level) -> Self {
+        match slog_level {
+            Level::Critical => Severity::Critical,
             Level::Error => Severity::Error,
-            Level::Warn => Severity::Warning,
+            Level::Warning => Severity::Warning,
             Level::Info => Severity::Info,
             Level::Debug => Severity::Debug,
             Level::Trace => Severity::Debug,
@@ -26,42 +71,114 @@ impl Severity {
     }
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct LogEntry<'a> {
-    message: String,
-    severity: Severity,
-    time: String,
-    module_path: Option<&'a str>,
-    file: Option<&'a str>,
-    line: Option<u32>,
-    thread_id: String,
+/// Options for configuring logging in this application
+pub struct LoggingConfiguration {
+    /// If true, logging output will be forced to JSON format using
+    /// [slog-json][1]. If false, logging format will be determined by detecting
+    /// whether `stderr` is a `tty`. If it is, output is formatted using
+    /// [slog-term][2]. Otherwise, `slog-json` is used.
+    ///
+    /// [1]: https://docs.rs/slog-json
+    /// [2]: https://docs.rs/slog-term
+    pub force_json_output: bool,
+    /// A version string which shall be attached to all log messages
+    pub version_string: &'static str,
+    /// Messages above this log level will be discarded
+    pub log_level: &'static str,
 }
 
-impl<'a> LogEntry<'a> {
-    fn from_record(fmt: &Formatter, record: &'a Record) -> LogEntry<'a> {
-        LogEntry {
-            severity: Severity::from_log_level(record.level()),
-            time: fmt.timestamp().to_string(),
-            message: record.args().to_string(),
-            module_path: record.module_path(),
-            file: record.file(),
-            line: record.line(),
-            thread_id: format!("{:?}", thread::current().id()),
-        }
-    }
+/// IoErrorDrain is a supertrait that lets us work generically with
+/// `slog::Drain`s.
+trait IoErrorDrain: Drain<Ok = (), Err = std::io::Error> + Send {}
+
+// Opt the `slog::Drain` implementations we use into IoErrorDrain
+impl IoErrorDrain for Json<Stderr> {}
+impl IoErrorDrain for FullFormat<TermDecorator> {}
+
+/// Initialize logging resources. On success, returns a tuple consisting of:
+///
+///   - a root [`slog::Logger`][1]
+///   - a `GlobalLoggerGuard` wrapping a [`slog_scope` global logger][2].
+///
+/// Child loggers should be created from the root `Logger` so that modules can
+/// add more key-value pairs to the events they log. The `GlobalLoggerGuard`
+/// must be kept live by the caller to enable the `slog_scope` global logger to
+/// function in modules that haven't yet opted into managing their own
+/// `slog::Logger`.
+///
+/// Returns an error if `LoggingConfiguration` is invalid.
+///
+/// [1]: https://docs.rs/slog/2.7.0/slog/struct.Logger.html
+/// [2]: https://docs.rs/slog-scope/4.4.0/slog_scope/
+pub fn setup_logging(config: &LoggingConfiguration) -> Result<(Logger, GlobalLoggerGuard)> {
+    // We have to box the Drain so that both branches return the same type
+    let drain: Box<dyn IoErrorDrain> = if atty::isnt(Stream::Stderr) || config.force_json_output {
+        // If stderr is not a tty, output logs as JSON structures on the
+        // assumption that we are running in a cloud.
+        let json_drain = Json::new(stderr())
+            .set_newlines(true)
+            // slog_json::JsonBuilder::add_default_keys adds keys for
+            // timestamp, level and the actual message, but we need the JSON
+            // keys to match what the Google Cloud Logging agent expects:
+            // https://cloud.google.com/logging/docs/agent/configuration#process-payload
+            .add_key_value(o!(
+                "time" => FnValue(|_| {
+                    chrono::Local::now().to_rfc3339()
+                }),
+                "severity" => FnValue(|record| {
+                    Severity::from(record.level()).to_string()
+                }),
+                "message" => PushFnValue(|record, serializer| {
+                    serializer.emit(record.msg())
+                }),
+            ))
+            .build();
+        Box::new(json_drain)
+    } else {
+        // stderr is a tty and output was not forced to JSON, so use a
+        // terminal pretty-printer
+        let decorator = TermDecorator::new().stderr().build();
+        Box::new(FullFormat::new(decorator).build())
+    };
+
+    // Create a filter to discard messages above desired level
+    let log_level = slog::Level::from_str(config.log_level)
+        .map_err(|_| anyhow!("{} is not a valid log level", config.log_level))?;
+    let level_filter = LevelFilter::new(drain, log_level);
+
+    // Use slog_async to make it safe to clone loggers across threads
+    let drain = slog_async::Async::new(level_filter.fuse()).build().fuse();
+    let root_logger = Logger::root(
+        drain,
+        o!(
+            "version"=> config.version_string,
+            "file" => FnValue(|record| {
+                record.file()
+            }),
+            "line" => FnValue(|record| {
+                record.line()
+            }),
+            "module_path" => FnValue(|record| {
+                record.module()
+            }),
+            "thread_id" => FnValue(|_| {
+                format!("{:?}", thread::current().id())
+            })
+        ),
+    );
+
+    // Over time, all modules in `facilitator` should begin using custom
+    // `slog::Loggers` decorated with appropriate k-v pairs, and we can stop
+    // creating a global `slog_scope` logger.
+    let slog_scope_guard = slog_scope::set_global_logger(root_logger.new(o!()));
+
+    Ok((root_logger, slog_scope_guard))
 }
 
-/// Sets up environment logging with GCP's expected format
-pub fn setup_env_logging() {
-    env_logger::builder()
-        .format_timestamp_nanos()
-        .format(|fmt, record| {
-            let log_entry = LogEntry::from_record(fmt, record);
-            match serde_json::to_string(&log_entry) {
-                Ok(json_value) => writeln!(fmt, "{}", json_value),
-                _ => writeln!(fmt, "{} - {}", record.level(), record.args()),
-            }
-        })
-        .init();
+/// Initialize logging for unit or integration tests. Must be public for
+/// visibility in integration tests.
+pub fn setup_test_logging() -> Logger {
+    let decorator = PlainSyncDecorator::new(TestStdoutWriter);
+    let drain = FullFormat::new(decorator).build().fuse();
+    Logger::root(drain, o!())
 }

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -2,7 +2,6 @@ use crate::config::StoragePath;
 use crate::http;
 use anyhow::{anyhow, Context, Result};
 use elliptic_curve::sec1::{EncodedPoint, ToEncodedPoint};
-use log::debug;
 use p256::pkcs8::FromPublicKey;
 use p256::NistP256;
 use pkix::pem::{pem_to_der, PEM_CERTIFICATE_REQUEST};
@@ -10,6 +9,7 @@ use pkix::pkcs10::DerCertificationRequest;
 use pkix::FromDer;
 use ring::signature::{UnparsedPublicKey, ECDSA_P256_SHA256_ASN1};
 use serde::Deserialize;
+use slog_scope::debug;
 use std::{collections::HashMap, str::FromStr};
 
 // See discussion in SpecificManifest::batch_signing_public_key

--- a/facilitator/src/metrics.rs
+++ b/facilitator/src/metrics.rs
@@ -1,9 +1,9 @@
 use anyhow::{Context, Result};
 use http::Response;
-use log::{error, info};
 use prometheus::{
     register_int_counter, register_int_counter_vec, Encoder, IntCounter, IntCounterVec, TextEncoder,
 };
+use slog_scope::{error, info};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tokio::runtime::Runtime;
 use warp::Filter;

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -5,13 +5,13 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Result};
 use chrono::NaiveDateTime;
-use log::info;
 use prio::{
     client::Client,
     encrypt::PublicKey,
     field::{Field32, FieldElement},
 };
 use rand::{thread_rng, Rng};
+use slog_scope::info;
 use uuid::Uuid;
 
 /// Configuration for output from sample generation.

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -5,8 +5,8 @@ use crate::{
     task::{Task, TaskHandle, TaskQueue},
 };
 use anyhow::{anyhow, Context, Result};
-use log::info;
 use serde::Deserialize;
+use slog_scope::info;
 use std::{io::Cursor, marker::PhantomData, time::Duration};
 use ureq::{Agent, AgentBuilder};
 use url::Url;

--- a/facilitator/src/task/sqs.rs
+++ b/facilitator/src/task/sqs.rs
@@ -1,10 +1,10 @@
 use anyhow::{anyhow, Context, Result};
 use derivative::Derivative;
-use log::info;
 use rusoto_core::Region;
 use rusoto_sqs::{
     ChangeMessageVisibilityRequest, DeleteMessageRequest, ReceiveMessageRequest, Sqs, SqsClient,
 };
+use slog_scope::info;
 use std::{convert::TryFrom, marker::PhantomData, str::FromStr, time::Duration};
 use tokio::runtime::Runtime;
 

--- a/facilitator/src/test_utils.rs
+++ b/facilitator/src/test_utils.rs
@@ -1,5 +1,4 @@
 use crate::{manifest::PacketEncryptionCertificateSigningRequest, BatchSigningKey};
-use log::LevelFilter;
 use prio::encrypt::{PrivateKey, PublicKey};
 use ring::signature::{
     EcdsaKeyPair, KeyPair, UnparsedPublicKey, ECDSA_P256_SHA256_ASN1,
@@ -142,17 +141,6 @@ pub fn default_pha_signing_public_key() -> UnparsedPublicKey<Vec<u8>> {
             .as_ref()
             .to_vec(),
     )
-}
-
-// Disappointingly there's no builtin way to run a setup or init function
-// before all tests in Rust, so per env_logger's advice we call init() at
-// the top of any test we want logs from.
-// https://docs.rs/env_logger/0.8.2/env_logger/#capturing-logs-in-tests
-pub fn log_init() {
-    let _ = env_logger::builder()
-        .filter_level(LevelFilter::Info)
-        .is_test(true)
-        .try_init();
 }
 
 pub fn default_pha_packet_encryption_public_key() -> PublicKey {

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -9,7 +9,7 @@ use crate::{
     Error,
 };
 use anyhow::{anyhow, Context, Result};
-use log::info;
+use slog_scope::info;
 use std::{
     io,
     io::{Read, Write},

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -8,12 +8,12 @@ use crate::{
 use anyhow::{Context, Result};
 use derivative::Derivative;
 use hyper_rustls::HttpsConnector;
-use log::info;
 use rusoto_core::{ByteStream, Region};
 use rusoto_s3::{
     AbortMultipartUploadRequest, CompleteMultipartUploadRequest, CompletedMultipartUpload,
     CompletedPart, CreateMultipartUploadRequest, GetObjectRequest, S3Client, UploadPartRequest, S3,
 };
+use slog_scope::info;
 use std::{
     io::{Read, Write},
     mem,
@@ -338,7 +338,7 @@ impl TransportWriter for MultipartUploadWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::log_init;
+    use crate::logging::setup_test_logging;
     use rusoto_core::{request::HttpDispatchError, signature::SignedRequest};
     use rusoto_mock::{MockRequestDispatcher, MultipleMockRequestDispatcher};
     use rusoto_s3::CreateMultipartUploadError;
@@ -445,7 +445,7 @@ mod tests {
 
     #[test]
     fn multipart_upload_create_fails() {
-        log_init();
+        setup_test_logging();
         let err = MultipartUploadWriter::new(
             String::from(TEST_BUCKET),
             String::from(TEST_KEY),
@@ -467,7 +467,7 @@ mod tests {
 
     #[test]
     fn multipart_upload_create_no_upload_id() {
-        log_init();
+        setup_test_logging();
         // Response body format from
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html
         MultipartUploadWriter::new(
@@ -493,7 +493,7 @@ mod tests {
 
     #[test]
     fn multipart_upload() {
-        log_init();
+        setup_test_logging();
         // Response body format from
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_Operations_Amazon_Simple_Storage_Service.html
         let mut writer =
@@ -596,7 +596,7 @@ mod tests {
 
     #[test]
     fn roundtrip_s3_transport() {
-        log_init();
+        setup_test_logging();
         let s3_path = S3Path {
             region: Region::UsWest2,
             bucket: TEST_BUCKET.into(),


### PR DESCRIPTION
We adopt the `slog-rs` family of crates for structured logging. `slog`
allows us to create trees of `Loggers` and `Drains`. `Logger`s can be
annotated with key-value pairs and then every message logged through
that `Logger` will themselves be annotated with the k-v pairs. Further,
the `slog` macros `info`, `error`, etc. allow adding arbitrary
additional k-v pairs to individual events. This lets us emit structured
log messages which can then be searched in something like the GCP Log
Explorer. `Drain`s can be configured to format log records in different
manners. We use `slog_json` to emit structured JSON logs, `slog_term` to
pretty print messages to a tty or a much simpler decorator for use in
tests.

`slog`'s model is that you create a root `Logger`, and then create a
tree of child loggers from it, each of which can be specialized with
context specific to some module or task. For instance, in this commit,
we augment `aggregation::BatchAggregator` so that it creates a `Logger`
from a provided parent logger, and annotates it with a trace ID and
other interesting values.

To ease the transition from the existing logging model to `slog`, we use
`slog_scope` as a drop-in replacement for the `log`/`env_logger` combo
previously employed in `facilitator`. Subsequent PRs will plumb `Logger`
instances into each module of `facilitator` and eventually `slog_scope`
should be removed altogether.

This commit is a start on #546