### PR TITLE
facilitator: hack to detect S3 upload failure

### DIFF
--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -11,6 +11,7 @@ atty = "0.2"
 avro-rs = { version = "0.13.0", features = ["snappy"] }
 backoff = "0.3.0"
 base64 = "0.13.0"
+bytes = "1.0.1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2.33.3"
 derivative = "2.1.1"
@@ -52,6 +53,5 @@ xml-rs = "0.8"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-bytes = "1.0.1"
 mockito = "0.30.0"
 serde_test = "1.0"


### PR DESCRIPTION
We hack around a situation where S3 reports a failure with HTTP status
200 OK, causing Rusoto to report success.

See https://github.com/rusoto/rusoto/issues/1936 for details.