### PR TITLE
facilitator: crypto self-check at startup

### DIFF
--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -199,6 +199,7 @@ resource "kubernetes_config_map" "intake_batch_config_map" {
     INSTANCE_NAME                        = var.data_share_processor_name
     PEER_IDENTITY                        = var.remote_peer_validation_bucket_identity
     PEER_MANIFEST_BASE_URL               = "https://${var.peer_manifest_base_url}"
+    OWN_MANIFEST_BASE_URL                = "https://${var.own_manifest_base_url}"
     OWN_OUTPUT                           = var.own_validation_bucket
     RUST_LOG                             = "info"
     RUST_BACKTRACE                       = "1"


### PR DESCRIPTION
The `intake-batch`, `intake-batch-worker`, `aggregate` and
`aggregate-worker` subcommands on `facilitator` may now be passed
`--own-manifest-base-url`. If present, the batch signing and packet
encryption public keys in the relevant specific manifest will be checked
against the batch signing and packet encryption private keys provided to
`facilitator` by round tripping signature+verification or
encryption+decryption, respectively. If the keys do not match up,
`facilitator` aborts, enabling us to rapidly detect misconfigurations.

Closes #757