### PR TITLE
`facilitator`: use non-default GCP SA to assume IAM role

### DIFF
--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -1,6 +1,9 @@
 use crate::{
     config::Identity,
-    http::{Method, RequestParameters, RetryingAgent},
+    gcp_oauth::{
+        GcpAccessTokenProvider, GkeMetadataServiceIdentityTokenProvider,
+        ImpersonatedServiceAccountIdentityTokenProvider, ProvideGcpIdentityToken,
+    },
     retries,
 };
 use anyhow::{anyhow, Context, Result};
@@ -21,15 +24,13 @@ use rusoto_core::{
 };
 use rusoto_mock::MockCredentialsProvider;
 use rusoto_sts::WebIdentityProvider;
-//use s3::signing::{canonical_request, signed_header_string, signing_key};
 use sha2::{Digest, Sha256};
-use slog::{debug, o, Logger};
+use slog::{o, Logger};
 use std::str;
 use std::{
     boxed::Box,
     convert::From,
     default::Default,
-    env,
     fmt::{self, Debug, Display},
     sync::Arc,
 };
@@ -97,15 +98,19 @@ impl Provider {
     /// values
     pub fn new(
         identity: Identity,
+        impersonate_service_account: Option<&str>,
         use_default_provider: bool,
         purpose: &str,
         logger: &Logger,
     ) -> Result<Self> {
         match (use_default_provider, identity) {
             (true, _) => Self::new_default(),
-            (_, Some(identity)) => {
-                Self::new_web_identity_with_oidc(identity, purpose.to_owned(), logger)
-            }
+            (_, Some(identity)) => Self::new_web_identity_with_oidc(
+                identity,
+                purpose.to_owned(),
+                impersonate_service_account,
+                logger,
+            ),
             (_, None) => Self::new_web_identity_from_kubernetes_environment(),
         }
     }
@@ -129,25 +134,15 @@ impl Provider {
         ))
     }
 
-    // We use workload identity to map GCP service accounts to Kubernetes
-    // service accounts and make an auth token for the GCP account available to
-    // containers in the GKE metadata service. Sadly we can't use the Kubernetes
-    // feature to automount a service account token, because that would provide
-    // the token for the *Kubernetes* service account, not the GCP one.
-    // See terraform/modules/gke/gke.tf and terraform/modules/kuberenetes/kubernetes.tf
-    fn metadata_service_token_url() -> Url {
-        Url::parse("http://metadata.google.internal:80/computeMetadata/v1/instance/service-accounts/default/identity")
-            .expect("could not parse token metadata api url")
-    }
-
     fn new_web_identity_with_oidc(
         iam_role: &str,
         purpose: String,
+        impersonated_gcp_service_account: Option<&str>,
         logger: &Logger,
     ) -> Result<Self> {
-        // When running in GKE, the token used to authenticate to AWS S3 is
-        // available from the instance metadata service.
-        // See terraform/modules/kubernetes/kubernetes.tf for discussion.
+        // When running in GKE, we obtain an identity token which we can then
+        // present to sts.amazonaws.com to get credentials that can authenticate
+        // to AWS S3.
         // This dynamic variable lets us provide a callback for fetching tokens,
         // allowing Rusoto to automatically get new credentials if they expire
         // (which they do every hour).
@@ -155,49 +150,29 @@ impl Provider {
             "iam_role" => iam_role.to_owned(),
             "purpose" => purpose.clone(),
         ));
+        let token_provider: Box<dyn ProvideGcpIdentityToken> =
+            match impersonated_gcp_service_account {
+                Some(impersonated_gcp_service_account) => {
+                    Box::new(ImpersonatedServiceAccountIdentityTokenProvider::new(
+                        impersonated_gcp_service_account.to_owned(),
+                        GcpAccessTokenProvider::new(
+                            "https://www.googleapis.com/auth/iam",
+                            None,
+                            None,
+                            None,
+                            &token_logger,
+                        )?,
+                        token_logger.clone(),
+                    ))
+                }
+                None => Box::new(GkeMetadataServiceIdentityTokenProvider::new(
+                    token_logger.clone(),
+                )),
+            };
         let oidc_token_variable = Variable::dynamic(move || {
-            debug!(
-                token_logger,
-                "obtaining OIDC token from GKE metadata service"
-            );
-            let aws_account_id = env::var("AWS_ACCOUNT_ID").map_err(|e| {
+            let token = token_provider.identity_token().map_err(|e| {
                 CredentialsError::new(format!(
-                    "could not read AWS account ID from environment: {}",
-                    e
-                ))
-            })?;
-
-            // We use ureq for this request because it is designed to use purely
-            // synchronous Rust. Ironically, we are in the context of an async
-            // runtime when this callback is invoked, but because the closure is
-            // not declared async, we cannot use .await to work with Futures.
-            let mut url = Self::metadata_service_token_url();
-
-            url.query_pairs_mut()
-                .append_pair("audience", &format!("sts.amazonaws.com/{}", aws_account_id))
-                .finish();
-
-            let agent = RetryingAgent::default();
-            let mut request = agent
-                .prepare_request(RequestParameters {
-                    url,
-                    method: Method::Get,
-                    ..Default::default()
-                })
-                .map_err(|e| CredentialsError::new(format!("failed to create request: {:?}", e)))?;
-
-            request = request.set("Metadata-Flavor", "Google");
-
-            let response = agent.call(&token_logger, &request).map_err(|e| {
-                CredentialsError::new(format!(
-                    "failed to fetch {} auth token from metadata service: {:?}",
-                    purpose, e
-                ))
-            })?;
-
-            let token = response.into_string().map_err(|e| {
-                CredentialsError::new(format!(
-                    "failed to fetch {} auth token from metadata service: {}",
+                    "failed to fetch {} identity token from GCP: {}",
                     purpose, e
                 ))
             })?;

--- a/facilitator/src/gcp_oauth.rs
+++ b/facilitator/src/gcp_oauth.rs
@@ -1,3 +1,20 @@
+//! API clients for obtaining authentication tokens for use with Google Cloud
+//! Platform
+//!
+//! This module provides clients that support a variety of authentication flows
+//! to GCP, whether for Google Kubernetes Engine workloads, clients using a GCP
+//! service account key file or identity federation with sts.amazonaws.com.
+//!
+//! Throughout this module we make reference to _access_ or _identity_ tokens.
+//! Both are Oauth tokens but are not the same. [Access tokens] represent "the
+//! authorization of a specific application to access specific parts of a user’s
+//! data" and are used to authenticate to GCP services while [identity or ID
+//! tokens] encode "the user’s authentication information" and are used for
+//! federation with external identity services (i.e. `sts.amazonaws.com`).
+//!
+//! [Access tokens]: https://www.oauth.com/oauth2-servers/access-tokens/
+//! [identity of ID tokens]: https://www.oauth.com/oauth2-servers/openid-connect/id-tokens/
+
 use anyhow::{anyhow, Context, Result};
 use chrono::{prelude::Utc, DateTime, Duration};
 use dyn_clone::DynClone;
@@ -6,7 +23,7 @@ use rusoto_core::{credential::ProvideAwsCredentials, Region};
 use serde::{Deserialize, Serialize};
 use slog::{debug, o, Logger};
 use std::{
-    fmt::{self, Debug},
+    fmt::{self, Debug, Formatter},
     io::Read,
     str,
     sync::{Arc, RwLock},
@@ -18,45 +35,28 @@ use crate::{
     aws_credentials::{self, basic_runtime, get_caller_identity_token},
     config::WorkloadIdentityPoolParameters,
     http::{
-        Method, OauthTokenProvider, RequestParameters, RetryingAgent, StaticOauthTokenProvider,
+        AccessTokenProvider, Method, RequestParameters, RetryingAgent, StaticAccessTokenProvider,
     },
 };
 
 const DEFAULT_METADATA_BASE_URL: &str = "http://metadata.google.internal:80";
-const DEFAULT_TOKEN_PATH: &str = "/computeMetadata/v1/instance/service-accounts/default/token";
+const DEFAULT_ACCESS_TOKEN_PATH: &str =
+    "/computeMetadata/v1/instance/service-accounts/default/token";
+const DEFAULT_IDENTITY_TOKEN_PATH: &str =
+    "/computeMetadata/v1/instance/service-accounts/default/identity";
 const DEFAULT_IAM_BASE_URL: &str = "https://iamcredentials.googleapis.com";
-
-fn default_oauth_token_url(base: &str) -> Url {
-    let mut request_url = Url::parse(base).expect("unable to parse metadata.google.internal url");
-    request_url.set_path(DEFAULT_TOKEN_PATH);
-    request_url
-}
-
-// API reference:
-// https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
-fn access_token_url_for_service_account(
-    base: &str,
-    service_account_to_impersonate: &str,
-) -> Result<Url> {
-    let request_url = format!(
-        "{}{}",
-        base,
-        access_token_path_for_service_account(service_account_to_impersonate)
-    );
-
-    Url::parse(&request_url).context(format!("failed to parse: {}", request_url))
-}
-
-fn access_token_path_for_service_account(service_account_to_impersonate: &str) -> String {
-    format!(
-        "/v1/projects/-/serviceAccounts/{}:generateAccessToken",
-        service_account_to_impersonate
-    )
-}
+// Both the GKE metadata service and iamcredentials.googleapis.com require an
+// audience parameter when requesting identity tokens, so we must provide
+// *something*. However, the value we provide can be anything so long as it
+// matches the role assumption policy configured on the AWS IAM role we are
+// trying to assume. That policy will be scoped to the numeric account ID of a
+// specific GCP service account anyway, so there's not much to be gained by
+// further scoping the identiy token to an audience
+const IDENTITY_TOKEN_AUDIENCE: &str = "sts.amazonaws.com/gke-identity-federation";
 
 /// Represents the claims encoded into JWTs when using a service account key
 /// file to authenticate as the default GCP service account.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 struct Claims {
     iss: String,
     scope: String,
@@ -65,14 +65,14 @@ struct Claims {
     exp: i64,
 }
 
-/// A wrapper around an Oauth token and its expiration date.
-#[derive(Clone)]
-struct OauthToken {
+/// A wrapper around an access token and its expiration date.
+#[derive(Clone, Debug)]
+struct AccessToken {
     token: String,
     expiration: DateTime<Utc>,
 }
 
-impl OauthToken {
+impl AccessToken {
     /// Returns true if the token is expired.
     fn expired(&self) -> bool {
         Utc::now() >= self.expiration
@@ -84,8 +84,8 @@ impl OauthToken {
 /// sts.googleapis.com's token method[2]
 /// [1] https://developers.google.com/identity/protocols/oauth2/service-account
 /// [2] https://cloud.google.com/iam/docs/reference/sts/rest/v1/TopLevel/token
-#[derive(Deserialize, PartialEq)]
-struct OauthTokenResponse {
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct AccessTokenResponse {
     access_token: String,
     expires_in: i64,
     token_type: String,
@@ -94,7 +94,7 @@ struct OauthTokenResponse {
 /// Represents the response from a POST request to the GCP IAM service's
 /// generateAccessToken endpoint.
 /// https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
-#[derive(Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 struct GenerateAccessTokenResponse {
     access_token: String,
@@ -116,45 +116,55 @@ struct ServiceAccountKeyFile {
     token_uri: String,
 }
 
-/// Implementations of ProvideDefaultToken obtain a default Oauth token, used
-/// either to authenticate to GCP services or to obtain a further service
-/// account Oauth token from GCP IAM.
-trait ProvideDefaultToken: DynClone + Debug {
-    fn default_token(&self) -> Result<Response>;
+/// Implementations of ProvideDefaultAccessToken obtain a default access token,
+/// used either to authenticate to GCP services or to obtain a further service
+/// account access token from GCP IAM.
+trait ProvideDefaultAccessToken: Debug + DynClone + Send + Sync {
+    fn default_access_token(&self) -> Result<Response>;
 }
 
-dyn_clone::clone_trait_object!(ProvideDefaultToken);
+dyn_clone::clone_trait_object!(ProvideDefaultAccessToken);
 
-/// Fetches a token from the GKE metadata service for the GCP SA mapped to the
-/// current Kubernetes SA via GKE workload identity (not to be confused with
-/// workload identity *pool*). Used by workloads in Google Kubernetes Engine.
+/// Fetches an access token from the GKE metadata service for the GCP SA mapped
+/// to the current Kubernetes SA via GKE workload identity (not to be confused
+/// with workload identity *pool*). Used by workloads in Google Kubernetes
+/// Engine.
 #[derive(Clone, Debug)]
-struct GkeMetadataServiceDefaultTokenProvider {
+struct GkeMetadataServiceDefaultAccessTokenProvider {
     agent: RetryingAgent,
     logger: Logger,
     /// Base URL at which to access GKE metadata service
     metadata_service_base_url: &'static str,
 }
 
-impl GkeMetadataServiceDefaultTokenProvider {
+impl GkeMetadataServiceDefaultAccessTokenProvider {
     fn new(agent: RetryingAgent, logger: Logger) -> Self {
-        GkeMetadataServiceDefaultTokenProvider {
+        Self {
             agent,
             logger,
             metadata_service_base_url: DEFAULT_METADATA_BASE_URL,
         }
     }
+
+    /// Returns the GKE metadata service URL from which access tokens for the
+    /// default GCP service account may be obtained.
+    fn default_access_token_url(base: &str) -> Url {
+        let mut request_url =
+            Url::parse(base).expect("unable to parse metadata.google.internal url");
+        request_url.set_path(DEFAULT_ACCESS_TOKEN_PATH);
+        request_url
+    }
 }
 
-impl ProvideDefaultToken for GkeMetadataServiceDefaultTokenProvider {
-    fn default_token(&self) -> Result<Response> {
+impl ProvideDefaultAccessToken for GkeMetadataServiceDefaultAccessTokenProvider {
+    fn default_access_token(&self) -> Result<Response> {
         debug!(
             self.logger,
-            "obtaining default account token from GKE metadata service"
+            "obtaining default account access token from GKE metadata service"
         );
 
         let mut request = self.agent.prepare_request(RequestParameters {
-            url: default_oauth_token_url(self.metadata_service_base_url),
+            url: Self::default_access_token_url(self.metadata_service_base_url),
             method: Method::Get,
             ..Default::default()
         })?;
@@ -163,23 +173,26 @@ impl ProvideDefaultToken for GkeMetadataServiceDefaultTokenProvider {
 
         self.agent
             .call(&self.logger, &request)
-            .context("failed to query GKE metadata service")
+            .context("failed to obtain default account access token from GKE metadata service")
     }
 }
 
 /// Uses a GCP service account key file to authenticate to GCP IAM as some
 /// service account.
 #[derive(Clone, Debug)]
-struct ServiceAccountKeyFileDefaultTokenProvider {
+struct ServiceAccountKeyFileDefaultAccessTokenProvider {
     key_file: ServiceAccountKeyFile,
     scope: String,
     agent: RetryingAgent,
     logger: Logger,
 }
 
-impl ProvideDefaultToken for ServiceAccountKeyFileDefaultTokenProvider {
-    fn default_token(&self) -> Result<Response> {
-        debug!(self.logger, "obtaining account token from key file");
+impl ProvideDefaultAccessToken for ServiceAccountKeyFileDefaultAccessTokenProvider {
+    fn default_access_token(&self) -> Result<Response> {
+        debug!(
+            self.logger,
+            "obtaining access token with service account key file"
+        );
         // We construct the JWT per Google documentation:
         // https://developers.google.com/identity/protocols/oauth2/service-account#authorizingrequests
         let mut header = Header::new(Algorithm::RS256);
@@ -219,23 +232,23 @@ impl ProvideDefaultToken for ServiceAccountKeyFileDefaultTokenProvider {
                     ("assertion", &token),
                 ],
             )
-            .context("failed to get account token with key file")
+            .context("failed to obtain access token with service account key file")
     }
 }
 
 /// Uses a GCP Workload Identity Pool to federate GCP IAM with AWS IAM, allowing
 /// workloads in AWS Elastic Kubernetes Service to impersonate a GCP SA.
 #[derive(Clone)]
-struct AwsIamFederationViaWorkloadIdentityPoolDefaultTokenProvider {
+struct AwsIamFederationViaWorkloadIdentityPoolDefaultAccessTokenProvider {
     aws_credentials_provider: aws_credentials::Provider,
     workload_identity_pool_provider: String,
     logger: Logger,
     agent: RetryingAgent,
 }
 
-impl Debug for AwsIamFederationViaWorkloadIdentityPoolDefaultTokenProvider {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AwsIamFederationViaWorkloadIdentityPoolDefaultTokenProvider")
+impl Debug for AwsIamFederationViaWorkloadIdentityPoolDefaultAccessTokenProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AwsIamFederationViaWorkloadIdentityPoolDefaultAccessTokenProvider")
             .field(
                 "token_source",
                 &"AWS IAM federation via workload identity pool",
@@ -244,8 +257,10 @@ impl Debug for AwsIamFederationViaWorkloadIdentityPoolDefaultTokenProvider {
     }
 }
 
-impl ProvideDefaultToken for AwsIamFederationViaWorkloadIdentityPoolDefaultTokenProvider {
-    fn default_token(&self) -> Result<Response> {
+impl ProvideDefaultAccessToken
+    for AwsIamFederationViaWorkloadIdentityPoolDefaultAccessTokenProvider
+{
+    fn default_access_token(&self) -> Result<Response> {
         debug!(
             self.logger,
             "getting GCP workload identity pool federated token"
@@ -299,47 +314,40 @@ impl ProvideDefaultToken for AwsIamFederationViaWorkloadIdentityPoolDefaultToken
             })?
             .set("Content-Type", "application/json; charset=utf-8");
 
-        debug!(
-            self.logger,
-            "obtaining federated access token. request {:?}\ngci_token {}\nbody {}",
-            request,
-            get_caller_identity_token,
-            request_body
-        );
         self.agent
             .send_json_request(&self.logger, &request, &request_body)
             .context("failed to obtain federated access token from sts.googleapis.com")
     }
 }
 
-/// GcpOauthTokenProvider manages a default service account Oauth token (i.e. the
-/// one for a GCP service account mapped to a Kubernetes service account, or the
-/// one found in a JSON key file) and an Oauth token used to impersonate another
-/// service account.
+/// GcpAccessTokenProvider manages a default service account access token (e.g.,
+/// the one for a GCP service account mapped to a Kubernetes service account, or
+/// the one found in a JSON key file) and an access token used to impersonate
+/// another service account.
 ///
 /// A note on thread safety: this struct stores any Oauth tokens it obtains in
 /// an Arc+Mutex, so an instance of GcpOauthTokenProvider may be .clone()d
 /// liberally and shared across threads, and credentials obtained from the GCP
 /// credentials API will be shared efficiently and safely.
 #[derive(Clone)]
-pub(crate) struct GcpOauthTokenProvider {
+pub(crate) struct GcpAccessTokenProvider {
     /// The Oauth scope for which tokens should be requested.
     scope: String,
-    /// Provides the default Oauth token, which may be used to directly access
+    /// Provides the default access token, which may be used to directly access
     /// GCP services or may be used to impersonate some GCP service account.
-    default_token_provider: Box<dyn ProvideDefaultToken>,
+    default_token_provider: Box<dyn ProvideDefaultAccessToken>,
     /// Holds the service account email to impersonate, if one was provided to
-    /// GcpOauthTokenProvider::new.
+    /// GcpAccessTokenProvider::new.
     account_to_impersonate: Option<String>,
     /// This field is None after instantiation and is Some after the first
     /// successful request for a token for the default service account, though
     /// the contained token may be expired.
-    default_account_token: Arc<RwLock<Option<OauthToken>>>,
+    default_access_token: Arc<RwLock<Option<AccessToken>>>,
     /// This field is None after instantiation and is Some after the first
     /// successful request for a token for the impersonated service account,
     /// though the contained token may be expired. This will always be None if
     /// account_to_impersonate is None.
-    impersonated_account_token: Arc<RwLock<Option<OauthToken>>>,
+    impersonated_account_token: Arc<RwLock<Option<AccessToken>>>,
     /// The agent will be used when making HTTP requests to GCP APIs to fetch
     /// Oauth tokens.
     agent: RetryingAgent,
@@ -349,15 +357,15 @@ pub(crate) struct GcpOauthTokenProvider {
     iam_service_base_url: &'static str,
 }
 
-impl fmt::Debug for GcpOauthTokenProvider {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("OauthTokenProvider")
+impl Debug for GcpAccessTokenProvider {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GcpAccessTokenProvider")
             .field("account_to_impersonate", &self.account_to_impersonate)
             .field("default_token_provider", &self.default_token_provider)
             .field(
-                "default_account_token",
+                "default_access_token",
                 &self
-                    .default_account_token
+                    .default_access_token
                     .read()
                     .unwrap()
                     .as_ref()
@@ -366,7 +374,7 @@ impl fmt::Debug for GcpOauthTokenProvider {
             .field(
                 "impersonated_account_token",
                 &self
-                    .default_account_token
+                    .impersonated_account_token
                     .read()
                     .unwrap()
                     .as_ref()
@@ -376,22 +384,22 @@ impl fmt::Debug for GcpOauthTokenProvider {
     }
 }
 
-impl OauthTokenProvider for GcpOauthTokenProvider {
+impl AccessTokenProvider for GcpAccessTokenProvider {
     /// Returns the Oauth token to use with GCP API in an Authorization header,
     /// fetching it or renewing it if necessary. If a service account to
     /// impersonate was provided, the default service account is used to
     /// authenticate to the GCP IAM API to retrieve an Oauth token. If no
     /// impersonation is taking place, provides the default service account
     /// Oauth token.
-    fn ensure_oauth_token(&mut self) -> Result<String> {
+    fn ensure_access_token(&self) -> Result<String> {
         match self.account_to_impersonate {
             Some(_) => self.ensure_impersonated_service_account_oauth_token(),
-            None => self.ensure_default_account_token(),
+            None => self.ensure_default_access_token(),
         }
     }
 }
 
-impl GcpOauthTokenProvider {
+impl GcpAccessTokenProvider {
     /// Creates a token provider which can impersonate the specified service
     /// account.
     pub(crate) fn new(
@@ -407,14 +415,14 @@ impl GcpOauthTokenProvider {
         ));
         let agent = RetryingAgent::default();
 
-        let default_token_provider: Box<dyn ProvideDefaultToken> =
+        let default_token_provider: Box<dyn ProvideDefaultAccessToken> =
             match (key_file_reader, workload_identity_pool_params) {
                 (Some(_), Some(_)) => {
                     return Err(anyhow!(
                         "either but not both of key_file_reader or aws_credentials may be provided"
                     ))
                 }
-                (Some(reader), None) => Box::new(ServiceAccountKeyFileDefaultTokenProvider {
+                (Some(reader), None) => Box::new(ServiceAccountKeyFileDefaultAccessTokenProvider {
                     key_file: serde_json::from_reader(reader)
                         .context("failed to deserialize JSON key file")?,
                     scope: scope.to_owned(),
@@ -422,24 +430,24 @@ impl GcpOauthTokenProvider {
                     logger: logger.clone(),
                 }),
                 (None, Some(parameters)) => Box::new(
-                    AwsIamFederationViaWorkloadIdentityPoolDefaultTokenProvider {
+                    AwsIamFederationViaWorkloadIdentityPoolDefaultAccessTokenProvider {
                         aws_credentials_provider: parameters.aws_credentials_provider,
                         workload_identity_pool_provider: parameters.workload_identity_pool_provider,
                         logger: logger.clone(),
                         agent: agent.clone(),
                     },
                 ),
-                (None, None) => Box::new(GkeMetadataServiceDefaultTokenProvider::new(
+                (None, None) => Box::new(GkeMetadataServiceDefaultAccessTokenProvider::new(
                     agent.clone(),
                     logger.clone(),
                 )),
             };
 
-        Ok(GcpOauthTokenProvider {
+        Ok(Self {
             scope: scope.to_owned(),
             default_token_provider,
             account_to_impersonate,
-            default_account_token: Arc::new(RwLock::new(None)),
+            default_access_token: Arc::new(RwLock::new(None)),
             impersonated_account_token: Arc::new(RwLock::new(None)),
             agent,
             logger,
@@ -447,40 +455,65 @@ impl GcpOauthTokenProvider {
         })
     }
 
-    /// Returns the current OAuth token for the default service account, if it
+    /// Returns the URL from which access tokens for the provided GCP service
+    /// account may be obtained.
+    /// API reference: https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
+    fn access_token_url_for_service_account(
+        base: &str,
+        service_account_to_impersonate: &str,
+    ) -> Result<Url> {
+        let request_url = format!(
+            "{}{}",
+            base,
+            Self::access_token_path_for_service_account(service_account_to_impersonate)
+        );
+
+        Url::parse(&request_url).context(format!("failed to parse: {}", request_url))
+    }
+
+    /// Returns the path relative to an API base URL from which access tokens for
+    /// the provided GCP service account may be obtained
+    fn access_token_path_for_service_account(service_account_to_impersonate: &str) -> String {
+        format!(
+            "/v1/projects/-/serviceAccounts/{}:generateAccessToken",
+            service_account_to_impersonate
+        )
+    }
+
+    /// Returns the current access token for the default service account, if it
     /// is valid. Otherwise obtains and returns a new one.
     /// The returned value is an owned reference because the token owned by this
     /// struct could change while the caller is still holding the returned token
-    fn ensure_default_account_token(&mut self) -> Result<String> {
-        if let Some(token) = &*self.default_account_token.read().unwrap() {
+    fn ensure_default_access_token(&self) -> Result<String> {
+        if let Some(token) = &*self.default_access_token.read().unwrap() {
             if !token.expired() {
-                debug!(self.logger, "cached default account token is still valid");
+                debug!(self.logger, "cached default access token is still valid");
                 return Ok(token.token.clone());
             }
         }
 
-        let mut default_account_token = self.default_account_token.write().unwrap();
+        let mut default_access_token = self.default_access_token.write().unwrap();
 
         // Check if the token was updated between when we dropped the read lock
         // and when we acquired the write lock
-        if let Some(token) = &*default_account_token {
+        if let Some(token) = &*default_access_token {
             if !token.expired() {
-                debug!(self.logger, "cached default account token is still valid");
+                debug!(self.logger, "cached default access token is still valid");
                 return Ok(token.token.clone());
             }
         }
 
-        let http_response = self.default_token_provider.default_token()?;
+        let http_response = self.default_token_provider.default_access_token()?;
 
         let response = http_response
-            .into_json::<OauthTokenResponse>()
+            .into_json::<AccessTokenResponse>()
             .context("failed to deserialize response from GCP token service")?;
 
         if response.token_type != "Bearer" {
             return Err(anyhow!("unexpected token type {}", response.token_type));
         }
 
-        *default_account_token = Some(OauthToken {
+        *default_access_token = Some(AccessToken {
             token: response.access_token.clone(),
             expiration: Utc::now() + Duration::seconds(response.expires_in),
         });
@@ -488,9 +521,9 @@ impl GcpOauthTokenProvider {
         Ok(response.access_token)
     }
 
-    /// Returns the current OAuth token for the impersonated service account, if
-    /// it is valid. Otherwise obtains and returns a new one.
-    fn ensure_impersonated_service_account_oauth_token(&mut self) -> Result<String> {
+    /// Returns the current access token for the impersonated service account,
+    /// if it is valid. Otherwise obtains and returns a new one.
+    fn ensure_impersonated_service_account_oauth_token(&self) -> Result<String> {
         if self.account_to_impersonate.is_none() {
             return Err(anyhow!("no service account to impersonate was provided"));
         }
@@ -505,17 +538,17 @@ impl GcpOauthTokenProvider {
             }
         }
 
-        let default_token = self.ensure_default_account_token()?;
+        let default_token = self.ensure_default_access_token()?;
         let mut impersonated_account_token = self.impersonated_account_token.write().unwrap();
         let service_account_to_impersonate = self.account_to_impersonate.clone().unwrap();
 
         let request = self.agent.prepare_request(RequestParameters {
-            url: access_token_url_for_service_account(
+            url: Self::access_token_url_for_service_account(
                 self.iam_service_base_url,
                 &service_account_to_impersonate,
             )?,
             method: Method::Post,
-            token_provider: Some(&mut StaticOauthTokenProvider::from(default_token)),
+            token_provider: Some(&mut StaticAccessTokenProvider::from(default_token)),
         })?;
 
         debug!(
@@ -533,19 +566,184 @@ impl GcpOauthTokenProvider {
                 }),
             )
             .context(format!(
-                "failed to get Oauth token to impersonate service account {}",
+                "failed to get access token to impersonate service account {}",
                 service_account_to_impersonate
             ))?;
 
         let response = http_response
             .into_json::<GenerateAccessTokenResponse>()
             .context("failed to deserialize response from IAM API")?;
-        *impersonated_account_token = Some(OauthToken {
+
+        *impersonated_account_token = Some(AccessToken {
             token: response.access_token.clone(),
             expiration: response.expire_time,
         });
 
         Ok(response.access_token)
+    }
+}
+
+/// Implementations of ProvideGcpIdentityToken obtain OpenID Connect identity
+/// tokens from some GCP server
+pub(crate) trait ProvideGcpIdentityToken: Debug + Send + Sync {
+    fn identity_token(&self) -> Result<String>;
+}
+
+/// Obtains identity tokens from the GKE metadata service for the workload's
+/// default service account. Used by workloads in GKE with Workload Identity
+/// configured.
+#[derive(Clone, Debug)]
+pub(crate) struct GkeMetadataServiceIdentityTokenProvider {
+    /// Base URL at which to access GKE metadata service
+    metadata_service_base_url: &'static str,
+    agent: RetryingAgent,
+    logger: Logger,
+}
+
+impl GkeMetadataServiceIdentityTokenProvider {
+    pub(crate) fn new(logger: Logger) -> Self {
+        Self {
+            metadata_service_base_url: DEFAULT_METADATA_BASE_URL,
+            agent: RetryingAgent::default(),
+            logger: logger.clone(),
+        }
+    }
+
+    /// Returns the GKE metadata service URL from which identity tokens for the
+    /// default GCP service account may be obtained.
+    fn default_identity_token_url(base: &str) -> Url {
+        let mut request_url =
+            Url::parse(base).expect("unable to parse metadata.google.internal url");
+        request_url.set_path(DEFAULT_IDENTITY_TOKEN_PATH);
+        request_url
+    }
+}
+
+impl ProvideGcpIdentityToken for GkeMetadataServiceIdentityTokenProvider {
+    fn identity_token(&self) -> Result<String> {
+        debug!(
+            self.logger,
+            "obtaining OIDC token from GKE metadata service"
+        );
+
+        let mut url = Self::default_identity_token_url(self.metadata_service_base_url);
+
+        url.query_pairs_mut()
+            .append_pair("audience", IDENTITY_TOKEN_AUDIENCE)
+            .finish();
+
+        let request = self
+            .agent
+            .prepare_request(RequestParameters {
+                url,
+                method: Method::Get,
+                ..Default::default()
+            })?
+            .set("Metadata-Flavor", "Google");
+
+        self.agent
+            .call(&self.logger, &request)
+            .context("failed to fetch identity token from metadata service")?
+            .into_string()
+            .context("failed to get response body from metadata service response")
+    }
+}
+
+/// The response from iamcredentials.googleapis.com's generateIdToken endpoint.
+/// API reference: https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateIdToken#response-body
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+struct GenerateIdTokenResponse {
+    token: String,
+}
+
+/// Obtains identity tokens from iamcredentials.googleapis.com for the specified
+/// GCP service account.
+#[derive(Clone, Debug)]
+pub(crate) struct ImpersonatedServiceAccountIdentityTokenProvider {
+    /// Email address of the GCP service account for which identity tokens are
+    /// to be obtained.
+    impersonated_service_account: String,
+    /// An access token provider for a service account with the permission
+    /// iam.serviceAccounts.getAccessToken on impersonated_service_account.
+    access_token_provider: Box<dyn AccessTokenProvider>,
+    /// Base URL at which to access GCP IAM service
+    iam_service_base_url: &'static str,
+    agent: RetryingAgent,
+    logger: Logger,
+}
+
+impl ImpersonatedServiceAccountIdentityTokenProvider {
+    pub(crate) fn new(
+        impersonated_service_account: String,
+        access_token_provider: GcpAccessTokenProvider,
+        logger: Logger,
+    ) -> Self {
+        Self {
+            impersonated_service_account,
+            access_token_provider: Box::new(access_token_provider),
+            iam_service_base_url: DEFAULT_IAM_BASE_URL,
+            agent: RetryingAgent::default(),
+            logger,
+        }
+    }
+
+    /// Returns the URL from which identity tokens for the provided GCP service
+    /// account may be obtained.
+    /// API reference: https://cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken
+    fn identity_token_url_for_service_account(&self) -> Result<Url> {
+        let request_url = format!(
+            "{}{}",
+            self.iam_service_base_url,
+            Self::identity_token_path_for_service_account(&self.impersonated_service_account)
+        );
+
+        Url::parse(&request_url).context(format!("failed to parse: {}", request_url))
+    }
+
+    /// Returns the path relative to an API base URL from which identity tokens for
+    /// the provided GCP service account may be obtained
+    fn identity_token_path_for_service_account(service_account_to_impersonate: &str) -> String {
+        format!(
+            "/v1/projects/-/serviceAccounts/{}:generateIdToken",
+            service_account_to_impersonate
+        )
+    }
+}
+
+impl ProvideGcpIdentityToken for ImpersonatedServiceAccountIdentityTokenProvider {
+    fn identity_token(&self) -> Result<String> {
+        debug!(
+            self.logger,
+            "obtaining identity token from IAM service";
+            "impersonated_service_account" => &self.impersonated_service_account,
+        );
+
+        let request = self.agent.prepare_request(RequestParameters {
+            url: self.identity_token_url_for_service_account()?,
+            method: Method::Post,
+            token_provider: Some(self.access_token_provider.as_ref()),
+        })?;
+
+        Ok(self
+            .agent
+            .send_json_request(
+                &self.logger,
+                &request,
+                &ureq::json!({
+                    "audience": IDENTITY_TOKEN_AUDIENCE,
+                    // By inspection, the identity tokens obtained from GKE metadata
+                    // include `email` and `email_verified` claims, so we request
+                    // those here for consistency
+                    "includeEmail": true,
+                }),
+            )
+            .context(format!(
+                "failed to get identity token to impersonate service account {}",
+                self.impersonated_service_account
+            ))?
+            .into_json::<GenerateIdTokenResponse>()
+            .context("failed to deserialize response from IAM API")?
+            .token)
     }
 }
 
@@ -561,7 +759,7 @@ mod tests {
     #[test]
     fn metadata_service_token() {
         let logger = setup_test_logging();
-        let mocked_get = mock("GET", DEFAULT_TOKEN_PATH)
+        let mocked_get = mock("GET", DEFAULT_ACCESS_TOKEN_PATH)
             .match_header("Metadata-Flavor", "Google")
             .with_status(200)
             .with_body(
@@ -576,16 +774,16 @@ mod tests {
             .expect(1)
             .create();
 
-        let provider = GkeMetadataServiceDefaultTokenProvider {
+        let provider = GkeMetadataServiceDefaultAccessTokenProvider {
             agent: RetryingAgent::default(),
             logger,
             metadata_service_base_url: leak_string(mockito::server_url()),
         };
 
         provider
-            .default_token()
+            .default_access_token()
             .unwrap()
-            .into_json::<OauthTokenResponse>()
+            .into_json::<AccessTokenResponse>()
             .unwrap();
         mocked_get.assert();
     }
@@ -648,26 +846,26 @@ jbxbE/VdW03+iXZyrnDNFAFAsRR+XgjeYheAUVLelg9qBjM7jYNf
             .expect(1)
             .create();
 
-        let provider = ServiceAccountKeyFileDefaultTokenProvider {
+        let provider = ServiceAccountKeyFileDefaultAccessTokenProvider {
             key_file,
             scope: "fake-scope".to_owned(),
             agent: RetryingAgent::default(),
             logger,
         };
         provider
-            .default_token()
+            .default_access_token()
             .unwrap()
-            .into_json::<OauthTokenResponse>()
+            .into_json::<AccessTokenResponse>()
             .unwrap();
 
         mocked_post.assert();
     }
 
     #[derive(Clone, Debug)]
-    struct FakeDefaultTokenProvider {}
+    struct FakeDefaultAccessTokenProvider {}
 
-    impl ProvideDefaultToken for FakeDefaultTokenProvider {
-        fn default_token(&self) -> Result<Response> {
+    impl ProvideDefaultAccessToken for FakeDefaultAccessTokenProvider {
+        fn default_access_token(&self) -> Result<Response> {
             Response::new(
                 200,
                 "OK",
@@ -688,7 +886,7 @@ jbxbE/VdW03+iXZyrnDNFAFAsRR+XgjeYheAUVLelg9qBjM7jYNf
         let logger = setup_test_logging();
 
         let access_token_path: &str =
-            &access_token_path_for_service_account("fake-service-account");
+            &GcpAccessTokenProvider::access_token_path_for_service_account("fake-service-account");
         let mocked_post_impersonated = mock("POST", access_token_path)
             .match_header("Authorization", "Bearer fake-default-token")
             .match_body(Matcher::Json(json!({"scope": ["fake-scope"] })))
@@ -704,11 +902,11 @@ jbxbE/VdW03+iXZyrnDNFAFAsRR+XgjeYheAUVLelg9qBjM7jYNf
             .expect(1)
             .create();
 
-        let mut provider = GcpOauthTokenProvider {
+        let provider = GcpAccessTokenProvider {
             scope: "fake-scope".to_string(),
-            default_token_provider: Box::new(FakeDefaultTokenProvider {}),
+            default_token_provider: Box::new(FakeDefaultAccessTokenProvider {}),
             account_to_impersonate: Some("fake-service-account".to_string()),
-            default_account_token: Arc::new(RwLock::new(None)),
+            default_access_token: Arc::new(RwLock::new(None)),
             impersonated_account_token: Arc::new(RwLock::new(None)),
             agent: RetryingAgent::default(),
             logger,

--- a/facilitator/src/http.rs
+++ b/facilitator/src/http.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use dyn_clone::DynClone;
 use slog::Logger;
 use std::{convert::From, default::Default, fmt::Debug, time::Duration};
 use ureq::{Agent, AgentBuilder, Request, Response, SerdeValue};
@@ -62,14 +63,14 @@ impl RetryingAgent {
     /// like `send()` or `send_bytes()` directly on the returned `Request`, but
     /// must use `RetryingAgent::send_json_request`, `::send_bytes` or
     /// `::send_string` to get retries.
-    /// Returns an Error if the OauthTokenProvider returns an error when
-    /// supplying the request with an OauthToken.
+    /// Returns an Error if the AccessTokenProvider returns an error when
+    /// supplying the request with an access token.
     pub(crate) fn prepare_request(&self, parameters: RequestParameters) -> Result<Request> {
         let mut request = self
             .agent
             .request_url(parameters.method.to_primitive_string(), &parameters.url);
         if let Some(token_provider) = parameters.token_provider {
-            let token = token_provider.ensure_oauth_token()?;
+            let token = token_provider.ensure_access_token()?;
             request = request.set("Authorization", &format!("Bearer {}", token));
         }
         Ok(request)
@@ -146,28 +147,30 @@ impl RetryingAgent {
 }
 
 /// Defines a behavior responsible for produing bearer authorization tokens
-pub(crate) trait OauthTokenProvider: Debug {
+pub(crate) trait AccessTokenProvider: Debug + DynClone + Send + Sync {
     /// Returns a valid bearer authroization token
-    fn ensure_oauth_token(&mut self) -> Result<String>;
+    fn ensure_access_token(&self) -> Result<String>;
 }
 
-/// StaticOauthTokenProvider is an OauthTokenProvider that contains a String
-/// as the token. This structure implements the OauthTokenProvider trait and can
+dyn_clone::clone_trait_object!(AccessTokenProvider);
+
+/// StaticAccessTokenProvider is an AccessTokenProvider that contains a String
+/// as the token. This structure implements the AccessTokenProvider trait and can
 /// be used in RequestParameters.
-#[derive(Debug)]
-pub(crate) struct StaticOauthTokenProvider {
+#[derive(Clone, Debug)]
+pub(crate) struct StaticAccessTokenProvider {
     pub token: String,
 }
 
-impl OauthTokenProvider for StaticOauthTokenProvider {
-    fn ensure_oauth_token(&mut self) -> Result<String> {
+impl AccessTokenProvider for StaticAccessTokenProvider {
+    fn ensure_access_token(&self) -> Result<String> {
         Ok(self.token.clone())
     }
 }
 
-impl From<String> for StaticOauthTokenProvider {
+impl From<String> for StaticAccessTokenProvider {
     fn from(token: String) -> Self {
-        StaticOauthTokenProvider { token }
+        StaticAccessTokenProvider { token }
     }
 }
 
@@ -179,9 +182,9 @@ pub(crate) struct RequestParameters<'a> {
     /// The method of the request (GET, POST, etc)
     pub method: Method,
     /// If this field is set, the request with be sent with an "Authorization"
-    /// header containing a bearer token obtained from the OauthTokenProvider.
+    /// header containing a bearer token obtained from the AccessTokenProvider.
     /// If unset, the request is sent unauthenticated.
-    pub token_provider: Option<&'a mut dyn OauthTokenProvider>,
+    pub token_provider: Option<&'a dyn AccessTokenProvider>,
 }
 
 impl Default for RequestParameters<'_> {
@@ -255,7 +258,7 @@ mod tests {
             .expect_at_most(1)
             .create();
 
-        let mut oauth_token_provider = StaticOauthTokenProvider {
+        let mut oauth_token_provider = StaticAccessTokenProvider {
             token: "fake-token".to_string(),
         };
 

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::Identity,
-    gcp_oauth::GcpOauthTokenProvider,
+    gcp_oauth::GcpAccessTokenProvider,
     http::{Method, RequestParameters, RetryingAgent},
     logging::event,
     task::{Task, TaskHandle, TaskQueue},
@@ -99,7 +99,7 @@ pub struct GcpPubSubTaskQueue<T: Task> {
     pubsub_api_endpoint: String,
     gcp_project_id: String,
     subscription_id: String,
-    oauth_token_provider: GcpOauthTokenProvider,
+    access_token_provider: GcpAccessTokenProvider,
     phantom_task: PhantomData<*const T>,
     agent: RetryingAgent,
     logger: Logger,
@@ -139,7 +139,7 @@ impl<T: Task> GcpPubSubTaskQueue<T> {
                 .to_owned(),
             gcp_project_id: gcp_project_id.to_string(),
             subscription_id: subscription_id.to_string(),
-            oauth_token_provider: GcpOauthTokenProvider::new(
+            access_token_provider: GcpAccessTokenProvider::new(
                 // This token is used to access PubSub API
                 // https://developers.google.com/identity/protocols/oauth2/scopes
                 "https://www.googleapis.com/auth/pubsub",
@@ -170,7 +170,7 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
                 &self.subscription_id,
             )?,
             method: Method::Post,
-            token_provider: Some(&mut self.oauth_token_provider),
+            token_provider: Some(&mut self.access_token_provider),
         })?;
 
         let http_response = self
@@ -233,7 +233,7 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
                 &self.subscription_id,
             )?,
             method: Method::Post,
-            token_provider: Some(&mut self.oauth_token_provider),
+            token_provider: Some(&mut self.access_token_provider),
         })?;
 
         self.agent
@@ -296,7 +296,7 @@ impl<T: Task> GcpPubSubTaskQueue<T> {
                 &self.subscription_id,
             )?,
             method: Method::Post,
-            token_provider: Some(&mut self.oauth_token_provider),
+            token_provider: Some(&mut self.access_token_provider),
         })?;
 
         self.agent

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -1,8 +1,8 @@
 use crate::{
     config::{GcsPath, Identity, WorkloadIdentityPoolParameters},
-    gcp_oauth::GcpOauthTokenProvider,
+    gcp_oauth::GcpAccessTokenProvider,
     http::{
-        Method, OauthTokenProvider, RequestParameters, RetryingAgent, StaticOauthTokenProvider,
+        AccessTokenProvider, Method, RequestParameters, RetryingAgent, StaticAccessTokenProvider,
     },
     logging::event,
     transport::{Transport, TransportWriter},
@@ -46,7 +46,7 @@ fn gcp_upload_object_url(storage_api_url: &str, bucket: &str) -> Result<Url> {
 #[derive(Debug)]
 pub struct GcsTransport {
     path: GcsPath,
-    oauth_token_provider: GcpOauthTokenProvider,
+    oauth_token_provider: GcpAccessTokenProvider,
     agent: RetryingAgent,
     logger: Logger,
 }
@@ -83,7 +83,7 @@ impl GcsTransport {
         );
         Ok(GcsTransport {
             path: path.ensure_directory_prefix(),
-            oauth_token_provider: GcpOauthTokenProvider::new(
+            oauth_token_provider: GcpAccessTokenProvider::new(
                 // This token is used to access GCS storage
                 // https://developers.google.com/identity/protocols/oauth2/scopes#storage
                 "https://www.googleapis.com/auth/devstorage.read_write",
@@ -148,7 +148,7 @@ impl Transport for GcsTransport {
         // expiring during the lifetime of that object, and so obtain a token
         // here instead of passing the token provider into the
         // StreamingTransferWriter.
-        let oauth_token = self.oauth_token_provider.ensure_oauth_token()?;
+        let oauth_token = self.oauth_token_provider.ensure_access_token()?;
         let writer = StreamingTransferWriter::new(
             self.path.bucket.to_owned(),
             [&self.path.key, key].concat(),
@@ -240,7 +240,7 @@ impl StreamingTransferWriter {
         let request = agent.prepare_request(RequestParameters {
             url: upload_url,
             method: Method::Post,
-            token_provider: Some(&mut StaticOauthTokenProvider::from(oauth_token)),
+            token_provider: Some(&mut StaticAccessTokenProvider::from(oauth_token)),
         })?;
 
         let http_response = agent

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -241,7 +241,7 @@ resource "aws_iam_role" "bucket_role" {
   # Since azp is set in the auth token Google generates, we must check oaud in
   # the role assumption policy, and the value must match what we request when
   # requesting tokens from the GKE metadata service in
-  # S3Transport::new_with_client
+  # GkeMetadataServiceIdentityTokenProvider::identity_token
   # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html
   assume_role_policy = <<ROLE
 {
@@ -256,7 +256,7 @@ resource "aws_iam_role" "bucket_role" {
       "Condition": {
         "StringEquals": {
           "accounts.google.com:sub": "${module.kubernetes.service_account_unique_id}",
-          "accounts.google.com:oaud": "sts.amazonaws.com/${data.aws_caller_identity.current.account_id}"
+          "accounts.google.com:oaud": "sts.amazonaws.com/gke-identity-federation"
         }
       }
     }

--- a/workflow-manager/aws/aws.go
+++ b/workflow-manager/aws/aws.go
@@ -7,7 +7,6 @@ import (
 	"github.com/letsencrypt/prio-server/workflow-manager/tokenfetcher"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -15,16 +14,10 @@ import (
 )
 
 func webIDP(sess *session.Session, identity string) (*credentials.Credentials, error) {
-	parsed, err := arn.Parse(identity)
-	if err != nil {
-		return nil, err
-	}
-	audience := fmt.Sprintf("sts.amazonaws.com/%s", parsed.AccountID)
-
 	stsSTS := sts.New(sess)
 	roleSessionName := ""
 	roleProvider := stscreds.NewWebIdentityRoleProviderWithToken(
-		stsSTS, identity, roleSessionName, tokenfetcher.NewTokenFetcher(audience))
+		stsSTS, identity, roleSessionName, tokenfetcher.NewTokenFetcher("sts.amazonaws.com/gke-identity-federation"))
 
 	return credentials.NewCredentials(roleProvider), nil
 }


### PR DESCRIPTION
`facilitator` was already capable of assuming AWS IAM roles when running
in GKE using `sts:AssumeRoleWithWebIdentity`, but it required that the
GCP SA mapped to the `facilitator`'s Kubernetes service account be
permitted to assume the role. This change enables `facilitator` to be
configured with an AWS IAM role to assume _and_ a GCP service account to
impersonate to do it. `facilitator` will get an _access_ token for the
default GCP service account, then use that to obtain an _identity_ token
for the specified GCP SA, then finally use that in a request to
`sts:AssumeRoleWithWebIdentity`.

On the way there, we do some cleanup in `gcp_oauth.rs` to clearly
distinguish between code that handles access tokens and code that
handles OpenID Connect identity/ID tokens, as previously all of these
were ambiguously referred to as "tokens" or "Oauth tokens".

Finally, we tweak the audience/`aud` value used in OIDC ID tokens:
previously we would use `sts.amazonaws.com/<aws-account-id>`, but this
doesn't achieve much and will make #747 more of a headache, so we now
use a fixed string instead when creating the role. Besides Terraform and
`facilitator`, this is reflected in the change to
`workflow-manager/aws/aws.go`.

Part of #747