### PR TITLE
facilitator: implement `Clone` on creds providers

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -576,6 +576,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "ecdsa"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +630,7 @@ dependencies = [
  "chrono",
  "clap",
  "derivative",
+ "dyn-clone",
  "elliptic-curve",
  "hex",
  "hmac 0.11.0",

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -15,6 +15,7 @@ bytes = "1.0.1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2.33.3"
 derivative = "2.1.1"
+dyn-clone = "1.0.4"
 elliptic-curve = { version = "0.10.2", features = ["pem"] }
 hex = "0.4"
 hmac = "0.11"

--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -51,7 +51,7 @@ pub(crate) fn basic_runtime() -> Result<Runtime> {
 
 /// The Provider enum allows us to generically handle different scenarios for
 /// authenticating to AWS APIs, while still having a concrete value that
-/// implements provideAwsCredentials and which can easily be used with Rusoto's
+/// implements ProvideAwsCredentials and which can easily be used with Rusoto's
 /// various client objects. It also provides a convenient place to implement
 /// std::fmt::Display, allowing facilitator's AWS clients to log something
 /// useful about the identity they use.
@@ -64,6 +64,13 @@ pub(crate) fn basic_runtime() -> Result<Runtime> {
 /// to eliminate boilerplate in facilitator.rs while also integrating gracefully
 /// with rusoto_s3::S3Client and rusoto_sqs::SqsClient, at the cost of some
 /// repetitive match arms in some of the enum's methods.
+///
+/// A note on thread safety and sharing Providers: each variant of this enum
+/// wraps an implementation of ProvideAwsCredentials which in turn uses an
+/// Arc<Mutex<>> to share the cached credentials across cloned instances. That
+/// means that even if a single instance of Provider is .clone()d many times and
+/// provided to multiple threads, they will efficiently share a single cached
+/// credential.
 #[derive(Clone)]
 pub enum Provider {
     /// Rusoto's default credentials provider, which attempts to source

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -1922,7 +1922,7 @@ fn transport_for_path(
                 match matches.value_of("gcp-workload-identity-pool-provider") {
                     Some(workload_identity_pool_provider) => Some(WorkloadIdentityPoolParameters {
                         workload_identity_pool_provider: workload_identity_pool_provider.to_owned(),
-                        aws_credentials_provider: Box::new(aws_credentials_provider(
+                        aws_credentials_provider: aws_credentials_provider(
                             // The identity parameter is the GCP SA that must be
                             // impersonated to access the GCS bucket. We create
                             // this aws_credentials::Provider with no identity,
@@ -1933,7 +1933,7 @@ fn transport_for_path(
                             "IAM federation",
                             use_default_aws_credentials_provider,
                             logger,
-                        )?),
+                        )?,
                     }),
                     None => None,
                 };

--- a/facilitator/src/config.rs
+++ b/facilitator/src/config.rs
@@ -1,11 +1,13 @@
 use anyhow::{anyhow, Context, Result};
-use rusoto_core::{credential::ProvideAwsCredentials, region::ParseRegionError, Region};
+use rusoto_core::{region::ParseRegionError, Region};
 use serde::{de, Deserialize, Deserializer};
 use std::{
     fmt::{self, Display, Formatter},
     path::PathBuf,
     str::FromStr,
 };
+
+use crate::aws_credentials;
 
 /// Identity represents a cloud identity: Either an AWS IAM ARN (i.e. "arn:...")
 /// or a GCP ServiceAccount (i.e. "foo@bar.com").
@@ -21,7 +23,7 @@ pub struct WorkloadIdentityPoolParameters {
     /// A credential provider that can get AWS credentials for an AWS IAM role
     /// or user that is permitted to impersonate a GCP service account via the
     /// workload_identity_pool_provider
-    pub aws_credentials_provider: Box<dyn ProvideAwsCredentials>,
+    pub aws_credentials_provider: aws_credentials::Provider,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
As we work towards #543, we need efficient `std::clone::Clone`
implementations on our `Transport` and `TaskQueue` implementations so
they can be efficiently shared across tasks. This commit starts towards
that goal by making the GCP and AWS credential providers `Clone`.
`aws_credentials::Provider` was already `Clone`, mostly thanks to
Rusoto's underlying implementations, but
`gcp_oauth::GcpOauthTokenProvider` needed some rework to implement
threadsafe interior mutability. I also took the opportunity to add some
test coverage.

This commit consists mainly of changes cherry-picked from #486.