### PR TITLE
actions: invoke cargo-clippy directly

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,12 +20,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Lint
       run: cargo fmt --message-format human -- --check
-    - uses: actions-rs/clippy-check@v1
-      with:
-        # https://docs.github.com/actions/reference/authentication-in-a-workflow
-        token: ${{ secrets.GITHUB_TOKEN }}
-        # working-directory only applies to run actions, so path to Cargo.toml needs to be manually specified
-        args: --manifest-path facilitator/Cargo.toml --all-targets
+    - name: clippy
+      run: cargo clippy --all-targets -- -D warnings
     - name: Build
       run: cargo build --verbose
     - name: Run tests
@@ -108,7 +104,7 @@ jobs:
       with:
         file: ./deploy-operator/Dockerfile
         context: ./deploy-operator
-  
+
   deploy-operator-test:
     runs-on: ubuntu-latest
     defaults:
@@ -148,7 +144,7 @@ jobs:
       with:
         file: ./manifest-updater/Dockerfile
         context: ./manifest-updater
-  
+
   manifest-updater-test:
     runs-on: ubuntu-latest
     defaults:
@@ -161,7 +157,7 @@ jobs:
       with:
         go-version: 1.15
     - name: Test
-      run: go test -race --coverprofile=cover.out --covermode=atomic ./... 
+      run: go test -race --coverprofile=cover.out --covermode=atomic ./...
     - name: Upload test coverage
       if: success()
       uses: codecov/codecov-action@v1
@@ -183,7 +179,7 @@ jobs:
       with:
         go-version: 1.15
     - name: Test
-      run: go test -race --coverprofile=cover.out --covermode=atomic ./... 
+      run: go test -race --coverprofile=cover.out --covermode=atomic ./...
     - name: Upload test coverage
       if: success()
       uses: codecov/codecov-action@v1

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -387,6 +387,7 @@ mod tests {
         transport::LocalFileTransport,
         Error,
     };
+    use assert_matches::assert_matches;
 
     #[allow(clippy::too_many_arguments)] // Grandfathered in
     fn roundtrip_batch<'a>(
@@ -499,10 +500,10 @@ mod tests {
         }
 
         // One more read should get EOF
-        match IngestionDataSharePacket::read(&mut packet_file_reader) {
-            Err(Error::EofError) => (),
-            v => assert!(false, "wrong error {:?}", v),
-        }
+        assert_matches!(
+            IngestionDataSharePacket::read(&mut packet_file_reader),
+            Err(Error::EofError)
+        );
     }
 
     #[test]
@@ -796,7 +797,7 @@ mod tests {
         let mut key_map = HashMap::new();
         key_map.insert(
             "key-identifier".to_owned(),
-            default_facilitator_signing_public_key().clone(),
+            default_facilitator_signing_public_key(),
         );
 
         assert_eq!(

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -28,7 +28,7 @@ use facilitator::{
     sample::{SampleGenerator, SampleOutput},
     task::{AggregationTask, AwsSqsTaskQueue, GcpPubSubTaskQueue, IntakeBatchTask, TaskQueue},
     transport::{
-        GCSTransport, LocalFileTransport, S3Transport, SignableTransport, Transport,
+        GcsTransport, LocalFileTransport, S3Transport, SignableTransport, Transport,
         VerifiableAndDecryptableTransport, VerifiableTransport,
     },
     BatchSigningKey, DATE_FORMAT,
@@ -1169,6 +1169,7 @@ fn generate_sample(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn intake_batch<F>(
     trace_id: &str,
     aggregation_id: &str,
@@ -1297,7 +1298,7 @@ fn intake_batch_worker(
                 .task
                 .trace_id
                 .map(|id| id.to_string())
-                .unwrap_or(String::from("None"));
+                .unwrap_or_else(|| String::from("None"));
 
             let result = intake_batch(
                 &trace_id,
@@ -1337,6 +1338,7 @@ fn intake_batch_worker(
     // unreachable
 }
 
+#[allow(clippy::too_many_arguments)]
 fn aggregate<F>(
     trace_id: &str,
     aggregation_id: &str,
@@ -1558,7 +1560,7 @@ fn aggregate_worker(sub_matches: &ArgMatches, parent_logger: &Logger) -> Result<
                 .task
                 .trace_id
                 .map(|id| id.to_string())
-                .unwrap_or(String::from("None"));
+                .unwrap_or_else(|| String::from("None"));
 
             let result = aggregate(
                 &trace_id,
@@ -1833,7 +1835,7 @@ fn transport_for_path(
             )?;
             Ok(Box::new(S3Transport::new(path, credentials_provider)))
         }
-        StoragePath::GCSPath(path) => Ok(Box::new(GCSTransport::new(
+        StoragePath::GcsPath(path) => Ok(Box::new(GcsTransport::new(
             path,
             identity,
             key_file_reader,

--- a/facilitator/src/idl.rs
+++ b/facilitator/src/idl.rs
@@ -1048,6 +1048,7 @@ impl Packet for InvalidPacket {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use assert_matches::assert_matches;
 
     #[test]
     fn roundtrip_batch_signature() {
@@ -1152,10 +1153,10 @@ mod tests {
         }
 
         // Do one more read. This should yield EOF.
-        match IngestionDataSharePacket::read(&mut reader) {
-            Err(Error::EofError) => (),
-            v => assert!(false, "wrong error {:?}", v),
-        }
+        assert_matches!(
+            IngestionDataSharePacket::read(&mut reader),
+            Err(Error::EofError)
+        );
     }
 
     #[test]
@@ -1232,10 +1233,7 @@ mod tests {
         }
 
         // Do one more read. This should yield EOF.
-        match ValidationPacket::read(&mut reader) {
-            Err(Error::EofError) => (),
-            v => assert!(false, "wrong error {:?}", v),
-        }
+        assert_matches!(ValidationPacket::read(&mut reader), Err(Error::EofError));
     }
 
     #[test]
@@ -1311,9 +1309,6 @@ mod tests {
         }
 
         // Do one more read. This should yield EOF.
-        match InvalidPacket::read(&mut reader) {
-            Err(Error::EofError) => (),
-            v => assert!(false, "wrong error {:?}", v),
-        }
+        assert_matches!(InvalidPacket::read(&mut reader), Err(Error::EofError));
     }
 }

--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -41,6 +41,7 @@ pub struct BatchIntaker<'a> {
 }
 
 impl<'a> BatchIntaker<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         trace_id: &'a str,
         aggregation_name: &str,
@@ -359,7 +360,7 @@ mod tests {
                 transport: Box::new(LocalFileTransport::new(
                     facilitator_tempdir.path().to_path_buf(),
                 )),
-                batch_signing_public_keys: ingestor_pub_keys.clone(),
+                batch_signing_public_keys: ingestor_pub_keys,
             },
             packet_decryption_keys: vec![PrivateKey::from_base64(
                 DEFAULT_PACKET_ENCRYPTION_CERTIFICATE_SIGNING_REQUEST_PRIVATE_KEY,
@@ -492,7 +493,7 @@ mod tests {
         let mut pha_ingest_transport = VerifiableAndDecryptableTransport {
             transport: VerifiableTransport {
                 transport: Box::new(LocalFileTransport::new(pha_tempdir.path().to_path_buf())),
-                batch_signing_public_keys: ingestor_pub_keys.clone(),
+                batch_signing_public_keys: ingestor_pub_keys,
             },
             packet_decryption_keys: vec![
                 PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap()
@@ -594,7 +595,7 @@ mod tests {
         let mut pha_ingest_transport = VerifiableAndDecryptableTransport {
             transport: VerifiableTransport {
                 transport: Box::new(LocalFileTransport::new(pha_tempdir.path().to_path_buf())),
-                batch_signing_public_keys: ingestor_pub_keys.clone(),
+                batch_signing_public_keys: ingestor_pub_keys,
             },
             packet_decryption_keys: vec![PrivateKey::from_base64(
                 DEFAULT_PACKET_ENCRYPTION_CERTIFICATE_SIGNING_REQUEST_PRIVATE_KEY,

--- a/facilitator/src/logging.rs
+++ b/facilitator/src/logging.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, Result};
 use atty::{self, Stream};
 use serde::Serialize;
 use slog::{o, Drain, FnValue, Level, LevelFilter, Logger, PushFnValue};
-use slog_async;
 use slog_json::Json;
 use slog_scope::{self, GlobalLoggerGuard};
 use slog_term::{FullFormat, PlainSyncDecorator, TermDecorator, TestStdoutWriter};

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -97,6 +97,7 @@ pub struct SampleGenerator<'a> {
 impl<'a> SampleGenerator<'a> {
     /// Creates a new SampleGenerator. See the documentation on struct
     /// SampleGenerator for discussion of each parameter.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         aggregation_name: &'a str,
         dimension: i32,

--- a/facilitator/src/task.rs
+++ b/facilitator/src/task.rs
@@ -85,7 +85,7 @@ impl Task for IntakeBatchTask {}
 impl Display for IntakeBatchTask {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(id) = self.trace_id {
-            write!(f, "trace ID: {}\n", id)?;
+            writeln!(f, "trace ID: {}", id)?;
         }
         write!(
             f,
@@ -119,7 +119,7 @@ impl Task for AggregationTask {}
 impl Display for AggregationTask {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(id) = self.trace_id {
-            write!(f, "trace ID: {}\n", id)?;
+            writeln!(f, "trace ID: {}", id)?;
         }
         write!(
             f,

--- a/facilitator/src/transport.rs
+++ b/facilitator/src/transport.rs
@@ -12,7 +12,7 @@ use std::{
     io::{Read, Write},
 };
 
-pub use gcs::GCSTransport;
+pub use gcs::GcsTransport;
 pub use local::LocalFileTransport;
 pub use s3::S3Transport;
 

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{GCSPath, Identity},
+    config::{GcsPath, Identity},
     gcp_oauth::GcpOauthTokenProvider,
     http::{
         prepare_request, prepare_request_without_agent, Method, OauthTokenProvider,
@@ -45,24 +45,24 @@ fn gcp_upload_object_url(storage_api_url: &str, bucket: &str) -> Result<Url> {
 /// or can impersonate another GCP service account if one is provided to
 /// GCSTransport::new.
 #[derive(Debug)]
-pub struct GCSTransport {
-    path: GCSPath,
+pub struct GcsTransport {
+    path: GcsPath,
     oauth_token_provider: GcpOauthTokenProvider,
     agent: Agent,
 }
 
-impl GCSTransport {
+impl GcsTransport {
     /// Instantiate a new GCSTransport to read or write objects from or to the
     /// provided path. If identity is None, GCSTransport authenticates to GCS
     /// as the default service account. If identity contains a service
     /// account email, GCSTransport will use the GCP IAM API to obtain an Oauth
     /// token to impersonate that service account.
     pub fn new(
-        path: GCSPath,
+        path: GcsPath,
         identity: Identity,
         key_file_reader: Option<Box<dyn Read>>,
-    ) -> Result<GCSTransport> {
-        Ok(GCSTransport {
+    ) -> Result<GcsTransport> {
+        Ok(GcsTransport {
             path: path.ensure_directory_prefix(),
             oauth_token_provider: GcpOauthTokenProvider::new(
                 // This token is used to access GCS storage
@@ -78,7 +78,7 @@ impl GCSTransport {
     }
 }
 
-impl Transport for GCSTransport {
+impl Transport for GcsTransport {
     fn path(&self) -> String {
         self.path.to_string()
     }

--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -280,7 +280,7 @@ fn aggregation_including_invalid_batch() {
         transport: Box::new(LocalFileTransport::new(
             facilitator_tempdir.path().join("own-validation"),
         )),
-        batch_signing_public_keys: facilitator_pub_keys.clone(),
+        batch_signing_public_keys: facilitator_pub_keys,
     };
 
     // Facilitator uses this transport to read PHA's validations
@@ -288,7 +288,7 @@ fn aggregation_including_invalid_batch() {
         transport: Box::new(LocalFileTransport::new(
             facilitator_tempdir.path().join("peer-validation"),
         )),
-        batch_signing_public_keys: pha_pub_keys.clone(),
+        batch_signing_public_keys: pha_pub_keys,
     };
 
     // PHA uses this transport to send sum parts
@@ -714,7 +714,7 @@ fn check_invalid_packets(
             match InvalidPacket::read(&mut invalid_packet_reader) {
                 Ok(packet) => assert!(dropped_packets.contains(&packet.uuid)),
                 Err(Error::EofError) => break,
-                Err(err) => assert!(false, "error reading invalid packet {}", err),
+                Err(err) => panic!("error reading invalid packet {}", err),
             }
         }
     } else {


### PR DESCRIPTION
We previously were using the
[clippy-check](https://github.com/actions-rs/clippy-check) GitHub Action
to run clippy on changes. There's two problems with this:

 1 - Because our `Cargo.toml` isn't at the root of the repo,
   `clippy-check` can't post clippy results into the PR as comments
   (see #69 and
   https://github.com/actions-rs/clippy-check/issues/28#issuecomment-680401392)
 2 - We recently set `GITHUB_TOKEN` to be readonly at the
   `abetterinternet` level to mitigate potential security problems.
   `clippy-check` requires write permissions to post results.

I'd prefer to keep the `GITHUB_TOKEN` passed to actions readonly, and
since the results wrangling never worked anyway, we can opt out of it.

Now, instead of using the action, we just run `cargo clippy` directly
and fail the build if any warnings are found. Previously `clippy-check`
would just emit findings into the void, never to be seen by anyone.