### PR TITLE
facilitator: bug fixes for international deployment

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -212,7 +212,9 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                     running in GKE.",
                     entity.str(),
                     use_default_aws_credentials_provider
-                ))),
+                )))
+                .default_value("")
+                .hide_default_value(true),
         )
         // It's counterintuitive that users must explicitly opt into the
         // default credentials provider. This was done to preserve backward
@@ -258,7 +260,9 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                     account to then assume the AWS IAM role using STS \
                     AssumeRoleWithWebIdentity.",
                     id
-                ))),
+                )))
+                .default_value("")
+                .hide_default_value(true),
         )
     }
 
@@ -393,7 +397,9 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                 .long_help(
                     "Identity to assume when accessing task queue. Should only \
                     be set when running under GKE and task-queue-kind is PubSub.",
-                ),
+                )
+                .default_value("")
+                .hide_default_value(true),
         )
         // It's counterintuitive that users must explicitly opt into the
         // default credentials provider. This was done to preserve backward

--- a/facilitator/src/config.rs
+++ b/facilitator/src/config.rs
@@ -63,7 +63,7 @@ impl Identity {
         self.inner.as_deref()
     }
 
-    pub(crate) fn is_some(&self) -> bool {
+    pub fn is_some(&self) -> bool {
         self.inner.is_some()
     }
 

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -22,17 +22,11 @@ pub mod transport;
 
 pub const DATE_FORMAT: &str = "%Y/%m/%d/%H/%M";
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// Compatibility enum entry to ease migration.
     #[error(transparent)]
-    // TODO(yuriks): The `From` impl should stay disabled while not updating errors, to avoid
-    //   accidentally wrapping an `EofError` inside `AnyhowError`, which would then get missed when
-    //   code tries to pattern-match against it. I don't trust our current test coverage enough to
-    //   detect all cases where that happens and leads to incorrect behavior.
-    //   Later on, `anyhow` downcasting with `Error::is` can be used to check for `EofError`.
-    AnyhowError(/*#[from]*/ anyhow::Error),
-
+    AnyhowError(#[from] anyhow::Error),
     #[error("avro error: {0}")]
     AvroError(String, #[source] avro_rs::Error),
     #[error("malformed header: {0}")]
@@ -41,6 +35,8 @@ pub enum Error {
     MalformedDataPacketError(String),
     #[error("end of file")]
     EofError,
+    #[error("HTTP resource error")]
+    HttpError(#[from] ureq::Error),
 }
 
 /// An implementation of transport::TransportWriter that computes a SHA256

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -254,6 +254,15 @@ impl DataShareProcessorSpecificManifest {
         }
     }
 
+    /// Returns the identity that should be assumed to write to the data share
+    /// processor's peer validation bucket
+    pub fn peer_validation_identity(&self) -> Identity {
+        match self {
+            Self::V1(_) => Identity::none(),
+            Self::V2(manifest) => manifest.peer_validation_identity.clone(),
+        }
+    }
+
     /// Returns the StoragePath for the data share processor's peer validation
     /// bucket.
     pub fn peer_validation_bucket(&self) -> &StoragePath {

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use anyhow::{anyhow, Context, Result};
 use serde::Deserialize;
-use slog::{info, o, Logger};
+use slog::{debug, info, o, Logger};
 use std::{io::Cursor, marker::PhantomData, time::Duration};
 use ureq::AgentBuilder;
 use url::Url;
@@ -159,7 +159,7 @@ impl<T: Task> GcpPubSubTaskQueue<T> {
 
 impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
     fn dequeue(&self) -> Result<Option<TaskHandle<T>>> {
-        info!(self.logger, "pull task");
+        debug!(self.logger, "pull task");
 
         let request = self.agent.prepare_request(RequestParameters {
             url: gcp_pubsub_pull_url(
@@ -258,7 +258,7 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
     }
 
     fn extend_task_deadline(&self, handle: &TaskHandle<T>, increment: &Duration) -> Result<()> {
-        info!(
+        debug!(
             self.logger, "extending deadline on task";
             event::TASK_ACKNOWLEDGEMENT_ID => &handle.acknowledgment_id,
         );

--- a/facilitator/src/task/sqs.rs
+++ b/facilitator/src/task/sqs.rs
@@ -4,7 +4,7 @@ use rusoto_core::Region;
 use rusoto_sqs::{
     ChangeMessageVisibilityRequest, DeleteMessageRequest, ReceiveMessageRequest, Sqs, SqsClient,
 };
-use slog::{info, o, Logger};
+use slog::{debug, info, o, Logger};
 use std::{convert::TryFrom, marker::PhantomData, str::FromStr, time::Duration};
 use tokio::runtime::Runtime;
 
@@ -55,7 +55,7 @@ impl<T: Task> AwsSqsTaskQueue<T> {
 
 impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
     fn dequeue(&self) -> Result<Option<TaskHandle<T>>> {
-        info!(self.logger, "pull task");
+        debug!(self.logger, "pull task");
 
         let client = self.sqs_client()?;
 
@@ -153,7 +153,7 @@ impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
     }
 
     fn extend_task_deadline(&self, task: &TaskHandle<T>, increment: &Duration) -> Result<()> {
-        info!(
+        debug!(
             self.logger, "extending deadline on task by 10 minutes";
             event::TASK_ACKNOWLEDGEMENT_ID => &task.acknowledgment_id,
         );


### PR DESCRIPTION
- Fix handling of `task-queue-identity` and a couple other `-identity` parameters
- The crypto self check will now gracefully be skipped if the instance's specific manifest does not exist, on the assumption that keys have not yet been generated and hence cannot be verified.
- Consult peer specific manifest to get identity to assume when writing to peer validation bucket as well as `peer-identity`

Resolves #833, #834