### PR TITLE
facilitator: introduce `http::RetryingAgent`

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -184,6 +184,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1e8deebfdca687fcef6fe024fc92cf8183f203075ce4fda263ae6ea13a8dc3"
 
 [[package]]
+name = "backoff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe17f59a06fe8b87a6fc8bf53bb70b3aba76d7685f432487a68cd5552853625"
+dependencies = [
+ "getrandom 0.2.2",
+ "instant",
+ "rand 0.8.3",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +643,7 @@ dependencies = [
  "async-trait",
  "atty",
  "avro-rs",
+ "backoff",
  "base64 0.13.0",
  "chrono",
  "clap",

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 atty = "0.2"
 avro-rs = { version = "0.13.0", features = ["snappy"] }
+backoff = "0.3.0"
 base64 = "0.13.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2.33.3"

--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::Identity,
-    http::{prepare_request_without_agent, Method, RequestParameters},
+    http::{Method, RequestParameters, RetryingAgent},
 };
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -136,16 +136,18 @@ impl Provider {
                 .append_pair("audience", &format!("sts.amazonaws.com/{}", aws_account_id))
                 .finish();
 
-            let mut request = prepare_request_without_agent(RequestParameters {
-                url,
-                method: Method::Get,
-                ..Default::default()
-            })
-            .map_err(|e| CredentialsError::new(format!("failed to create request: {:?}", e)))?;
+            let agent = RetryingAgent::default();
+            let mut request = agent
+                .prepare_request(RequestParameters {
+                    url,
+                    method: Method::Get,
+                    ..Default::default()
+                })
+                .map_err(|e| CredentialsError::new(format!("failed to create request: {:?}", e)))?;
 
             request = request.set("Metadata-Flavor", "Google");
 
-            let response = request.call().map_err(|e| {
+            let response = agent.call(&request).map_err(|e| {
                 CredentialsError::new(format!(
                     "failed to fetch {} auth token from metadata service: {:?}",
                     purpose, e

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -14,6 +14,7 @@ pub mod kubernetes;
 pub mod logging;
 pub mod manifest;
 pub mod metrics;
+mod retries;
 pub mod sample;
 pub mod task;
 pub mod test_utils;

--- a/facilitator/src/retries.rs
+++ b/facilitator/src/retries.rs
@@ -1,0 +1,171 @@
+use backoff::{retry, ExponentialBackoff};
+use slog_scope::{debug, info};
+use std::{fmt::Debug, time::Duration};
+
+/// Executes the provided action `f`, retrying with exponential backoff if the
+/// error returned by `f` is deemed retryable by `is_retryable`. On success,
+/// returns the value returned by `f`. On failure, returns the error returned by
+/// the last attempt to call `f`. Retryable failures will be logged using the
+/// provided action string.
+pub(crate) fn retry_request<F, T, E, R>(action: &str, f: F, is_retryable: R) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+    R: FnMut(&E) -> bool,
+    E: Debug,
+{
+    // Default ExponentialBackoff parameters are borrowed from the parameters
+    // used in the GCP Go SDK[1]. AWS doesn't give us specific guidance on what
+    // intervals to use, but the GCP implementation cites AWS blog posts so the
+    // same parameters are probably fine for both.
+    // [1] https://github.com/googleapis/gax-go/blob/fbaf9882acf3297573f3a7cb832e54c7d8f40635/v2/call_option.go#L120
+    retry_request_with_params(
+        action,
+        Duration::from_secs(1),
+        Duration::from_secs(30),
+        // We don't have explicit guidance from Google on how long to retry
+        // before giving up but the Google Cloud Storage guide for retries
+        // suggests 600 seconds.
+        // https://cloud.google.com/storage/docs/retry-strategy#exponential-backoff
+        Duration::from_secs(600),
+        f,
+        is_retryable,
+    )
+}
+
+/// Private version of retry_request that exposes parameters for backoff. Should
+/// only be used for testing. Othewise behaves identically to `retry_request`.
+fn retry_request_with_params<F, T, E, R>(
+    action: &str,
+    backoff_initial_interval: Duration,
+    backoff_max_interval: Duration,
+    backoff_max_elapsed: Duration,
+    mut f: F,
+    mut is_retryable: R,
+) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+    R: FnMut(&E) -> bool,
+    E: Debug,
+{
+    let backoff = ExponentialBackoff {
+        initial_interval: backoff_initial_interval,
+        max_interval: backoff_max_interval,
+        multiplier: 2.0,
+        max_elapsed_time: Some(backoff_max_elapsed),
+        ..Default::default()
+    };
+
+    retry(backoff, || {
+        // Invoke the function and wrap its E into backoff::Error
+        f().map_err(|error| {
+            if is_retryable(&error) {
+                info!(
+                    "encountered retryable error while trying to {}: {:?}",
+                    action, error
+                );
+                backoff::Error::Transient(error)
+            } else {
+                debug!(
+                    "encountered non-retryable error while trying to {}: {:?}",
+                    action, error
+                );
+                backoff::Error::Permanent(error)
+            }
+        })
+    })
+    // Unwrap the backoff::Error to get the E back and let the caller wrap that
+    // in whatever they want
+    .map_err(|e| match e {
+        backoff::Error::Permanent(inner) => inner,
+        backoff::Error::Transient(inner) => inner,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn success() {
+        let mut counter = 0;
+        let f = || -> Result<(), bool> {
+            counter += 1;
+            Ok(())
+        };
+
+        retry_request_with_params(
+            "test",
+            Duration::from_millis(10),
+            Duration::from_millis(10),
+            Duration::from_millis(10),
+            f,
+            |_| false,
+        )
+        .unwrap();
+        assert_eq!(counter, 1);
+    }
+
+    #[test]
+    fn retryable_failure() {
+        let mut counter = 0;
+        let f = || -> Result<(), bool> {
+            counter += 1;
+            if counter == 1 {
+                Err(false)
+            } else {
+                Ok(())
+            }
+        };
+
+        retry_request_with_params(
+            "test",
+            Duration::from_millis(10),
+            Duration::from_millis(10),
+            Duration::from_millis(30),
+            f,
+            |_| true,
+        )
+        .unwrap();
+        assert!(counter > 1);
+    }
+
+    #[test]
+    fn retryable_failure_exhaust_max_elapsed() {
+        let mut counter = 0;
+        let f = || -> std::result::Result<(), bool> {
+            counter += 1;
+            Err(false)
+        };
+
+        retry_request_with_params(
+            "test",
+            Duration::from_millis(10),
+            Duration::from_millis(10),
+            Duration::from_millis(30),
+            f,
+            |_| true,
+        )
+        .unwrap_err();
+        assert!(counter >= 2);
+    }
+
+    #[test]
+    fn unretryable_failure() {
+        let mut counter = 0;
+        let f = || -> std::result::Result<(), bool> {
+            counter += 1;
+            Err(false)
+        };
+
+        retry_request_with_params(
+            "test",
+            Duration::from_millis(10),
+            Duration::from_millis(10),
+            Duration::from_millis(30),
+            f,
+            |_| false,
+        )
+        .unwrap_err();
+        assert_eq!(counter, 1);
+    }
+}


### PR DESCRIPTION
In order to be more robust against transient failures in cloud APIs, we
introduce a `RetryingAgent` which uses the `backoff` crate to resend
failed HTTP requests with exponential backoff if the failure is
determined to be transient (e.g., an HTTP 503). The `RetryingAgent` is
adopted throughout the crate, meaning we now get retries when:

  - fetching peer JSON manifests
  - pulling messagesfrom GCP PubSub subscriptions
  - reading or writing to Google Cloud Storage
  - obtaining Oauth tokens from the GKE metadata service or IAM API

We should also record Prometheus metrics about retryable request
failures, which will happen in a future PR.

This change doesn't help with AWS API clients (S3, SQS and IAM) because
they do not use our `ureq` based HTTP client but rather Rusoto (and that
in turn uses Hyper).

Related to #351, #352, #353