### PR TITLE
actions: enable tests on all pull requests

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main, release/** ]
   pull_request:
-    branches: [ main, release/** ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/deploy-tool-build.yml
+++ b/.github/workflows/deploy-tool-build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main, release/** ]
   pull_request:
-    branches: [ main, release/** ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Changes `on.pull_request.branches` so that PRs targeting branches
besides `[main, release/**]` will trigger CI, enabling automated tests
on stacked PRs.