### PR TITLE
facilitator: retries w/ backoff for AWS

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -645,6 +645,7 @@ dependencies = [
  "avro-rs",
  "backoff",
  "base64 0.13.0",
+ "bytes",
  "chrono",
  "clap",
  "derivative",
@@ -685,6 +686,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "warp",
+ "xml-rs",
 ]
 
 [[package]]

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -49,8 +49,10 @@ url = "2.2.1"
 urlencoding = "1.1.1"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 warp = "^0.3"
+xml-rs = "0.8"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
+bytes = "1.0.1"
 mockito = "0.30.0"
 serde_test = "1.0"


### PR DESCRIPTION
Adapts `aws_credentials::retry_request` to use mod `retries` (and hence
`backoff::ExponentialBackoff` so that we get more graceful retry
behavior, in line with AWS developer guidelines. Additionally, our
assessment of which errors are retryable is more sophisticated: we now
retry on all credential fetch failures, on server errors (i.e., HTTP
5xx) and when throttled.

Resolves #41, #354