### PR TITLE
facilitator: cache credentials

### DIFF
--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -27,11 +27,12 @@ use rusoto_core::{
 use rusoto_mock::MockCredentialsProvider;
 use rusoto_sts::WebIdentityProvider;
 use sha2::{Digest, Sha256};
-use slog::{o, Logger};
+use slog::{debug, o, Logger};
 #[cfg(test)]
 use std::sync::Arc;
 use std::{
     boxed::Box,
+    collections::HashMap,
     convert::From,
     default::Default,
     fmt::{self, Debug, Display},
@@ -48,6 +49,83 @@ const HOST_HEADER: &str = "host";
 const AMAZON_DATE_HEADER: &str = "x-amz-date";
 const AMAZON_SECURITY_TOKEN_HEADER: &str = "x-amz-security-token";
 const GOOGLE_TARGET_RESOURCE_HEADER: &str = "x-goog-cloud-target-resource";
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct ProviderFactoryKey {
+    aws_identity: Identity,
+    impersonate_gcp_service_account: Identity,
+    use_default_provider: bool,
+    purpose: &'static str,
+}
+
+/// Manages a cache of credentials providers keyed by the identity for which
+/// credentials are being obtained, for efficient credential caching across
+/// multiple API clients.
+#[derive(Clone, Debug)]
+pub struct ProviderFactory {
+    runtime_handle: Handle,
+    api_metrics: ApiClientMetricsCollector,
+    logger: Logger,
+    providers: HashMap<ProviderFactoryKey, Provider>,
+}
+
+impl ProviderFactory {
+    /// Creates a new credential provider factory. The provided `api_metrics`,
+    /// `runtime_handle` and `logger` will be used when creating any `Provider`.
+    pub fn new(
+        runtime_handle: &Handle,
+        api_metrics: &ApiClientMetricsCollector,
+        logger: &Logger,
+    ) -> Self {
+        Self {
+            runtime_handle: runtime_handle.clone(),
+            api_metrics: api_metrics.clone(),
+            logger: logger.clone(),
+            providers: HashMap::new(),
+        }
+    }
+
+    pub fn get(
+        &mut self,
+        aws_identity: Identity,
+        impersonate_gcp_service_account: Identity,
+        use_default_provider: bool,
+        purpose: &'static str,
+    ) -> Result<Provider> {
+        let key = ProviderFactoryKey {
+            aws_identity: aws_identity.clone(),
+            impersonate_gcp_service_account: impersonate_gcp_service_account.clone(),
+            use_default_provider,
+            purpose,
+        };
+        match self.providers.get(&key) {
+            Some(provider) => {
+                debug!(
+                    self.logger,
+                    "reusing cached AWS credentials provider {:?}", key
+                );
+                Ok(provider.clone())
+            }
+            None => {
+                debug!(
+                    self.logger,
+                    "creating new AWS credentials provider {:?}", key
+                );
+                let provider = Provider::new(
+                    aws_identity,
+                    impersonate_gcp_service_account,
+                    use_default_provider,
+                    purpose,
+                    &self.runtime_handle,
+                    &self.logger,
+                    &self.api_metrics,
+                )?;
+                self.providers.insert(key, provider.clone());
+                Ok(provider)
+            }
+        }
+    }
+}
 
 /// The Provider enum allows us to generically handle different scenarios for
 /// authenticating to AWS APIs, while still having a concrete value that
@@ -110,11 +188,11 @@ impl Provider {
     /// If `use_default_provider` is true, then ambient AWS credentials from the
     /// environment or ~/.aws/credentials will be used and other arguments are
     /// ignored.
-    pub fn new(
+    fn new(
         aws_identity: Identity,
         impersonate_gcp_service_account: Identity,
         use_default_provider: bool,
-        purpose: &str,
+        purpose: &'static str,
         runtime_handle: &Handle,
         logger: &Logger,
         api_metrics: &ApiClientMetricsCollector,
@@ -123,7 +201,7 @@ impl Provider {
             (true, _) => Self::new_default(api_metrics),
             (_, Some(identity)) => Self::new_web_identity_with_oidc(
                 identity,
-                purpose.to_owned(),
+                purpose,
                 impersonate_gcp_service_account,
                 runtime_handle,
                 logger,
@@ -160,7 +238,7 @@ impl Provider {
 
     fn new_web_identity_with_oidc(
         iam_role: &str,
-        purpose: String,
+        purpose: &'static str,
         impersonated_gcp_service_account: Identity,
         runtime_handle: &Handle,
         logger: &Logger,
@@ -174,7 +252,7 @@ impl Provider {
         // (which they do every hour).
         let token_logger = logger.new(o!(
             "iam_role" => iam_role.to_owned(),
-            "purpose" => purpose.clone(),
+            "purpose" => purpose,
         ));
         let token_provider: Box<dyn ProvideGcpIdentityToken> =
             match impersonated_gcp_service_account.as_str() {

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -970,6 +970,9 @@ fn main() -> Result<(), anyhow::Error> {
     let runtime = runtime::Builder::new_multi_thread().enable_all().build()?;
     let api_metrics = ApiClientMetricsCollector::new()?;
 
+    let mut aws_provider_factory =
+        aws_credentials::ProviderFactory::new(runtime.handle(), &api_metrics, &root_logger);
+
     let result = match matches.subcommand() {
         // The configuration of the Args above should guarantee that the
         // various parameters are present and valid, so it is safe to use
@@ -978,32 +981,47 @@ fn main() -> Result<(), anyhow::Error> {
             &Uuid::new_v4(),
             sub_matches,
             runtime.handle(),
+            &mut aws_provider_factory,
             &api_metrics,
             &root_logger,
         ),
-        ("generate-ingestion-sample-worker", Some(sub_matches)) => {
-            generate_sample_worker(sub_matches, runtime.handle(), &api_metrics, &root_logger)
-        }
+        ("generate-ingestion-sample-worker", Some(sub_matches)) => generate_sample_worker(
+            sub_matches,
+            runtime.handle(),
+            &mut aws_provider_factory,
+            &api_metrics,
+            &root_logger,
+        ),
         ("intake-batch", Some(sub_matches)) => intake_batch_subcommand(
             &Uuid::new_v4(),
             sub_matches,
             runtime.handle(),
+            &mut aws_provider_factory,
             &api_metrics,
             &root_logger,
         ),
-        ("intake-batch-worker", Some(sub_matches)) => {
-            intake_batch_worker(sub_matches, runtime.handle(), &api_metrics, &root_logger)
-        }
+        ("intake-batch-worker", Some(sub_matches)) => intake_batch_worker(
+            sub_matches,
+            runtime.handle(),
+            &mut aws_provider_factory,
+            &api_metrics,
+            &root_logger,
+        ),
         ("aggregate", Some(sub_matches)) => aggregate_subcommand(
             &Uuid::new_v4(),
             sub_matches,
             runtime.handle(),
+            &mut aws_provider_factory,
             &api_metrics,
             &root_logger,
         ),
-        ("aggregate-worker", Some(sub_matches)) => {
-            aggregate_worker(sub_matches, runtime.handle(), &api_metrics, &root_logger)
-        }
+        ("aggregate-worker", Some(sub_matches)) => aggregate_worker(
+            sub_matches,
+            runtime.handle(),
+            &mut aws_provider_factory,
+            &api_metrics,
+            &root_logger,
+        ),
         ("lint-manifest", Some(sub_matches)) => {
             lint_manifest(sub_matches, &root_logger, &api_metrics)
         }
@@ -1066,6 +1084,7 @@ fn crypto_self_check(
 fn generate_sample_worker(
     sub_matches: &ArgMatches,
     runtime_handle: &Handle,
+    aws_provider_factory: &mut aws_credentials::ProviderFactory,
     api_metrics: &ApiClientMetricsCollector,
     root_logger: &Logger,
 ) -> Result<(), anyhow::Error> {
@@ -1078,6 +1097,7 @@ fn generate_sample_worker(
             &trace_id,
             sub_matches,
             runtime_handle,
+            aws_provider_factory,
             api_metrics,
             root_logger,
         );
@@ -1257,6 +1277,7 @@ fn generate_sample(
     trace_id: &Uuid,
     sub_matches: &ArgMatches,
     runtime_handle: &Handle,
+    aws_provider_factory: &mut aws_credentials::ProviderFactory,
     api_metrics: &ApiClientMetricsCollector,
     logger: &Logger,
 ) -> Result<(), anyhow::Error> {
@@ -1302,6 +1323,7 @@ fn generate_sample(
                 sub_matches,
                 runtime_handle,
                 api_metrics,
+                aws_provider_factory,
                 logger,
             )?,
             batch_signing_key: own_batch_signing_key,
@@ -1347,6 +1369,7 @@ fn generate_sample(
                 sub_matches,
                 runtime_handle,
                 api_metrics,
+                aws_provider_factory,
                 logger,
             )?,
             batch_signing_key: own_batch_signing_key,
@@ -1385,17 +1408,23 @@ fn intake_batch<F>(
     batch_id: &str,
     date: &str,
     sub_matches: &ArgMatches,
+    runtime_handle: &Handle,
+    aws_provider_factory: &mut aws_credentials::ProviderFactory,
     metrics_collector: Option<&IntakeMetricsCollector>,
     api_metrics: &ApiClientMetricsCollector,
     parent_logger: &Logger,
-    runtime_handle: &Handle,
     callback: F,
 ) -> Result<(), anyhow::Error>
 where
     F: FnMut(&Logger),
 {
-    let mut intake_transport =
-        intake_transport_from_args(sub_matches, runtime_handle, api_metrics, parent_logger)?;
+    let mut intake_transport = intake_transport_from_args(
+        sub_matches,
+        runtime_handle,
+        api_metrics,
+        aws_provider_factory,
+        parent_logger,
+    )?;
 
     // We need the bucket to which we will write validations for the
     // peer data share processor, which can either be fetched from the
@@ -1435,6 +1464,7 @@ where
             sub_matches,
             runtime_handle,
             api_metrics,
+            aws_provider_factory,
             parent_logger,
         )?,
         batch_signing_key: batch_signing_key_from_arg(sub_matches)?,
@@ -1490,6 +1520,7 @@ fn intake_batch_subcommand(
     trace_id: &Uuid,
     sub_matches: &ArgMatches,
     runtime_handle: &Handle,
+    aws_provider_factory: &mut aws_credentials::ProviderFactory,
     api_metrics: &ApiClientMetricsCollector,
     parent_logger: &Logger,
 ) -> Result<(), anyhow::Error> {
@@ -1501,10 +1532,11 @@ fn intake_batch_subcommand(
         sub_matches.value_of("batch-id").unwrap(),
         sub_matches.value_of("date").unwrap(),
         sub_matches,
+        runtime_handle,
+        aws_provider_factory,
         None,
         api_metrics,
         parent_logger,
-        runtime_handle,
         |_| {}, // no-op callback
     )
 }
@@ -1512,6 +1544,7 @@ fn intake_batch_subcommand(
 fn intake_batch_worker(
     sub_matches: &ArgMatches,
     runtime_handle: &Handle,
+    aws_provider_factory: &mut aws_credentials::ProviderFactory,
     api_metrics: &ApiClientMetricsCollector,
     parent_logger: &Logger,
 ) -> Result<(), anyhow::Error> {
@@ -1519,8 +1552,14 @@ fn intake_batch_worker(
     let metrics_collector = IntakeMetricsCollector::new()?;
     let scrape_port = value_t!(sub_matches.value_of("metrics-scrape-port"), u16)?;
     start_metrics_scrape_endpoint(scrape_port, runtime_handle, parent_logger)?;
-    let queue =
-        intake_task_queue_from_args(sub_matches, runtime_handle, api_metrics, parent_logger)?;
+
+    let queue = intake_task_queue_from_args(
+        sub_matches,
+        runtime_handle,
+        api_metrics,
+        aws_provider_factory,
+        parent_logger,
+    )?;
 
     crypto_self_check(sub_matches, parent_logger, api_metrics)
         .context("crypto self check failed")?;
@@ -1540,10 +1579,11 @@ fn intake_batch_worker(
                 &task_handle.task.batch_id,
                 &task_handle.task.date,
                 sub_matches,
+                runtime_handle,
+                aws_provider_factory,
                 Some(&metrics_collector),
                 api_metrics,
                 parent_logger,
-                runtime_handle,
                 |logger| {
                     if let Err(e) =
                         queue.maybe_extend_task_deadline(&task_handle, &task_start.elapsed())
@@ -1581,9 +1621,10 @@ fn aggregate<F>(
     end: &str,
     batches: Vec<(&str, &str)>,
     sub_matches: &ArgMatches,
+    runtime_handle: &Handle,
+    aws_provider_factory: &mut aws_credentials::ProviderFactory,
     metrics_collector: Option<&AggregateMetricsCollector>,
     api_metrics: &ApiClientMetricsCollector,
-    runtime_handle: &Handle,
     logger: &Logger,
     callback: F,
 ) -> Result<()>
@@ -1593,8 +1634,13 @@ where
     let instance_name = sub_matches.value_of("instance-name").unwrap();
     let is_first = is_first_from_arg(sub_matches);
 
-    let mut intake_transport =
-        intake_transport_from_args(sub_matches, runtime_handle, api_metrics, logger)?;
+    let mut intake_transport = intake_transport_from_args(
+        sub_matches,
+        runtime_handle,
+        api_metrics,
+        aws_provider_factory,
+        logger,
+    )?;
 
     // We created the bucket that peers wrote validations into, and so
     // it is simply provided via argument.
@@ -1608,6 +1654,7 @@ where
         sub_matches,
         runtime_handle,
         api_metrics,
+        aws_provider_factory,
         logger,
     )?;
 
@@ -1666,6 +1713,7 @@ where
         sub_matches,
         runtime_handle,
         api_metrics,
+        aws_provider_factory,
         logger,
     )?;
 
@@ -1737,6 +1785,7 @@ fn aggregate_subcommand(
     trace_id: &Uuid,
     sub_matches: &ArgMatches,
     runtime_handle: &Handle,
+    aws_provider_factory: &mut aws_credentials::ProviderFactory,
     api_metrics: &ApiClientMetricsCollector,
     parent_logger: &Logger,
 ) -> Result<(), anyhow::Error> {
@@ -1766,9 +1815,10 @@ fn aggregate_subcommand(
         sub_matches.value_of("aggregation-end").unwrap(),
         batch_info,
         sub_matches,
+        runtime_handle,
+        aws_provider_factory,
         None,
         api_metrics,
-        runtime_handle,
         parent_logger,
         |_| {}, // no-op callback
     )
@@ -1777,12 +1827,18 @@ fn aggregate_subcommand(
 fn aggregate_worker(
     sub_matches: &ArgMatches,
     runtime_handle: &Handle,
+    aws_provider_factory: &mut aws_credentials::ProviderFactory,
     api_metrics: &ApiClientMetricsCollector,
     parent_logger: &Logger,
 ) -> Result<(), anyhow::Error> {
     let termination_instant = termination_instant_from_args(sub_matches)?;
-    let queue =
-        aggregation_task_queue_from_args(sub_matches, runtime_handle, api_metrics, parent_logger)?;
+    let queue = aggregation_task_queue_from_args(
+        sub_matches,
+        runtime_handle,
+        api_metrics,
+        aws_provider_factory,
+        parent_logger,
+    )?;
     let metrics_collector = AggregateMetricsCollector::new()?;
     let scrape_port = value_t!(sub_matches.value_of("metrics-scrape-port"), u16)?;
     start_metrics_scrape_endpoint(scrape_port, runtime_handle, parent_logger)?;
@@ -1813,9 +1869,10 @@ fn aggregate_worker(
                 &task_handle.task.aggregation_end,
                 batches,
                 sub_matches,
+                runtime_handle,
+                aws_provider_factory,
                 Some(&metrics_collector),
                 api_metrics,
-                runtime_handle,
                 parent_logger,
                 |logger| {
                     if let Err(e) =
@@ -1981,6 +2038,7 @@ fn intake_transport_from_args(
     matches: &ArgMatches,
     runtime_handle: &Handle,
     api_metrics: &ApiClientMetricsCollector,
+    aws_provider_factory: &mut aws_credentials::ProviderFactory,
     logger: &Logger,
 ) -> Result<VerifiableAndDecryptableTransport> {
     let identity = value_t!(
@@ -1998,6 +2056,7 @@ fn intake_transport_from_args(
         matches,
         runtime_handle,
         api_metrics,
+        aws_provider_factory,
         logger,
     )?;
 
@@ -2060,6 +2119,7 @@ enum PathOrInOut {
     InOut(InOut),
 }
 
+#[allow(clippy::too_many_arguments)]
 fn transport_from_args(
     identity: Identity,
     entity: Entity,
@@ -2067,6 +2127,7 @@ fn transport_from_args(
     matches: &ArgMatches,
     runtime_handle: &Handle,
     api_metrics: &ApiClientMetricsCollector,
+    aws_provider_factory: &mut aws_credentials::ProviderFactory,
     logger: &Logger,
 ) -> Result<Box<dyn Transport>> {
     let path = match path_or_in_out {
@@ -2088,10 +2149,12 @@ fn transport_from_args(
         matches,
         runtime_handle,
         api_metrics,
+        aws_provider_factory,
         logger,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn transport_for_path(
     path: StoragePath,
     identity: Identity,
@@ -2099,6 +2162,7 @@ fn transport_for_path(
     matches: &ArgMatches,
     runtime_handle: &Handle,
     api_metrics: &ApiClientMetricsCollector,
+    aws_provider_factory: &mut aws_credentials::ProviderFactory,
     logger: &Logger,
 ) -> Result<Box<dyn Transport>> {
     let use_default_aws_credentials_provider = value_t!(
@@ -2113,14 +2177,11 @@ fn transport_for_path(
 
     match path {
         StoragePath::S3Path(path) => {
-            let credentials_provider = aws_credentials::Provider::new(
+            let credentials_provider = aws_provider_factory.get(
                 identity,
                 sa_to_impersonate,
                 use_default_aws_credentials_provider,
                 "s3",
-                runtime_handle,
-                logger,
-                api_metrics,
             )?;
             Ok(Box::new(S3Transport::new(
                 path,
@@ -2145,9 +2206,7 @@ fn transport_for_path(
                 WorkloadIdentityPoolParameters::new(
                     matches.value_of("gcp-workload-identity-pool-provider"),
                     use_default_aws_credentials_provider,
-                    runtime_handle,
-                    api_metrics,
-                    logger,
+                    aws_provider_factory,
                 )?,
                 runtime_handle,
                 logger,
@@ -2179,6 +2238,7 @@ fn intake_task_queue_from_args(
     matches: &ArgMatches,
     runtime_handle: &Handle,
     api_metrics: &ApiClientMetricsCollector,
+    aws_provider_factory: &mut aws_credentials::ProviderFactory,
     logger: &Logger,
 ) -> Result<Box<dyn TaskQueue<IntakeBatchTask>>> {
     let task_queue_kind = TaskQueueKind::from_str(
@@ -2211,7 +2271,7 @@ fn intake_task_queue_from_args(
             let sqs_region = matches
                 .value_of("aws-sqs-region")
                 .ok_or_else(|| anyhow!("aws-sqs-region is required"))?;
-            let credentials_provider = aws_credentials::Provider::new(
+            let credentials_provider = aws_provider_factory.get(
                 identity,
                 Identity::none(),
                 value_t!(
@@ -2219,9 +2279,6 @@ fn intake_task_queue_from_args(
                     bool
                 )?,
                 "sqs",
-                runtime_handle,
-                logger,
-                api_metrics,
             )?;
             Ok(Box::new(AwsSqsTaskQueue::new(
                 sqs_region,
@@ -2239,6 +2296,7 @@ fn aggregation_task_queue_from_args(
     matches: &ArgMatches,
     runtime_handle: &Handle,
     api_metrics: &ApiClientMetricsCollector,
+    aws_provider_factory: &mut aws_credentials::ProviderFactory,
     logger: &Logger,
 ) -> Result<Box<dyn TaskQueue<AggregationTask>>> {
     let task_queue_kind = TaskQueueKind::from_str(
@@ -2271,7 +2329,7 @@ fn aggregation_task_queue_from_args(
             let sqs_region = matches
                 .value_of("aws-sqs-region")
                 .ok_or_else(|| anyhow!("aws-sqs-region is required"))?;
-            let credentials_provider = aws_credentials::Provider::new(
+            let credentials_provider = aws_provider_factory.get(
                 identity,
                 Identity::none(),
                 value_t!(
@@ -2279,9 +2337,6 @@ fn aggregation_task_queue_from_args(
                     bool
                 )?,
                 "sqs",
-                runtime_handle,
-                logger,
-                api_metrics,
             )?;
             Ok(Box::new(AwsSqsTaskQueue::new(
                 sqs_region,

--- a/facilitator/src/config.rs
+++ b/facilitator/src/config.rs
@@ -1,9 +1,6 @@
 use anyhow::{anyhow, Context, Result};
 use rusoto_core::{region::ParseRegionError, Region};
 use serde::{de, Deserialize, Deserializer};
-use slog::Logger;
-use tokio::runtime::Handle;
-
 use std::{
     convert::Infallible,
     fmt::{self, Display, Formatter},
@@ -11,13 +8,13 @@ use std::{
     str::FromStr,
 };
 
-use crate::{aws_credentials, metrics::ApiClientMetricsCollector};
+use crate::aws_credentials;
 
 /// Identity represents a cloud identity: Either an AWS IAM ARN (i.e. "arn:...")
 /// or a GCP ServiceAccount (i.e. "foo@bar.com"). It treats the empty string as
 /// equivalent to None, allowing arguments to unconditionally be provided to
 /// facilitator.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Identity {
     inner: Option<String>,
 }
@@ -93,9 +90,7 @@ impl WorkloadIdentityPoolParameters {
     pub fn new(
         workload_identity_pool_provider_id: Option<&str>,
         use_default_aws_credentials_provider: bool,
-        runtime_handle: &Handle,
-        api_metrics: &ApiClientMetricsCollector,
-        logger: &Logger,
+        aws_provider_factory: &mut aws_credentials::ProviderFactory,
     ) -> Result<Option<Self>> {
         let parameters = match workload_identity_pool_provider_id {
             // We treat the empty string as equivalent to None, to allow the
@@ -104,7 +99,7 @@ impl WorkloadIdentityPoolParameters {
             None | Some("") => None,
             Some(provider_id) => Some(Self {
                 workload_identity_pool_provider: provider_id.to_owned(),
-                aws_credentials_provider: aws_credentials::Provider::new(
+                aws_credentials_provider: aws_provider_factory.get(
                     // We create this provider with no identity and no
                     // impersonated GCP service account, requiring that the
                     // authentication to AWS use either ambient AWS credentials
@@ -113,9 +108,6 @@ impl WorkloadIdentityPoolParameters {
                     Identity::none(),
                     use_default_aws_credentials_provider,
                     "IAM federation",
-                    runtime_handle,
-                    logger,
-                    api_metrics,
                 )?,
             }),
         };

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -6,7 +6,7 @@ pub mod aggregation;
 pub mod aws_credentials;
 pub mod batch;
 pub mod config;
-mod gcp_oauth;
+pub mod gcp_oauth;
 pub mod http;
 pub mod idl;
 pub mod intake;


### PR DESCRIPTION
This series of commits introduces factories for AWS and GCP credentials providers, allowing instances of `aws_credentials::Provider` and `gcp_oauth::GcpAccessTokenProvider` to be efficiently shared across task queues, transports and even each other.

Resolves #543 