### PR TITLE
facilitator: use GCP SA to assume IAM role

### DIFF
--- a/facilitator/src/config.rs
+++ b/facilitator/src/config.rs
@@ -62,6 +62,14 @@ impl Identity {
     pub(crate) fn as_str(&self) -> Option<&str> {
         self.inner.as_deref()
     }
+
+    pub(crate) fn is_some(&self) -> bool {
+        self.inner.is_some()
+    }
+
+    pub(crate) fn is_none(&self) -> bool {
+        self.inner.is_none()
+    }
 }
 
 /// Parameters necessary to configure federation from AWS IAM to GCP IAM using
@@ -94,9 +102,11 @@ impl WorkloadIdentityPoolParameters {
             Some(provider_id) => Some(Self {
                 workload_identity_pool_provider: provider_id.to_owned(),
                 aws_credentials_provider: aws_credentials::Provider::new(
-                    // We create this provider with no identity, effectively
-                    // requiring that the authentication to AWS use either
-                    // ambient AWS credentials or an EKS cluster OIDC provider.
+                    // We create this provider with no identity and no
+                    // impersonated GCP service account, requiring that the
+                    // authentication to AWS use either ambient AWS credentials
+                    // or an EKS cluster OIDC provider.
+                    Identity::none(),
                     Identity::none(),
                     use_default_aws_credentials_provider,
                     "IAM federation",
@@ -382,7 +392,7 @@ mod tests {
 
     #[test]
     fn identity() {
-        assert!(Identity::from_str("").unwrap().as_str().is_none());
+        assert!(Identity::from_str("").unwrap().is_none());
 
         assert_eq!(
             Identity::from_str("identity").unwrap().as_str(),

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -241,7 +241,7 @@ resource "aws_iam_role" "bucket_role" {
   # Since azp is set in the auth token Google generates, we must check oaud in
   # the role assumption policy, and the value must match what we request when
   # requesting tokens from the GKE metadata service in
-  # S3Transport::new_with_client
+  # GkeMetadataServiceIdentityTokenProvider::identity_token
   # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html
   assume_role_policy = <<ROLE
 {
@@ -256,7 +256,7 @@ resource "aws_iam_role" "bucket_role" {
       "Condition": {
         "StringEquals": {
           "accounts.google.com:sub": "${module.kubernetes.service_account_unique_id}",
-          "accounts.google.com:oaud": "sts.amazonaws.com/${data.aws_caller_identity.current.account_id}"
+          "accounts.google.com:oaud": "sts.amazonaws.com/gke-identity-federation"
         }
       }
     }

--- a/workflow-manager/aws/aws.go
+++ b/workflow-manager/aws/aws.go
@@ -7,7 +7,6 @@ import (
 	"github.com/letsencrypt/prio-server/workflow-manager/tokenfetcher"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -15,16 +14,10 @@ import (
 )
 
 func webIDP(sess *session.Session, identity string) (*credentials.Credentials, error) {
-	parsed, err := arn.Parse(identity)
-	if err != nil {
-		return nil, err
-	}
-	audience := fmt.Sprintf("sts.amazonaws.com/%s", parsed.AccountID)
-
 	stsSTS := sts.New(sess)
 	roleSessionName := ""
 	roleProvider := stscreds.NewWebIdentityRoleProviderWithToken(
-		stsSTS, identity, roleSessionName, tokenfetcher.NewTokenFetcher(audience))
+		stsSTS, identity, roleSessionName, tokenfetcher.NewTokenFetcher("sts.amazonaws.com/gke-identity-federation"))
 
 	return credentials.NewCredentials(roleProvider), nil
 }


### PR DESCRIPTION
`facilitator` was already capable of assuming AWS IAM roles when running
in GKE using `sts:AssumeRoleWithWebIdentity`, but it required that the
GCP SA mapped to the `facilitator`'s Kubernetes service account be
permitted to assume the role. This change enables `facilitator` to be
configured with an AWS IAM role to assume _and_ a GCP service account to
impersonate to do it. `facilitator` will get an _access_ token for the
default GCP service account, then use that to obtain an _identity_ token
for the specified GCP SA, then finally use that in a request to
`sts:AssumeRoleWithWebIdentity`.

On the way there, we do some cleanup in `gcp_oauth.rs` to clearly
distinguish between code that handles access tokens and code that
handles OpenID Connect identity/ID tokens, as previously all of these
were ambiguously referred to as "tokens" or "Oauth tokens".

Finally, we tweak the audience/`aud` value used in OIDC ID tokens:
previously we would use `sts.amazonaws.com/<aws-account-id>`, but this
doesn't achieve much and will make #747 more of a headache, so we now
use a fixed string instead when creating the role. Besides Terraform and
`facilitator`, this is reflected in the change to
`workflow-manager/aws/aws.go`.

Part of #747