### PR TITLE
facilitator: fix `RUST_LOG` handling

### DIFF
--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -551,13 +551,13 @@ mod tests {
 
         let mut batch_writer: BatchWriter<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchWriter::new(
-                Batch::new_ingestion(&aggregation_name, &batch_id, &date),
+                Batch::new_ingestion(aggregation_name, &batch_id, &date),
                 &mut write_transport,
                 "trace-id",
             );
         let mut batch_reader: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchReader::new(
-                Batch::new_ingestion(&aggregation_name, &batch_id, &date),
+                Batch::new_ingestion(aggregation_name, &batch_id, &date),
                 &mut read_transport,
                 false,
                 "trace-id",
@@ -625,13 +625,13 @@ mod tests {
 
         let mut batch_writer: BatchWriter<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchWriter::new(
-                Batch::new_validation(&aggregation_name, &batch_id, &date, is_first),
+                Batch::new_validation(aggregation_name, &batch_id, &date, is_first),
                 &mut write_transport,
                 "trace-id",
             );
         let mut batch_reader: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchReader::new(
-                Batch::new_validation(&aggregation_name, &batch_id, &date, is_first),
+                Batch::new_validation(aggregation_name, &batch_id, &date, is_first),
                 &mut read_transport,
                 false,
                 "trace-id",
@@ -711,13 +711,13 @@ mod tests {
 
         let mut batch_writer: BatchWriter<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchWriter::new(
-                Batch::new_sum(&instance_name, &aggregation_name, &start, &end, is_first),
+                Batch::new_sum(instance_name, aggregation_name, &start, &end, is_first),
                 &mut write_transport,
                 "trace-id",
             );
         let mut batch_reader: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchReader::new(
-                Batch::new_sum(instance_name, &aggregation_name, &start, &end, is_first),
+                Batch::new_sum(instance_name, aggregation_name, &start, &end, is_first),
                 &mut read_transport,
                 false,
                 "trace-id",
@@ -778,13 +778,13 @@ mod tests {
 
         let mut batch_writer: BatchWriter<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchWriter::new(
-                Batch::new_sum(&instance_name, &aggregation_name, &start, &end, true),
+                Batch::new_sum(instance_name, aggregation_name, &start, &end, true),
                 &mut write_transport,
                 "trace-id",
             );
         let mut batch_reader: BatchReader<'_, IngestionHeader, IngestionDataSharePacket> =
             BatchReader::new(
-                Batch::new_sum(instance_name, &aggregation_name, &start, &end, true),
+                Batch::new_sum(instance_name, aggregation_name, &start, &end, true),
                 &mut read_transport,
                 true, // permit_malformed_batch
                 "trace-id",

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -9,7 +9,7 @@ use ring::signature::{
 };
 use slog::{debug, error, info, Logger};
 use std::{
-    collections::HashMap, fs, fs::File, io::Read, str::FromStr, time::Duration, time::Instant,
+    collections::HashMap, env, fs, fs::File, io::Read, str::FromStr, time::Duration, time::Instant,
 };
 use uuid::Uuid;
 
@@ -918,11 +918,13 @@ fn main() -> Result<(), anyhow::Error> {
         .get_matches();
 
     let force_json_log_output = value_t!(matches.value_of("force-json-log-output"), bool)?;
-
+    let log_level = &env::var("RUST_LOG")
+        .unwrap_or_else(|_| "INFO".to_owned())
+        .to_uppercase();
     let root_logger = setup_logging(&LoggingConfiguration {
         force_json_output: force_json_log_output,
         version_string: option_env!("BUILD_INFO").unwrap_or("(BUILD_INFO unavailable)"),
-        log_level: option_env!("RUST_LOG").unwrap_or("INFO"),
+        log_level,
     })?;
     let args: Vec<String> = std::env::args().collect();
     info!(

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -942,7 +942,7 @@ fn main() -> Result<(), anyhow::Error> {
             generate_sample(&Uuid::new_v4(), sub_matches, &root_logger)
         }
         ("generate-ingestion-sample-worker", Some(sub_matches)) => {
-            generate_sample_worker(&sub_matches, &root_logger)
+            generate_sample_worker(sub_matches, &root_logger)
         }
         ("intake-batch", Some(sub_matches)) => intake_batch_subcommand(sub_matches, &root_logger),
         ("intake-batch-worker", Some(sub_matches)) => {
@@ -1010,7 +1010,7 @@ fn generate_sample_worker(
 
     loop {
         let trace_id = Uuid::new_v4();
-        let result = generate_sample(&trace_id, &sub_matches, root_logger);
+        let result = generate_sample(&trace_id, sub_matches, root_logger);
 
         if let Err(e) = result {
             error!(
@@ -1261,7 +1261,7 @@ fn generate_sample(
     };
 
     let mut sample_generator = SampleGenerator::new(
-        &sub_matches.value_of("aggregation-id").unwrap(),
+        sub_matches.value_of("aggregation-id").unwrap(),
         value_t!(sub_matches.value_of("dimension"), i32)?,
         value_t!(sub_matches.value_of("epsilon"), f64)?,
         value_t!(sub_matches.value_of("batch-start-time"), i64)?,
@@ -1276,7 +1276,7 @@ fn generate_sample(
         &value_t!(sub_matches.value_of("batch-id"), Uuid).unwrap_or_else(|_| Uuid::new_v4()),
         &sub_matches.value_of("date").map_or_else(
             || Utc::now().naive_utc(),
-            |v| NaiveDateTime::parse_from_str(&v, DATE_FORMAT).unwrap(),
+            |v| NaiveDateTime::parse_from_str(v, DATE_FORMAT).unwrap(),
         ),
         value_t!(sub_matches.value_of("packet-count"), usize)?,
     )?;
@@ -1361,7 +1361,7 @@ where
 
     let mut batch_intaker = BatchIntaker::new(
         trace_id,
-        &aggregation_id,
+        aggregation_id,
         &batch_id,
         &date,
         &mut intake_transport,
@@ -1696,7 +1696,7 @@ fn aggregate_subcommand(
 
     aggregate(
         "None",
-        &sub_matches.value_of("aggregation-id").unwrap(),
+        sub_matches.value_of("aggregation-id").unwrap(),
         sub_matches.value_of("aggregation-start").unwrap(),
         sub_matches.value_of("aggregation-end").unwrap(),
         batch_info,

--- a/facilitator/src/gcp_oauth.rs
+++ b/facilitator/src/gcp_oauth.rs
@@ -587,7 +587,7 @@ impl GcpAccessTokenProvider {
         let request = self.agent.prepare_request(RequestParameters {
             url: Self::access_token_url_for_service_account(
                 self.iam_service_base_url,
-                &service_account_to_impersonate,
+                service_account_to_impersonate,
             )?,
             method: Method::Post,
             token_provider: Some(&StaticAccessTokenProvider::from(default_token)),

--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -220,7 +220,7 @@ impl<'a> BatchIntaker<'a> {
                 }
                 processed_packets += 1;
                 if processed_packets % callback_cadence == 0 {
-                    callback(&logger);
+                    callback(logger);
                 }
             },
         )?;

--- a/facilitator/src/logging.rs
+++ b/facilitator/src/logging.rs
@@ -90,7 +90,7 @@ impl From<Level> for Severity {
 }
 
 /// Options for configuring logging in this application
-pub struct LoggingConfiguration {
+pub struct LoggingConfiguration<'a> {
     /// If true, logging output will be forced to JSON format using
     /// [slog-json][1]. If false, logging format will be determined by detecting
     /// whether `stderr` is a `tty`. If it is, output is formatted using
@@ -100,9 +100,9 @@ pub struct LoggingConfiguration {
     /// [2]: https://docs.rs/slog-term
     pub force_json_output: bool,
     /// A version string which shall be attached to all log messages
-    pub version_string: &'static str,
+    pub version_string: &'a str,
     /// Messages above this log level will be discarded
-    pub log_level: &'static str,
+    pub log_level: &'a str,
 }
 
 /// IoErrorDrain is a supertrait that lets us work generically with
@@ -160,7 +160,7 @@ pub fn setup_logging(config: &LoggingConfiguration) -> Result<Logger> {
     let root_logger = Logger::root(
         drain,
         o!(
-            "version"=> config.version_string,
+            "version"=> config.version_string.to_owned(),
             "file" => FnValue(|record| {
                 record.file()
             }),

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -307,7 +307,7 @@ impl DataShareProcessorSpecificManifest {
         let test_message: Vec<u8> = (0..100).map(|_| rand::random::<u8>()).collect();
         let signature = batch_signing_private_key
             .key
-            .sign(&SystemRandom::new(), &&test_message)
+            .sign(&SystemRandom::new(), &test_message)
             .context(format!(
                 "failed to sign test message with private key {}",
                 batch_signing_private_key.identifier
@@ -347,7 +347,7 @@ impl DataShareProcessorSpecificManifest {
             ))?;
 
             for private_key in packet_encryption_private_keys {
-                match decrypt_share(&encrypted, &private_key) {
+                match decrypt_share(&encrypted, private_key) {
                     Ok(decrypted) => {
                         // AEAD decryption succeeding but yielding incorrect
                         // plaintext is incredibly unlikely
@@ -1722,7 +1722,7 @@ mod tests {
         assert_eq!(test_message, decrypted);
 
         let expected_encrypted = encrypt_share(&test_message, &expected).unwrap();
-        let decrypted = decrypt_share(&&expected_encrypted, &private_key).unwrap();
+        let decrypted = decrypt_share(&expected_encrypted, &private_key).unwrap();
         assert_eq!(test_message, decrypted);
     }
 

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -259,7 +259,7 @@ impl StreamingTransferWriter {
             minimum_upload_chunk_size,
             buffer: Vec::with_capacity(minimum_upload_chunk_size * 2),
             object_upload_position: 0,
-            upload_session_uri: Url::parse(&upload_session_uri).context(format!(
+            upload_session_uri: Url::parse(upload_session_uri).context(format!(
                 "failed to parse upload_session_uri url: {}",
                 &upload_session_uri
             ))?,

--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -209,7 +209,7 @@ fn aggregation_including_invalid_batch() {
         let mut pha_batch_intaker = BatchIntaker::new(
             "None",
             aggregation_name,
-            &uuid,
+            uuid,
             &date,
             &mut pha_ingest_transport,
             &mut pha_own_validation_transport,
@@ -223,7 +223,7 @@ fn aggregation_including_invalid_batch() {
         let mut facilitator_batch_intaker = BatchIntaker::new(
             "None",
             aggregation_name,
-            &uuid,
+            uuid,
             &date,
             &mut facilitator_ingest_transport,
             &mut facilitator_own_validation_transport,


### PR DESCRIPTION
We configure log level via the `RUST_LOG` environment variable. We were
using the `option_env!` macro to get its value, but that macro gets
environment variables at _compile_ time, not _run_ time, so it was
effectively impossible to set the log level to anything but `INFO`,
except by recompiling `facilitator`. We now use `std::env::var`, and
also apply `str::to_uppercase` to the value so that either of `debug` or
`DEBUG` will enable debug level logs.