### PR TITLE
facilitator: use `slog::Logger` in `http` module

### DIFF
--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -157,7 +157,7 @@ impl Provider {
                 .append_pair("audience", &format!("sts.amazonaws.com/{}", aws_account_id))
                 .finish();
 
-            let agent = RetryingAgent::default();
+            let agent = RetryingAgent::default(&token_logger);
             let mut request = agent
                 .prepare_request(RequestParameters {
                     url,

--- a/facilitator/src/gcp_oauth.rs
+++ b/facilitator/src/gcp_oauth.rs
@@ -179,7 +179,7 @@ impl GcpOauthTokenProvider {
             account_to_impersonate,
             default_account_token: None,
             impersonated_account_token: None,
-            agent: RetryingAgent::default(),
+            agent: RetryingAgent::default(&logger),
             logger,
         })
     }


### PR DESCRIPTION
Plumbs structured logging into `http::RetryingAgent`, requiring the same
to be passed through other modules that depend on `RetryingAgent`.
`RetryingAgent::logger` isn't yet used; that will come in a subsequent
PR that passes the logger into `retries::retry_request`.

Part of #546