### PR TITLE
facilitator: don't require `--task-queue-identity`

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -212,7 +212,9 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                     running in GKE.",
                     entity.str(),
                     use_default_aws_credentials_provider
-                ))),
+                )))
+                .default_value("")
+                .hide_default_value(true),
         )
         // It's counterintuitive that users must explicitly opt into the
         // default credentials provider. This was done to preserve backward
@@ -393,7 +395,9 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                 .long_help(
                     "Identity to assume when accessing task queue. Should only \
                     be set when running under GKE and task-queue-kind is PubSub.",
-                ),
+                )
+                .default_value("")
+                .hide_default_value(true),
         )
         // It's counterintuitive that users must explicitly opt into the
         // default credentials provider. This was done to preserve backward


### PR DESCRIPTION
Make `--task-queue-identity/TASK_QUEUE_IDENTITY` optional by setting its
default value to "", which is treated as `None` by `config::Identity`.

Resolves #833