### PR TITLE
facilitator: remove OpenSSL dependency

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -690,21 +690,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,19 +1044,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
 name = "idna"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,24 +1151,25 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-timeout",
- "hyper-tls",
  "jsonpath_lib",
  "k8s-openapi",
  "kube-core",
- "openssl",
  "pem",
  "pin-project 1.0.5",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror",
  "tokio",
- "tokio-native-tls",
  "tokio-util",
  "tower",
  "tower-http",
  "tracing",
+ "webpki",
 ]
 
 [[package]]
@@ -1381,24 +1354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1466,37 +1421,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "openssl"
-version = "0.10.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "lazy_static",
- "libc",
- "openssl-sys",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -1562,11 +1490,11 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "918192b5c59119d51e0cd221f4d49dde9112824ba717369e903c97d076083d0f"
 dependencies = [
- "pin-project-internal 0.4.27",
+ "pin-project-internal 0.4.28",
 ]
 
 [[package]]
@@ -1580,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+checksum = "3be26700300be6d9d23264c73211d8190e755b6b5ca7a1b28230025511b52a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1623,12 +1551,6 @@ dependencies = [
  "spki",
  "zeroize",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "pkix"
@@ -2029,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064fd21ff87c6e87ed4506e68beb42459caa4a0e2eb144932e6776768556980b"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
  "base64 0.13.0",
  "log",
@@ -2050,6 +1972,15 @@ dependencies = [
  "rustls",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -2370,7 +2301,7 @@ checksum = "eab12d3c261b2308b0d80c26fffb58d17eba81a4be97890101f416b478c79ca7"
 dependencies = [
  "doc-comment",
  "futures-core",
- "pin-project 0.4.27",
+ "pin-project 0.4.28",
  "snafu-derive",
 ]
 
@@ -2733,16 +2664,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,9 +2715,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
+checksum = "f60422bc7fefa2f3ec70359b8ff1caff59d785877eb70595904605bcc412470f"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2852,9 +2773,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3033,12 +2954,6 @@ dependencies = [
  "getrandom 0.2.2",
  "serde",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec_map"

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -21,7 +21,7 @@ hyper = "^0.14"
 hyper-rustls = "^0.22"
 jsonwebtoken = "7"
 k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_20"] }
-kube = "0.56.0"
+kube = { version = "0.56.0", default-features = false, features = ["client", "rustls-tls"] }
 kube-runtime = "0.56.0"
 p256 = "0.8.1"
 pem = "0.8"

--- a/facilitator/Dockerfile
+++ b/facilitator/Dockerfile
@@ -1,11 +1,6 @@
 FROM rust:1.52.1-alpine as builder
 
-RUN apk add libc-dev openssl-dev && apk update
-
-# This is required so OpenSSL links properly. OpenSSL is required by reqwest, as used by
-# prometheus with the `push` option.
-# https://users.rust-lang.org/t/sigsegv-with-program-linked-against-openssl-in-an-alpine-container/52172
-ENV RUSTFLAGS='-C target-feature=-crt-static'
+RUN apk add libc-dev && apk update
 
 # Attempt to install a nonexistent package. This triggers
 # updating the crates.io index separately from building the
@@ -35,13 +30,15 @@ COPY ./avro-schema ./avro-schema
 COPY ./facilitator ./facilitator
 
 ARG BUILD_INFO=unspecified
-ENV OPENSSL_STATIC=true
 
 # This cargo build command must match the one above, or the build cache will not be reused.
 RUN cargo build --manifest-path ./facilitator/Cargo.toml
 # We build in debug mode so the build runs quickly, then strip the binary for size.
 RUN strip facilitator/target/debug/facilitator
 
-# Build a minimal container containing only the binary, the one .so it needs, and root certs.
-RUN cp /usr/src/prio-server/facilitator/target/debug/facilitator /facilitator
+# Build a minimal container from Alpine containing only the stripped binary and
+# no intermediate build artifacts
+FROM rust:1.52.1-alpine
+
+COPY --from=builder /usr/src/prio-server/facilitator/target/debug/facilitator facilitator
 ENTRYPOINT ["/facilitator"]

--- a/facilitator/Dockerfile
+++ b/facilitator/Dockerfile
@@ -32,9 +32,7 @@ COPY ./facilitator ./facilitator
 ARG BUILD_INFO=unspecified
 
 # This cargo build command must match the one above, or the build cache will not be reused.
-RUN cargo build --manifest-path ./facilitator/Cargo.toml
-# We build in debug mode so the build runs quickly, then strip the binary for size.
-RUN strip facilitator/target/debug/facilitator
+RUN cargo build --manifest-path ./facilitator/Cargo.toml --release
 
 # Build a minimal container from Alpine containing only the stripped binary and
 # no intermediate build artifacts

--- a/facilitator/README.md
+++ b/facilitator/README.md
@@ -112,6 +112,12 @@ Had you generated and intaken multiple batches with `generate-ingestion-sample` 
 
 To build a Docker image, run `./build.sh`. To run that image locally, `docker run letsencrypt/prio-facilitator -- --help`.
 
+### Be careful to avoid depending on OpenSSL!
+
+We take great care to use [`rustls`](https://github.com/ctz/rustls) instead of any native TLS implementation, to avoid depending on OpenSSL. Besides `rustls`'s sterling reputation for quality, using a pure Rust TLS implementation means we don't [have to use special tricks to statically link OpenSSL](https://users.rust-lang.org/t/sigsegv-with-program-linked-against-openssl-in-an-alpine-container/52172).
+
+When adding a dependency to `Cargo.toml`, check if it depends on [`native-tls`](https://crates.io/crates/native-tls) or otherwise winds up pulling in the [`openssl`](https://crates.io/crates/openssl) crate. See if it can be configured to use `rustls`. For example, [Rusoto's crates all have a `rustls` feature](https://crates.io/crates/rusoto_core).
+
 ## Linting manifest files
 
 The `facilitator lint-manifest` subcommand can validate the various manifest files used in the system. See that subcommand's help text for more information on usage.


### PR DESCRIPTION
We now configure `kube` to use `rustls`, removing our dependency on any
native TLS implementation which ends up pulling in OpenSSL. This means
we no longer need to install `openssl-dev` when building the
`facilitator` Docker image, nor do we need to play special games to
statically link it on Alpine.

We still end up depending on
[`openssl-probe`](https://crates.io/crates/openssl-probe), but that
crate doesn't actually link OpenSSL and so is harmless.

This commit also separates the `prio-facilitator` Dockerfile so that we
copy just the compiled binary from the builder container into the image
we run, which cuts down image size by ~500 MB.

Closes #451