### PR TITLE
facilitator: TaskQueue doesn't need &mut self

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -1390,7 +1390,7 @@ fn intake_batch_worker(
     let metrics_collector = IntakeMetricsCollector::new()?;
     let scrape_port = value_t!(sub_matches.value_of("metrics-scrape-port"), u16)?;
     let _runtime = start_metrics_scrape_endpoint(scrape_port, parent_logger)?;
-    let mut queue = intake_task_queue_from_args(sub_matches, parent_logger)?;
+    let queue = intake_task_queue_from_args(sub_matches, parent_logger)?;
 
     crypto_self_check(sub_matches, parent_logger).context("crypto self check failed")?;
 
@@ -1663,7 +1663,7 @@ fn aggregate_subcommand(
 }
 
 fn aggregate_worker(sub_matches: &ArgMatches, parent_logger: &Logger) -> Result<(), anyhow::Error> {
-    let mut queue = aggregation_task_queue_from_args(sub_matches, parent_logger)?;
+    let queue = aggregation_task_queue_from_args(sub_matches, parent_logger)?;
     let metrics_collector = AggregateMetricsCollector::new()?;
     let scrape_port = value_t!(sub_matches.value_of("metrics-scrape-port"), u16)?;
     let _runtime = start_metrics_scrape_endpoint(scrape_port, parent_logger)?;

--- a/facilitator/src/task.rs
+++ b/facilitator/src/task.rs
@@ -23,29 +23,25 @@ pub trait TaskQueue<T: Task>: Debug {
     /// passed to acknowledge_task to permanently remove the task. If
     /// acknowledge_task is never called, the task will eventually be
     /// re-delivered via dequeue().
-    fn dequeue(&mut self) -> Result<Option<TaskHandle<T>>>;
+    fn dequeue(&self) -> Result<Option<TaskHandle<T>>>;
 
     /// Signal to the task queue that the task has been handled and should be
     /// removed from the queue.
-    fn acknowledge_task(&mut self, handle: TaskHandle<T>) -> Result<()>;
+    fn acknowledge_task(&self, handle: TaskHandle<T>) -> Result<()>;
 
     /// Signal to the task queue that the task was not handled and should be
     /// retried later.
-    fn nacknowledge_task(&mut self, handle: TaskHandle<T>) -> Result<()>;
+    fn nacknowledge_task(&self, handle: TaskHandle<T>) -> Result<()>;
 
     /// Signal to the task queue that more time is needed to handle the task.
-    fn extend_task_deadline(&mut self, handle: &TaskHandle<T>, increment: &Duration) -> Result<()>;
+    fn extend_task_deadline(&self, handle: &TaskHandle<T>, increment: &Duration) -> Result<()>;
 
     /// Extend the deadline for the provided task if enough time has elapsed
     /// since the start of handling the task to require an extension. Returns
     /// Ok(()) if either the task deadline does not need extension or if the
     /// deadline was successfully extended, or an error if something goes wrong
     /// extending the deadline.
-    fn maybe_extend_task_deadline(
-        &mut self,
-        handle: &TaskHandle<T>,
-        elapsed: &Duration,
-    ) -> Result<()> {
+    fn maybe_extend_task_deadline(&self, handle: &TaskHandle<T>, elapsed: &Duration) -> Result<()> {
         // We assume that 10 minutes is a reasonable deadline increment
         // regardless of queue implementation or what the task is. In the future
         // this could be a tunable parameter on facilitator.

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -158,7 +158,7 @@ impl<T: Task> GcpPubSubTaskQueue<T> {
 }
 
 impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
-    fn dequeue(&mut self) -> Result<Option<TaskHandle<T>>> {
+    fn dequeue(&self) -> Result<Option<TaskHandle<T>>> {
         info!(self.logger, "pull task");
 
         let request = self.agent.prepare_request(RequestParameters {
@@ -218,7 +218,7 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
         Ok(Some(handle))
     }
 
-    fn acknowledge_task(&mut self, handle: TaskHandle<T>) -> Result<()> {
+    fn acknowledge_task(&self, handle: TaskHandle<T>) -> Result<()> {
         let logger = self.logger.new(o!(
             event::TASK_ACKNOWLEDGEMENT_ID => handle.acknowledgment_id.to_owned(),
         ));
@@ -247,7 +247,7 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
         Ok(())
     }
 
-    fn nacknowledge_task(&mut self, handle: TaskHandle<T>) -> Result<()> {
+    fn nacknowledge_task(&self, handle: TaskHandle<T>) -> Result<()> {
         info!(
             self.logger, "nacknowledging task";
             event::TASK_ACKNOWLEDGEMENT_ID => &handle.acknowledgment_id,
@@ -257,7 +257,7 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
             .context("failed to nacknowledge task")
     }
 
-    fn extend_task_deadline(&mut self, handle: &TaskHandle<T>, increment: &Duration) -> Result<()> {
+    fn extend_task_deadline(&self, handle: &TaskHandle<T>, increment: &Duration) -> Result<()> {
         info!(
             self.logger, "extending deadline on task";
             event::TASK_ACKNOWLEDGEMENT_ID => &handle.acknowledgment_id,
@@ -271,11 +271,7 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
 impl<T: Task> GcpPubSubTaskQueue<T> {
     /// Changes the ack deadline on the message described by the task handle,
     /// resetting it to the provided duration.
-    fn modify_ack_deadline(
-        &mut self,
-        handle: &TaskHandle<T>,
-        ack_deadline: &Duration,
-    ) -> Result<()> {
+    fn modify_ack_deadline(&self, handle: &TaskHandle<T>, ack_deadline: &Duration) -> Result<()> {
         let logger = self.logger.new(o!(
             event::TASK_ACKNOWLEDGEMENT_ID => handle.acknowledgment_id.to_owned(),
         ));

--- a/facilitator/src/task/sqs.rs
+++ b/facilitator/src/task/sqs.rs
@@ -54,7 +54,7 @@ impl<T: Task> AwsSqsTaskQueue<T> {
 }
 
 impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
-    fn dequeue(&mut self) -> Result<Option<TaskHandle<T>>> {
+    fn dequeue(&self) -> Result<Option<TaskHandle<T>>> {
         info!(self.logger, "pull task");
 
         let client = self.sqs_client()?;
@@ -116,7 +116,7 @@ impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
         }))
     }
 
-    fn acknowledge_task(&mut self, task: TaskHandle<T>) -> Result<()> {
+    fn acknowledge_task(&self, task: TaskHandle<T>) -> Result<()> {
         info!(
             self.logger, "acknowledging task";
             event::TASK_ACKNOWLEDGEMENT_ID => &task.acknowledgment_id,
@@ -139,7 +139,7 @@ impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
         .context("failed to delete/acknowledge message in SQS")
     }
 
-    fn nacknowledge_task(&mut self, task: TaskHandle<T>) -> Result<()> {
+    fn nacknowledge_task(&self, task: TaskHandle<T>) -> Result<()> {
         // In SQS, messages are nacked by changing the message visibility
         // timeout to 0
         // https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html#terminating-message-visibility-timeout
@@ -152,7 +152,7 @@ impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
             .context("failed to nacknowledge task")
     }
 
-    fn extend_task_deadline(&mut self, task: &TaskHandle<T>, increment: &Duration) -> Result<()> {
+    fn extend_task_deadline(&self, task: &TaskHandle<T>, increment: &Duration) -> Result<()> {
         info!(
             self.logger, "extending deadline on task by 10 minutes";
             event::TASK_ACKNOWLEDGEMENT_ID => &task.acknowledgment_id,
@@ -184,7 +184,7 @@ impl<T: Task> AwsSqsTaskQueue<T> {
     /// Changes the message visibility of the SQS message described by the TaskHandle, resetting it
     /// to the specified visibility timeout.
     fn change_message_visibility(
-        &mut self,
+        &self,
         task: &TaskHandle<T>,
         visibility_timeout: &Duration,
     ) -> Result<()> {


### PR DESCRIPTION
Due to recent advances in the science of credential obtention, we no
longer need methods on `TaskQueue` implementations to take `&mut self`.
This commit updates various method signatures to take immutable
references and fixes up the call sites.
