### PR TITLE
facilitator: cloneable `Transport` impls

### DIFF
--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -230,6 +230,14 @@ impl Display for Provider {
     }
 }
 
+impl Debug for Provider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Provider")
+            .field("credential_source", &self.to_string())
+            .finish()
+    }
+}
+
 #[async_trait]
 impl ProvideAwsCredentials for Provider {
     async fn credentials(&self) -> Result<AwsCredentials, CredentialsError> {

--- a/facilitator/src/metrics.rs
+++ b/facilitator/src/metrics.rs
@@ -60,7 +60,7 @@ fn handle_scrape() -> Result<Vec<u8>> {
 }
 
 /// A group of collectors for intake tasks.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct IntakeMetricsCollector {
     pub intake_tasks_started: IntCounter,
     pub intake_tasks_finished: IntCounterVec,
@@ -88,7 +88,7 @@ impl IntakeMetricsCollector {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AggregateMetricsCollector {
     pub aggregate_tasks_started: IntCounter,
     pub aggregate_tasks_finished: IntCounterVec,
@@ -120,7 +120,7 @@ impl AggregateMetricsCollector {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BatchReaderMetricsCollector {
     pub invalid_validation_batches: IntCounterVec,
 }

--- a/facilitator/src/transport.rs
+++ b/facilitator/src/transport.rs
@@ -5,6 +5,7 @@ mod s3;
 use crate::{manifest::BatchSigningPublicKeys, BatchSigningKey};
 use anyhow::Result;
 use derivative::Derivative;
+use dyn_clone::{clone_trait_object, DynClone};
 use prio::encrypt::PrivateKey;
 use std::{
     boxed::Box,
@@ -18,7 +19,7 @@ pub use local::LocalFileTransport;
 
 /// A transport along with the public keys that can be used to verify signatures
 /// on the batches read from the transport.
-#[derive(Derivative)]
+#[derive(Clone, Derivative)]
 #[derivative(Debug)]
 pub struct VerifiableTransport {
     pub transport: Box<dyn Transport>,
@@ -26,7 +27,7 @@ pub struct VerifiableTransport {
     pub batch_signing_public_keys: BatchSigningPublicKeys,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct VerifiableAndDecryptableTransport {
     pub transport: VerifiableTransport,
     pub packet_decryption_keys: Vec<PrivateKey>,
@@ -69,7 +70,7 @@ impl<T: TransportWriter + ?Sized> TransportWriter for Box<T> {
 /// provided as parameters to these methods rather than being fields on the
 /// Transport's own Logger because a single Transport could be re-used across
 /// many tasks.
-pub trait Transport: Debug {
+pub trait Transport: Debug + DynClone + Send {
     /// Returns an std::io::Read instance from which the contents of the value
     /// of the provided key may be read.
     fn get(&mut self, key: &str, trace_id: &str) -> Result<Box<dyn Read>>;
@@ -79,3 +80,5 @@ pub trait Transport: Debug {
 
     fn path(&self) -> String;
 }
+
+clone_trait_object!(Transport);

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -43,7 +43,7 @@ fn gcp_upload_object_url(storage_api_url: &str, bucket: &str) -> Result<Url> {
 /// struct can either use the default service account from the metadata service,
 /// or can impersonate another GCP service account if one is provided to
 /// GCSTransport::new.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct GcsTransport {
     path: GcsPath,
     oauth_token_provider: GcpAccessTokenProvider,

--- a/facilitator/src/transport/local.rs
+++ b/facilitator/src/transport/local.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 /// A transport implementation backed by the local filesystem.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LocalFileTransport {
     directory: PathBuf,
 }

--- a/facilitator/src/transport/s3.rs
+++ b/facilitator/src/transport/s3.rs
@@ -18,6 +18,7 @@ use rusoto_s3::{
 };
 use slog::{debug, info, o, Logger};
 use std::{
+    fmt::Debug,
     io::{Read, Write},
     mem,
     pin::Pin,
@@ -29,81 +30,87 @@ use tokio::{
 };
 
 /// ClientProvider allows mocking out a client for testing.
-type ClientProvider = Box<dyn Fn(&Region, aws_credentials::Provider) -> Result<S3Client>>;
+pub trait ClientProvider: Debug + Sized + Clone + Send {
+    fn provide_client(&self) -> Result<S3Client>;
+}
+
+#[derive(Clone, Debug)]
+pub struct ClientProviderImpl {
+    region: Region,
+    credentials_provider: aws_credentials::Provider,
+}
+
+impl ClientProvider for ClientProviderImpl {
+    fn provide_client(&self) -> Result<S3Client> {
+        // Rusoto uses Hyper which uses connection pools. The default
+        // timeout for those connections is 90 seconds[1]. Amazon S3's
+        // API closes idle client connections after 20 seconds[2]. If we
+        // use a default client via S3Client::new, this mismatch causes
+        // uploads to fail when Hyper tries to re-use a connection that
+        // has been idle too long. Until this is fixed in Rusoto[3], we
+        // construct our own HTTP request dispatcher whose underlying
+        // hyper::Client is configured to timeout idle connections after
+        // 10 seconds.
+        //
+        // [1]: https://docs.rs/hyper/0.13.8/hyper/client/struct.Builder.html#method.pool_idle_timeout
+        // [2]: https://aws.amazon.com/premiumsupport/knowledge-center/s3-socket-connection-timeout-error/
+        // [3]: https://github.com/rusoto/rusoto/issues/1686
+        let mut builder = hyper::Client::builder();
+        builder.pool_idle_timeout(Duration::from_secs(10));
+        let connector = HttpsConnector::with_native_roots();
+        let http_client = rusoto_core::HttpClient::from_builder(builder, connector);
+
+        Ok(S3Client::new_with(
+            http_client,
+            self.credentials_provider.clone(),
+            self.region.clone(),
+        ))
+    }
+}
 
 /// Implementation of Transport that reads and writes objects from Amazon S3.
-#[derive(Derivative)]
-#[derivative(Debug)]
-pub struct S3Transport {
+#[derive(Clone, Debug)]
+pub struct S3Transport<P: ClientProvider> {
     path: S3Path,
-    #[derivative(Debug = "ignore")]
-    credentials_provider: aws_credentials::Provider,
-    // client_provider allows injection of mock S3Client for testing purposes
-    #[derivative(Debug = "ignore")]
-    client_provider: ClientProvider,
+    client_provider: P,
     logger: Logger,
 }
 
-impl S3Transport {
+impl S3Transport<ClientProviderImpl> {
     pub fn new(
         path: S3Path,
         credentials_provider: aws_credentials::Provider,
         parent_logger: &Logger,
     ) -> Self {
+        let logger = parent_logger.new(o!(
+            event::IDENTITY => credentials_provider.to_string(),
+        ));
+        let region = path.region.clone();
         S3Transport::new_with_client(
             path,
-            credentials_provider,
-            Box::new(
-                |region: &Region, credentials_provider: aws_credentials::Provider| {
-                    // Rusoto uses Hyper which uses connection pools. The default
-                    // timeout for those connections is 90 seconds[1]. Amazon S3's
-                    // API closes idle client connections after 20 seconds[2]. If we
-                    // use a default client via S3Client::new, this mismatch causes
-                    // uploads to fail when Hyper tries to re-use a connection that
-                    // has been idle too long. Until this is fixed in Rusoto[3], we
-                    // construct our own HTTP request dispatcher whose underlying
-                    // hyper::Client is configured to timeout idle connections after
-                    // 10 seconds.
-                    //
-                    // [1]: https://docs.rs/hyper/0.13.8/hyper/client/struct.Builder.html#method.pool_idle_timeout
-                    // [2]: https://aws.amazon.com/premiumsupport/knowledge-center/s3-socket-connection-timeout-error/
-                    // [3]: https://github.com/rusoto/rusoto/issues/1686
-                    let mut builder = hyper::Client::builder();
-                    builder.pool_idle_timeout(Duration::from_secs(10));
-                    let connector = HttpsConnector::with_native_roots();
-                    let http_client = rusoto_core::HttpClient::from_builder(builder, connector);
-
-                    Ok(S3Client::new_with(
-                        http_client,
-                        credentials_provider,
-                        region.clone(),
-                    ))
-                },
-            ),
-            parent_logger,
+            ClientProviderImpl {
+                region,
+                credentials_provider,
+            },
+            &logger,
         )
     }
+}
 
-    fn new_with_client(
-        path: S3Path,
-        credentials_provider: aws_credentials::Provider,
-        client_provider: ClientProvider,
-        parent_logger: &Logger,
-    ) -> Self {
+impl<P: ClientProvider> S3Transport<P> {
+    fn new_with_client(path: S3Path, client_provider: P, parent_logger: &Logger) -> Self {
         let logger = parent_logger.new(o!(
             event::STORAGE_PATH => path.to_string(),
-            event::IDENTITY => credentials_provider.to_string(),
         ));
         S3Transport {
             path: path.ensure_directory_prefix(),
-            credentials_provider,
             client_provider,
             logger,
         }
     }
 }
 
-impl Transport for S3Transport {
+impl<P: ClientProvider> Transport for S3Transport<P> {
     fn path(&self) -> String {
         self.path.to_string()
     }
@@ -116,7 +123,7 @@ impl Transport for S3Transport {
         ));
         info!(logger, "get");
         let runtime = basic_runtime()?;
-        let client = (self.client_provider)(&self.path.region, self.credentials_provider.clone())?;
+        let client = self.client_provider.provide_client()?;
 
         let get_output = retry_request(&logger, || {
             runtime.block_on(client.get_object(GetObjectRequest {
@@ -144,7 +151,7 @@ impl Transport for S3Transport {
             // Set buffer size to 5 MB, which is the minimum required by Amazon
             // https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
             5_242_880,
-            (self.client_provider)(&self.path.region, self.credentials_provider.clone())?,
+            self.client_provider.provide_client()?,
             &logger,
         )?;
         Ok(Box::new(writer))
@@ -400,6 +407,7 @@ impl TransportWriter for MultipartUploadWriter {
 mod tests {
     use super::*;
     use crate::logging::setup_test_logging;
+    use derivative::Derivative;
     use rusoto_core::{request::HttpDispatchError, signature::SignedRequest};
     use rusoto_mock::{MockRequestDispatcher, MultipleMockRequestDispatcher};
     use rusoto_s3::CreateMultipartUploadError;
@@ -732,6 +740,56 @@ mod tests {
         writer.complete_upload().unwrap_err();
     }
 
+    // Rusoto's MockRequestDispatcher and MultipleMockRequestDispatcher do not
+    // implement Clone so we must provide something that does, from which we can
+    // instantiate the mock dispatchers.
+    #[derive(Clone)]
+    struct MockRequest<F: Fn(&SignedRequest) + Send + Sync + Clone + 'static> {
+        status: u16,
+        request_checker: F,
+        header: Option<(&'static str, &'static str)>,
+        body: Option<&'static str>,
+    }
+
+    #[derive(Clone, Derivative)]
+    #[derivative(Debug)]
+    struct MockClientProvider<F: Fn(&SignedRequest) + Send + Sync + Clone + 'static> {
+        region: Region,
+        credentials_provider: aws_credentials::Provider,
+        #[derivative(Debug = "ignore")]
+        requests: Vec<MockRequest<F>>,
+    }
+
+    impl<F: Fn(&SignedRequest) + Send + Sync + Clone + 'static> ClientProvider
+        for MockClientProvider<F>
+    {
+        fn provide_client(&self) -> Result<S3Client> {
+            let mock_dispatchers: Vec<MockRequestDispatcher> = self
+                .requests
+                .iter()
+                .map(|r| {
+                    let mut mock_dispatcher = MockRequestDispatcher::with_status(r.status)
+                        .with_request_checker(r.request_checker.clone());
+
+                    if let Some(header) = r.header {
+                        mock_dispatcher = mock_dispatcher.with_header(header.0, header.1);
+                    }
+                    if let Some(body) = r.body {
+                        mock_dispatcher = mock_dispatcher.with_body(body);
+                    }
+
+                    mock_dispatcher
+                })
+                .collect();
+
+            Ok(S3Client::new_with(
+                MultipleMockRequestDispatcher::new(mock_dispatchers),
+                self.credentials_provider.clone(),
+                self.region.clone(),
+            ))
+        }
+    }
+
     #[test]
     fn roundtrip_s3_transport() {
         let logger = setup_test_logging();
@@ -741,44 +799,37 @@ mod tests {
             key: "".into(),
         };
 
-        let client_provider = Box::new(
-            |region: &Region, credentials_provider: aws_credentials::Provider| {
-                Ok(S3Client::new_with(
-                    // Failed GetObject request
-                    MockRequestDispatcher::with_status(404)
-                        .with_request_checker(is_get_object_request),
-                    credentials_provider,
-                    region.clone(),
-                ))
-            },
-        );
-        let mut transport = S3Transport::new_with_client(
-            s3_path.clone(),
-            aws_credentials::Provider::new_mock(),
-            client_provider,
-            &logger,
-        );
+        let client_provider = MockClientProvider {
+            region: Region::UsWest2,
+            credentials_provider: aws_credentials::Provider::new_mock(),
+            requests: vec![MockRequest {
+                status: 404,
+                request_checker: is_get_object_request,
+                header: None,
+                body: None,
+            }],
+        };
+
+        let mut transport = S3Transport::new_with_client(s3_path.clone(), client_provider, &logger);
 
         let ret = transport.get(TEST_KEY, "trace-id");
         assert!(ret.is_err(), "unexpected return value {:?}", ret.err());
 
-        let mut transport = S3Transport::new_with_client(
-            s3_path.clone(),
-            aws_credentials::Provider::new_mock(),
-            Box::new(
-                |region: &Region, credentials_provider: aws_credentials::Provider| {
-                    Ok(S3Client::new_with(
-                        // Successful GetObject request
-                        MockRequestDispatcher::with_status(200)
-                            .with_request_checker(is_get_object_request)
-                            .with_body("fake-content"),
-                        credentials_provider,
-                        region.clone(),
-                    ))
+        let client_provider = MockClientProvider {
+            region: Region::UsWest2,
+            credentials_provider: aws_credentials::Provider::new_mock(),
+            requests: vec![
+                // Successful GetObject request
+                MockRequest {
+                    status: 200,
+                    request_checker: is_get_object_request,
+                    header: None,
+                    body: Some("fake-content"),
                 },
-            ),
-            &logger,
-        );
+            ],
+        };
+
+        let mut transport = S3Transport::new_with_client(s3_path.clone(), client_provider, &logger);
 
         let mut reader = transport
             .get(TEST_KEY, "trace-id")
@@ -787,51 +838,68 @@ mod tests {
         reader.read_to_end(&mut content).expect("failed to read");
         assert_eq!(Vec::from("fake-content"), content);
 
-        let mut transport = S3Transport::new_with_client(
-            s3_path,
-            aws_credentials::Provider::new_mock(),
-            Box::new(
-                |region: &Region, credentials_provider: aws_credentials::Provider| {
-                    let requests = vec![
-                        // Response to CreateMultipartUpload
-                        MockRequestDispatcher::with_status(200)
-                            .with_body(
-                                r#"<?xml version="1.0" encoding="UTF-8"?>
+        let requests = vec![
+            // Response to CreateMultipartUpload
+            MockRequest {
+                status: 200,
+                request_checker: is_create_multipart_upload_request
+                    as for<'r> fn(&'r SignedRequest),
+                header: None,
+                body: Some(
+                    r#"<?xml version="1.0" encoding="UTF-8"?>
 <InitiateMultipartUploadResult>
    <Bucket>fake-bucket</Bucket>
    <Key>fake-key</Key>
    <UploadId>upload-id</UploadId>
 </InitiateMultipartUploadResult>"#,
-                            )
-                            .with_request_checker(is_create_multipart_upload_request),
-                        // Well formed response to UploadPart
-                        MockRequestDispatcher::with_status(200)
-                            .with_request_checker(is_upload_part_request)
-                            .with_header("ETag", "fake-etag"),
-                        // Well formed response to CompleteMultipartUpload
-                        MockRequestDispatcher::with_status(200)
-                            .with_request_checker(is_complete_multipart_upload_request)
-                            .with_body(
-                                r#"<?xml version="1.0" encoding="UTF-8"?>
+                ),
+            },
+            // Well formed response to UploadPart
+            MockRequest {
+                status: 200,
+                request_checker: is_upload_part_request,
+                header: Some(("Etag", "fake-etag")),
+                body: Some(
+                    r#"<?xml version="1.0" encoding="UTF-8"?>
 <CompleteMultipartUploadResult>
    <Location>string</Location>
    <Bucket>fake-bucket</Bucket>
    <Key>fake-key</Key>
    <ETag>fake-etag</ETag>
 </CompleteMultipartUploadResult>"#,
-                            ),
-                        // Response to AbortMultipartUpload, expected because of
-                        // cancel_upload call
-                        MockRequestDispatcher::with_status(204)
-                            .with_request_checker(is_abort_multipart_upload_request),
-                    ];
-                    Ok(S3Client::new_with(
-                        MultipleMockRequestDispatcher::new(requests),
-                        credentials_provider,
-                        region.clone(),
-                    ))
-                },
-            ),
+                ),
+            },
+            // Well formed response to CompleteMultipartUpload
+            MockRequest {
+                status: 200,
+                request_checker: is_complete_multipart_upload_request,
+                header: None,
+                body: Some(
+                    r#"<?xml version="1.0" encoding="UTF-8"?>
+<CompleteMultipartUploadResult>
+   <Location>string</Location>
+   <Bucket>fake-bucket</Bucket>
+   <Key>fake-key</Key>
+   <ETag>fake-etag</ETag>
+</CompleteMultipartUploadResult>"#,
+                ),
+            },
+            // Response to AbortMultipartUpload, expected because of
+            // cancel_upload call
+            MockRequest {
+                status: 204,
+                request_checker: is_abort_multipart_upload_request,
+                header: None,
+                body: None,
+            },
+        ];
+        let mut transport = S3Transport::new_with_client(
+            s3_path,
+            MockClientProvider {
+                region: Region::UsWest2,
+                credentials_provider: aws_credentials::Provider::new_mock(),
+                requests,
+            },
             &logger,
         );
 


### PR DESCRIPTION
This commit continues our progress toward #543 by making the `Transport`
trait require `std::clone::Clone` (via
`[dyn_clone`](https://docs.rs/dyn-clone/1.0.4/dyn_clone/), and making
all `Transport` impls implement `Clone`. Mostly this is a simple matter
of tagging existing definitions with `#[derive(Clone)]`, but it required
some extra gymnastics for `S3Client` and its associated structs:

 - `ClientProvider` was refactored from a supertrait over
   `std::ops::Fn` into a more conventional trait to make it
   easier to reason about how to `Clone` it.
 - Because Rusoto's `MockRequestDispatcher` & Co. are not
   `Clone` and have private fields, we had to introduce some
   proxy objects that can be cloned.

This commit consists mostly of changes cherry-picked from #486.