### PR TITLE
facilitator: log retryable errors

### DIFF
--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -157,7 +157,7 @@ impl Provider {
                 .append_pair("audience", &format!("sts.amazonaws.com/{}", aws_account_id))
                 .finish();
 
-            let agent = RetryingAgent::default(&token_logger);
+            let agent = RetryingAgent::default();
             let mut request = agent
                 .prepare_request(RequestParameters {
                     url,
@@ -168,7 +168,7 @@ impl Provider {
 
             request = request.set("Metadata-Flavor", "Google");
 
-            let response = agent.call(&request).map_err(|e| {
+            let response = agent.call(&token_logger, &request).map_err(|e| {
                 CredentialsError::new(format!(
                     "failed to fetch {} auth token from metadata service: {:?}",
                     purpose, e

--- a/facilitator/src/gcp_oauth.rs
+++ b/facilitator/src/gcp_oauth.rs
@@ -179,7 +179,7 @@ impl GcpOauthTokenProvider {
             account_to_impersonate,
             default_account_token: None,
             impersonated_account_token: None,
-            agent: RetryingAgent::default(&logger),
+            agent: RetryingAgent::default(),
             logger,
         })
     }
@@ -235,7 +235,7 @@ impl GcpOauthTokenProvider {
         request = request.set("Metadata-Flavor", "Google");
 
         self.agent
-            .call(&request)
+            .call(&self.logger, &request)
             .context("failed to query GKE metadata service")
     }
 
@@ -284,7 +284,7 @@ impl GcpOauthTokenProvider {
 
         let request = request.set("Content-Type", "application/x-www-form-urlencoded");
         self.agent
-            .send_string(&request, &request_body)
+            .send_string(&self.logger, &request, &request_body)
             .context("failed to get account token with key file")
     }
 
@@ -323,6 +323,7 @@ impl GcpOauthTokenProvider {
         let http_response = self
             .agent
             .send_json_request(
+                &self.logger,
                 &request,
                 &ureq::json!({
                     "scope": [self.scope]

--- a/facilitator/src/retries.rs
+++ b/facilitator/src/retries.rs
@@ -1,5 +1,5 @@
 use backoff::{retry, ExponentialBackoff};
-use slog::{debug, info, Logger};
+use slog::{debug, warn, Logger};
 use std::{fmt::Debug, time::Duration};
 
 /// Executes the provided action `f`, retrying with exponential backoff if the
@@ -59,7 +59,7 @@ where
         // Invoke the function and wrap its E into backoff::Error
         f().map_err(|error| {
             if is_retryable(&error) {
-                info!(
+                warn!(
                     logger, "encountered retryable error";
                     "error" => format!("{:?}", error),
                 );

--- a/facilitator/src/retries.rs
+++ b/facilitator/src/retries.rs
@@ -59,7 +59,10 @@ where
         // Invoke the function and wrap its E into backoff::Error
         f().map_err(|error| {
             if is_retryable(&error) {
-                info!(logger, "encountered retryable error");
+                info!(
+                    logger, "encountered retryable error";
+                    "error" => format!("{:?}", error),
+                );
                 backoff::Error::Transient(error)
             } else {
                 debug!(logger, "encountered non-retryable error");


### PR DESCRIPTION
`retries::retry_request_with_params` was not logging the retryable error
it encountered. Additionally, this commit changes the log level on
retryable erors to `warn!` so that such errors will stand out more.