### PR TITLE
facilitator: move event keys to `logging::event`

### DIFF
--- a/facilitator/src/aggregation.rs
+++ b/facilitator/src/aggregation.rs
@@ -4,10 +4,7 @@ use crate::{
         IngestionDataSharePacket, IngestionHeader, InvalidPacket, Packet, SumPart,
         ValidationHeader, ValidationPacket,
     },
-    logging::{
-        EVENT_KEY_AGGREGATION_NAME, EVENT_KEY_INGESTION_PATH, EVENT_KEY_OWN_VALIDATION_PATH,
-        EVENT_KEY_PACKET_UUID, EVENT_KEY_PEER_VALIDATION_PATH, EVENT_KEY_TRACE_ID,
-    },
+    logging::event,
     metrics::AggregateMetricsCollector,
     transport::{SignableTransport, VerifiableAndDecryptableTransport, VerifiableTransport},
     BatchSigningKey, Error,
@@ -61,11 +58,11 @@ impl<'a> BatchAggregator<'a> {
         parent_logger: &Logger,
     ) -> Result<BatchAggregator<'a>> {
         let logger = parent_logger.new(o!(
-            EVENT_KEY_TRACE_ID => trace_id.to_owned(),
-            EVENT_KEY_AGGREGATION_NAME => aggregation_name.to_owned(),
-            EVENT_KEY_INGESTION_PATH => ingestion_transport.transport.transport.path(),
-            EVENT_KEY_OWN_VALIDATION_PATH => own_validation_transport.transport.path(),
-            EVENT_KEY_PEER_VALIDATION_PATH => peer_validation_transport.transport.path(),
+            event::TRACE_ID => trace_id.to_owned(),
+            event::AGGREGATION_NAME => aggregation_name.to_owned(),
+            event::INGESTION_PATH => ingestion_transport.transport.transport.path(),
+            event::OWN_VALIDATION_PATH => own_validation_transport.transport.path(),
+            event::PEER_VALIDATION_PATH => peer_validation_transport.transport.path(),
         ));
         Ok(BatchAggregator {
             trace_id,
@@ -319,7 +316,7 @@ impl<'a> BatchAggregator<'a> {
             if processed_ingestion_packets.contains(&ingestion_packet.uuid) {
                 info!(
                     logger, "ignoring duplicate packet";
-                    EVENT_KEY_PACKET_UUID => ingestion_packet.uuid.to_string()
+                    event::PACKET_UUID => ingestion_packet.uuid.to_string()
                 );
                 continue;
             }
@@ -364,7 +361,7 @@ impl<'a> BatchAggregator<'a> {
                         if !valid {
                             info!(
                                 logger, "rejecting packet due to invalid proof";
-                                EVENT_KEY_PACKET_UUID => peer_validation_packet.uuid.to_string(),
+                                event::PACKET_UUID => peer_validation_packet.uuid.to_string(),
                             );
                             invalid_uuids.push(peer_validation_packet.uuid);
                         }
@@ -421,7 +418,7 @@ fn get_validation_packet<'a>(
         None => {
             info!(
                 logger, "no {} validation packet", kind;
-                EVENT_KEY_PACKET_UUID => uuid.to_string()
+                event::PACKET_UUID => uuid.to_string()
             );
             invalid_uuids.push(*uuid);
             None

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -19,7 +19,7 @@ use facilitator::{
     config::{leak_string, Entity, Identity, InOut, ManifestKind, StoragePath, TaskQueueKind},
     intake::BatchIntaker,
     kubernetes::KubernetesClient,
-    logging::{setup_logging, LoggingConfiguration, EVENT_KEY_TASK_HANDLE, EVENT_KEY_TRACE_ID},
+    logging::{event, setup_logging, LoggingConfiguration},
     manifest::{
         DataShareProcessorGlobalManifest, IngestionServerManifest, PortalServerGlobalManifest,
         SpecificManifest,
@@ -920,7 +920,7 @@ fn generate_sample_worker(
         if let Err(e) = result {
             error!(
                 root_logger, "Error: {:?}", e;
-                EVENT_KEY_TRACE_ID => trace_id.to_string(),
+                event::TRACE_ID => trace_id.to_string(),
             );
         }
         std::thread::sleep(Duration::from_secs(interval))
@@ -1294,7 +1294,7 @@ fn intake_batch_worker(
     loop {
         if let Some(task_handle) = queue.dequeue()? {
             info!(parent_logger, "dequeued intake task";
-                EVENT_KEY_TASK_HANDLE => task_handle.clone(),
+                event::TASK_HANDLE => task_handle.clone(),
             );
             let task_start = Instant::now();
 
@@ -1318,8 +1318,8 @@ fn intake_batch_worker(
                     {
                         error!(
                             logger, "{}", e;
-                            EVENT_KEY_TRACE_ID => trace_id.clone(),
-                            EVENT_KEY_TASK_HANDLE => task_handle.clone(),
+                            event::TRACE_ID => trace_id.clone(),
+                            event::TASK_HANDLE => task_handle.clone(),
                         );
                     }
                 },
@@ -1330,8 +1330,8 @@ fn intake_batch_worker(
                 Err(err) => {
                     error!(
                         parent_logger, "error while processing intake task: {:?}", err;
-                        EVENT_KEY_TASK_HANDLE => task_handle.clone(),
-                        EVENT_KEY_TRACE_ID => trace_id,
+                        event::TASK_HANDLE => task_handle.clone(),
+                        event::TRACE_ID => trace_id,
                     );
                     queue.nacknowledge_task(task_handle)?;
                 }
@@ -1558,7 +1558,7 @@ fn aggregate_worker(sub_matches: &ArgMatches, parent_logger: &Logger) -> Result<
         if let Some(task_handle) = queue.dequeue()? {
             info!(
                 parent_logger, "dequeued aggregate task";
-                EVENT_KEY_TASK_HANDLE => task_handle.clone(),
+                event::TASK_HANDLE => task_handle.clone(),
             );
             let task_start = Instant::now();
 
@@ -1590,8 +1590,8 @@ fn aggregate_worker(sub_matches: &ArgMatches, parent_logger: &Logger) -> Result<
                     {
                         error!(
                             logger, "{}", e;
-                            EVENT_KEY_TRACE_ID => trace_id.clone(),
-                            EVENT_KEY_TASK_HANDLE => task_handle.clone(),
+                            event::TRACE_ID => trace_id.clone(),
+                            event::TASK_HANDLE => task_handle.clone(),
                         );
                     }
                 },
@@ -1602,8 +1602,8 @@ fn aggregate_worker(sub_matches: &ArgMatches, parent_logger: &Logger) -> Result<
                 Err(err) => {
                     error!(
                         parent_logger, "error while processing task: {:?}", err;
-                        EVENT_KEY_TRACE_ID => trace_id,
-                        EVENT_KEY_TASK_HANDLE => task_handle.clone(),
+                        event::TRACE_ID => trace_id,
+                        event::TASK_HANDLE => task_handle.clone(),
                     );
                     queue.nacknowledge_task(task_handle)?;
                 }

--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -1,11 +1,7 @@
 use crate::{
     batch::{Batch, BatchReader, BatchWriter},
     idl::{IngestionDataSharePacket, IngestionHeader, Packet, ValidationHeader, ValidationPacket},
-    logging::{
-        EVENT_KEY_AGGREGATION_NAME, EVENT_KEY_BATCH_DATE, EVENT_KEY_BATCH_ID,
-        EVENT_KEY_INGESTION_PATH, EVENT_KEY_OWN_VALIDATION_PATH, EVENT_KEY_PACKET_UUID,
-        EVENT_KEY_PEER_VALIDATION_PATH, EVENT_KEY_TRACE_ID,
-    },
+    logging::event,
     metrics::IntakeMetricsCollector,
     transport::{SignableTransport, VerifiableAndDecryptableTransport},
     BatchSigningKey, Error, DATE_FORMAT,
@@ -55,13 +51,13 @@ impl<'a> BatchIntaker<'a> {
         parent_logger: &Logger,
     ) -> Result<BatchIntaker<'a>> {
         let logger = parent_logger.new(o!(
-            EVENT_KEY_TRACE_ID => trace_id.to_owned(),
-            EVENT_KEY_AGGREGATION_NAME => aggregation_name.to_owned(),
-            EVENT_KEY_BATCH_ID => batch_id.to_string(),
-            EVENT_KEY_BATCH_DATE => date.format(DATE_FORMAT).to_string(),
-            EVENT_KEY_INGESTION_PATH => ingestion_transport.transport.transport.path(),
-            EVENT_KEY_OWN_VALIDATION_PATH => own_validation_transport.transport.path(),
-            EVENT_KEY_PEER_VALIDATION_PATH => peer_validation_transport.transport.path(),
+            event::TRACE_ID => trace_id.to_owned(),
+            event::AGGREGATION_NAME => aggregation_name.to_owned(),
+            event::BATCH_ID => batch_id.to_string(),
+            event::BATCH_DATE => date.format(DATE_FORMAT).to_string(),
+            event::INGESTION_PATH => ingestion_transport.transport.transport.path(),
+            event::OWN_VALIDATION_PATH => own_validation_transport.transport.path(),
+            event::PEER_VALIDATION_PATH => peer_validation_transport.transport.path(),
         ));
         Ok(BatchIntaker {
             intake_batch: BatchReader::new(
@@ -194,7 +190,7 @@ impl<'a> BatchIntaker<'a> {
                                 more packet decryption keys if available.";
                                 o!(
                                     "decryption_error" => format!("{:?}", e),
-                                    EVENT_KEY_PACKET_UUID => packet.uuid.to_string(),
+                                    event::PACKET_UUID => packet.uuid.to_string(),
                                 )
                             );
                             continue;

--- a/facilitator/src/logging.rs
+++ b/facilitator/src/logging.rs
@@ -13,35 +13,38 @@ use std::{
     thread,
 };
 
-/// An event key is a key that could be encountered in the fields of a
-/// structured log message.
-type EventKey = &'static str;
+/// `event` defines constants for structured events
+pub mod event {
+    /// An event key is a key that could be encountered in the fields of a
+    /// structured log message.
+    type EventKey = &'static str;
 
-/// The trace ID of the event
-pub const EVENT_KEY_TRACE_ID: EventKey = "trace_id";
-/// The task handle structure
-pub const EVENT_KEY_TASK_HANDLE: EventKey = "task_handle";
-/// The name of the aggregation
-pub(crate) const EVENT_KEY_AGGREGATION_NAME: EventKey = "aggregation_name";
-/// The storage path from which ingestion batches are read/written
-pub(crate) const EVENT_KEY_INGESTION_PATH: EventKey = "ingestion_path";
-/// The storage path from which own validation batches are read/written
-pub(crate) const EVENT_KEY_OWN_VALIDATION_PATH: EventKey = "own_validation_path";
-/// The storage path from which peer validation batches are read/written
-pub(crate) const EVENT_KEY_PEER_VALIDATION_PATH: EventKey = "peer_validation_path";
-/// The UUID of a packet that something happened to
-pub(crate) const EVENT_KEY_PACKET_UUID: EventKey = "packet_uuid";
-/// The ID (usually a UUID) of a batch that something happened to
-pub(crate) const EVENT_KEY_BATCH_ID: EventKey = "batch_id";
-/// The date of a batch that something happened to
-pub(crate) const EVENT_KEY_BATCH_DATE: EventKey = "batch_date";
-/// The path to some object store (e.g., an S3 bucket or a local directory)
-pub(crate) const EVENT_KEY_STORAGE_PATH: EventKey = "path";
-/// The key for an object in some object store
-pub(crate) const EVENT_KEY_STORAGE_KEY: EventKey = "key";
-/// An identity used while accessing some cloud resource (e.g., an AWS role ARN
-/// or a GCP service account email)
-pub(crate) const EVENT_KEY_IDENTITY: EventKey = "identity";
+    /// The trace ID of the event
+    pub const TRACE_ID: EventKey = "trace_id";
+    /// The task handle structure
+    pub const TASK_HANDLE: EventKey = "task_handle";
+    /// The name of the aggregation
+    pub(crate) const AGGREGATION_NAME: EventKey = "aggregation_name";
+    /// The storage path from which ingestion batches are read/written
+    pub(crate) const INGESTION_PATH: EventKey = "ingestion_path";
+    /// The storage path from which own validation batches are read/written
+    pub(crate) const OWN_VALIDATION_PATH: EventKey = "own_validation_path";
+    /// The storage path from which peer validation batches are read/written
+    pub(crate) const PEER_VALIDATION_PATH: EventKey = "peer_validation_path";
+    /// The UUID of a packet that something happened to
+    pub(crate) const PACKET_UUID: EventKey = "packet_uuid";
+    /// The ID (usually a UUID) of a batch that something happened to
+    pub(crate) const BATCH_ID: EventKey = "batch_id";
+    /// The date of a batch that something happened to
+    pub(crate) const BATCH_DATE: EventKey = "batch_date";
+    /// The path to some object store (e.g., an S3 bucket or a local directory)
+    pub(crate) const STORAGE_PATH: EventKey = "path";
+    /// The key for an object in some object store
+    pub(crate) const STORAGE_KEY: EventKey = "key";
+    /// An identity used while accessing some cloud resource (e.g., an AWS role ARN
+    /// or a GCP service account email)
+    pub(crate) const IDENTITY: EventKey = "identity";
+}
 
 /// Severity maps `log::Level` to Google Cloud Platform's notion of Severity.
 /// https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#LogSeverity

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -1,9 +1,7 @@
 use crate::{
     batch::{Batch, BatchWriter},
     idl::{IngestionDataSharePacket, IngestionHeader, Packet},
-    logging::{
-        EVENT_KEY_AGGREGATION_NAME, EVENT_KEY_BATCH_DATE, EVENT_KEY_BATCH_ID, EVENT_KEY_TRACE_ID,
-    },
+    logging::event,
     transport::SignableTransport,
     DATE_FORMAT,
 };
@@ -109,7 +107,7 @@ impl<'a> SampleGenerator<'a> {
         parent_logger: &Logger,
     ) -> Self {
         let logger = parent_logger.new(o!(
-            EVENT_KEY_AGGREGATION_NAME => aggregation_name.to_owned(),
+            event::AGGREGATION_NAME => aggregation_name.to_owned(),
         ));
         Self {
             aggregation_name,
@@ -159,9 +157,9 @@ impl<'a> SampleGenerator<'a> {
         packet_count: usize,
     ) -> Result<ReferenceSum> {
         let local_logger = self.logger.new(o!(
-            EVENT_KEY_TRACE_ID => trace_id.to_owned(),
-            EVENT_KEY_BATCH_ID => batch_uuid.to_string(),
-            EVENT_KEY_BATCH_DATE => date.format(DATE_FORMAT).to_string(),
+            event::TRACE_ID => trace_id.to_owned(),
+            event::BATCH_ID => batch_uuid.to_string(),
+            event::BATCH_DATE => date.format(DATE_FORMAT).to_string(),
             "pha_output_path" => self.pha_output.transport.transport.path(),
             "facilitator_output_path" => self.facilitator_output.transport.transport.path(),
         ));

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -4,9 +4,7 @@ use crate::{
     http::{
         Method, OauthTokenProvider, RequestParameters, RetryingAgent, StaticOauthTokenProvider,
     },
-    logging::{
-        EVENT_KEY_IDENTITY, EVENT_KEY_STORAGE_KEY, EVENT_KEY_STORAGE_PATH, EVENT_KEY_TRACE_ID,
-    },
+    logging::event,
     transport::{Transport, TransportWriter},
     Error,
 };
@@ -80,8 +78,8 @@ impl GcsTransport {
             vec![408, 429],
         );
         let logger = parent_logger.new(o!(
-            EVENT_KEY_STORAGE_PATH => path.to_string(),
-            EVENT_KEY_IDENTITY => identity.unwrap_or("default identity").to_owned(),
+            event::STORAGE_PATH => path.to_string(),
+            event::IDENTITY => identity.unwrap_or("default identity").to_owned(),
         ));
         Ok(GcsTransport {
             path: path.ensure_directory_prefix(),
@@ -106,8 +104,8 @@ impl Transport for GcsTransport {
     fn get(&mut self, key: &str, trace_id: &str) -> Result<Box<dyn Read>> {
         info!(
             self.logger, "get";
-            EVENT_KEY_TRACE_ID => trace_id,
-            EVENT_KEY_STORAGE_KEY => key,
+            event::TRACE_ID => trace_id,
+            event::STORAGE_KEY => key,
         );
         // Per API reference, the object key must be URL encoded.
         // API reference: https://cloud.google.com/storage/docs/json_api/v1/objects/get
@@ -136,8 +134,8 @@ impl Transport for GcsTransport {
     fn put(&mut self, key: &str, trace_id: &str) -> Result<Box<dyn TransportWriter>> {
         info!(
             self.logger, "put";
-            EVENT_KEY_TRACE_ID => trace_id,
-            EVENT_KEY_STORAGE_KEY => key,
+            event::TRACE_ID => trace_id,
+            event::STORAGE_KEY => key,
         );
         // The Oauth token will only be used once, during the call to
         // StreamingTransferWriter::new, so we don't have to worry about it
@@ -224,7 +222,7 @@ impl StreamingTransferWriter {
         parent_logger: &Logger,
     ) -> Result<StreamingTransferWriter> {
         let logger = parent_logger.new(o!(
-            EVENT_KEY_STORAGE_KEY => object.clone(),
+            event::STORAGE_KEY => object.clone(),
         ));
 
         // Initiate the resumable, streaming upload.

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -2,9 +2,7 @@ use crate::aws_credentials;
 use crate::{
     aws_credentials::{basic_runtime, retry_request},
     config::S3Path,
-    logging::{
-        EVENT_KEY_IDENTITY, EVENT_KEY_STORAGE_KEY, EVENT_KEY_STORAGE_PATH, EVENT_KEY_TRACE_ID,
-    },
+    logging::event,
     transport::{Transport, TransportWriter},
     Error,
 };
@@ -91,8 +89,8 @@ impl S3Transport {
         parent_logger: &Logger,
     ) -> Self {
         let logger = parent_logger.new(o!(
-            EVENT_KEY_STORAGE_PATH => path.to_string(),
-            EVENT_KEY_IDENTITY => credentials_provider.to_string(),
+            event::STORAGE_PATH => path.to_string(),
+            event::IDENTITY => credentials_provider.to_string(),
         ));
         S3Transport {
             path: path.ensure_directory_prefix(),
@@ -111,8 +109,8 @@ impl Transport for S3Transport {
     fn get(&mut self, key: &str, trace_id: &str) -> Result<Box<dyn Read>> {
         info!(
             self.logger, "get";
-            EVENT_KEY_STORAGE_KEY => key,
-            EVENT_KEY_TRACE_ID => trace_id,
+            event::STORAGE_KEY => key,
+            event::TRACE_ID => trace_id,
         );
         let runtime = basic_runtime()?;
         let client = (self.client_provider)(&self.path.region, self.credentials_provider.clone())?;
@@ -134,8 +132,8 @@ impl Transport for S3Transport {
     fn put(&mut self, key: &str, trace_id: &str) -> Result<Box<dyn TransportWriter>> {
         info!(
             self.logger, "put";
-            EVENT_KEY_STORAGE_KEY => key,
-            EVENT_KEY_TRACE_ID => trace_id,
+            event::STORAGE_KEY => key,
+            event::TRACE_ID => trace_id,
         );
         let writer = MultipartUploadWriter::new(
             self.path.bucket.to_owned(),


### PR DESCRIPTION
Per @jsha's suggestion in #595, we now define the various `EVENT_KEY_*`
constants in the `logging::event` module, allowing us to rename the
constants from `EVENT_KEY_THING` to just `THING`.