### PR TITLE
facilitator: beef up config::Identity type

### DIFF
--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -101,7 +101,7 @@ impl Provider {
         purpose: &str,
         logger: &Logger,
     ) -> Result<Self> {
-        match (use_default_provider, identity) {
+        match (use_default_provider, identity.as_str()) {
             (true, _) => Self::new_default(),
             (_, Some(identity)) => {
                 Self::new_web_identity_with_oidc(identity, purpose.to_owned(), logger)

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -116,7 +116,7 @@ impl<T: Task> GcpPubSubTaskQueue<T> {
         let logger = parent_logger.new(o!(
             "gcp_project_id" => gcp_project_id.to_owned(),
             event::TASK_QUEUE_ID => subscription_id.to_owned(),
-            event::IDENTITY => identity.unwrap_or("default identity").to_owned(),
+            event::IDENTITY => identity.to_string(),
         ));
         let ureq_agent = AgentBuilder::new()
             // Empirically, if there are no messages available in the
@@ -143,7 +143,7 @@ impl<T: Task> GcpPubSubTaskQueue<T> {
                 // This token is used to access PubSub API
                 // https://developers.google.com/identity/protocols/oauth2/scopes
                 "https://www.googleapis.com/auth/pubsub",
-                identity.map(|x| x.to_string()),
+                identity,
                 // GCP key file; None because PubSub is only used if the
                 // workload is on GKE
                 None,

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -66,7 +66,7 @@ impl GcsTransport {
     ) -> Result<Self> {
         let logger = parent_logger.new(o!(
             event::STORAGE_PATH => path.to_string(),
-            event::IDENTITY => identity.unwrap_or("default identity").to_owned(),
+            event::IDENTITY => identity.to_string(),
         ));
         let ureq_agent = AgentBuilder::new()
             // We set an unusually long timeout for uploads to GCS, per Google's
@@ -87,7 +87,7 @@ impl GcsTransport {
                 // This token is used to access GCS storage
                 // https://developers.google.com/identity/protocols/oauth2/scopes#storage
                 "https://www.googleapis.com/auth/devstorage.read_write",
-                identity.map(|x| x.to_string()),
+                identity,
                 key_file_reader,
                 workload_identity_pool_params,
                 &logger,


### PR DESCRIPTION
This commit enhances the existing `config::Identity` type to make it
into a struct wrapping an `Option<String>`. The goal is to abstract away
the special handling of the value `Some("")` as being equivalent to
`None` and make it easier to use `Identity` throughout the crate instead
of passing AWS role ARNs and GCP service account emails as
`Option<&str>` or `Option<String>` in various places. This will make
things more clear when a subsequent commit introduces support for AWS
authentication flows that first require authenticating to GCP, and so
`aws_credentials::Provider` will have to manage more than one identity.

We provide `std::str::FromStr` and `serde::Deserialize` implementations
on `config::Identity` to allow for graceful instantiation of `Identity`
from program arguments or JSON manifests. Along the way, we make some
improvements to the defintions in `manifest.rs` to use `Identity` and
`StoragePath` instead of `Option<String>` and `String`.