### PR TITLE
terraform: script and guide for state surgery

### DIFF
--- a/terraform/state-surgery/README.md
+++ b/terraform/state-surgery/README.md
@@ -1,0 +1,111 @@
+# state-surgery
+
+Deploying `prio-server` in support of international ENPA required some
+[significant refactoring of Terraform modules](https://github.com/abetterinternet/prio-server/issues/655).
+That meant that the existing `prod-us` environment's `.tfstate` lost track of
+managed resources, which had moved to new paths in the refactored modules. This
+is a guide to performing surgery on the Terraform state of an existing
+environment to bring it under the management of the refactored Terraform
+modules.
+
+Note that the guide here and the `./state-surgery.sh` script apply only to the
+Terraform module refactor done in July/August 2021.
+
+## Migrating an environment
+
+First, we must get a copy remote state so we can safely operate on it without
+damaging the remote state. Once you have initialized Terraform, you can use TF
+to fetch a copy of state:
+
+    ENV=<env> TF_VAR_aws_profile=<profile> make prep
+    terraform state pull > <local path>
+
+We are going to operate on that local copy, and we make a further backup of it
+so that we can always restore Terraform to a known state.
+
+Next, we must make sure we can perform Terraform actions against that local
+state to check that the state modifications we will later make worked. Apply
+changes like this diff to `terraform/main.tf` (this exact patch may not apply
+cleanly by the time you read this) so that `terraform plan` will not use the
+remote state bucket:
+
+```
+diff --git a/terraform/main.tf b/terraform/main.tf
+index a409873..cab1db1 100644
+--- a/terraform/main.tf
++++ b/terraform/main.tf
+@@ -199,7 +199,9 @@ variable "cluster_settings" {
+ }
+
+ terraform {
+-  backend "gcs" {}
++  backend "local" {
++    path = "<local path>"
++  }
+
+   required_version = ">= 0.14.4"
+
+@@ -246,16 +248,6 @@ terraform {
+   }
+ }
+
+-data "terraform_remote_state" "state" {
+-  backend = "gcs"
+-
+-  workspace = "${var.environment}-${var.gcp_region}"
+-
+-  config = {
+-    bucket = "${var.environment}-${var.gcp_region}-prio-terraform"
+-  }
+-}
+-
+ data "google_project" "current" {}
+ data "google_client_config" "current" {}
+ data "aws_caller_identity" "current" {}
+```
+
+Then `init` and `plan`, to prove we can work against our local tfstate file.
+
+    rm -rf /path/to/prio-server/terraform/.terraform
+    terraform init --lock=false --upgrade --verify-plugins=true --backend=true
+    terraform plan --state=<local path> --input=false --var-file=variables/<env>.tfvars --refresh=true --lock=false
+
+The plan output should be empty or correspond to the stuff we haven't moved
+yet. If it wants to rebuild the whole world from scratch, we did it wrong. If
+the plan output looks reasonable, then we are ready to move stuff:
+
+    ./state-surgery.sh <local path> "namespace-1 namespace-2 ..." "ingestor-1 ingestor-2 ..."
+
+The arguments to `state-surgery.sh` are positional:
+ - `$1` is the path to the local `.tfstate` file
+ - `$2` is a list of namespaces (a.k.a. localities) in the environment
+ - `$3` is a list of ingestors, which are assumed to exist in each locality
+ - `$4` (optional) is a list of extra arguments transparently passed through
+   to `terraform state mv`. For instance, set `--dry-run` to see what _would_
+   get moved.
+
+After doing surgery, we run `terraform plan` again (with args as above) and we
+should see fewer items in the plan if we moved resources into the correct place.
+
+When we are satisfied with the changes, we push the modified state back into the
+remote backend place. First, we remove the change made to `main.tf`. Then we
+re-init terraform, since the `terraform.backend` block in `main.tf` has changed:
+
+    ENV=<env> TF_VAR_aws_profile=<profile> make prep
+
+Then we push the state to the backend (i.e., upload to the GCS bucket):
+
+    terraform state push <local path>
+
+Finally, check `terraform plan` output to make sure it is as expected.
+
+    ENV=<env> TF_VAR_aws_profile=<profile> make plan
+
+And now we can work with the doctored state as normal, using the `plan` and
+`apply` `make` targets.
+
+## Restoring a state backup
+
+Simply identify the backend GCS bucket for the environment and copy the backup
+`default.tfstate` stored earlier into it, using `gsutil` or the Google Cloud
+Platform Console.

--- a/terraform/state-surgery/state-surgery.sh
+++ b/terraform/state-surgery/state-surgery.sh
@@ -1,0 +1,60 @@
+#!/bin/bash -eu
+
+STATEFILE=${1}
+NAMESPACES=${2}
+INGESTORS=${3}
+EXTRA_ARGS=${4:-}
+
+declare -a RESOURCE_RENAMES=(
+    'google_compute_network.network module.gke[0].google_compute_network.network'
+    'module.gke.google_compute_router.router module.gke[0].google_compute_router.router'
+    'module.gke.google_compute_router_nat.nat module.gke[0].google_compute_router_nat.nat'
+    'module.gke.google_compute_subnetwork.subnet module.gke[0].google_compute_subnetwork.subnet'
+    'module.gke.google_container_cluster.cluster module.gke[0].google_container_cluster.cluster'
+    'module.gke.google_container_node_pool.worker_nodes module.gke[0].google_container_node_pool.worker_nodes'
+    'module.gke.google_kms_crypto_key.etcd_encryption_key module.gke[0].google_kms_crypto_key.etcd_encryption_key'
+    'module.gke.google_kms_crypto_key_iam_binding.etcd-encryption-key-iam-binding module.gke[0].google_kms_crypto_key_iam_binding.etcd-encryption-key-iam-binding'
+    'module.gke.google_kms_key_ring.keyring module.gke[0].google_kms_key_ring.keyring'
+    'google_project_service.compute module.gke[0].google_project_service.compute'
+    'google_project_service.container module.gke[0].google_project_service.container'
+    'google_project_service.kms module.gke[0].google_project_service.kms'
+    'module.manifest.google_compute_backend_bucket.manifests module.manifest_gcp[0].google_compute_backend_bucket.manifests[0]'
+    'module.manifest.google_compute_global_address.manifests module.manifest_gcp[0].google_compute_global_address.manifests[0]'
+    'module.manifest.google_compute_global_forwarding_rule.manifests module.manifest_gcp[0].google_compute_global_forwarding_rule.manifests[0]'
+    'module.manifest.google_compute_managed_ssl_certificate.manifests module.manifest_gcp[0].google_compute_managed_ssl_certificate.manifests[0]'
+    'module.manifest.google_compute_target_https_proxy.manifests module.manifest_gcp[0].google_compute_target_https_proxy.manifests[0]'
+    'module.manifest.google_compute_url_map.manifests module.manifest_gcp[0].google_compute_url_map.manifests[0]'
+    'module.manifest.google_dns_record_set.manifests module.manifest_gcp[0].google_dns_record_set.manifests[0]'
+    'module.manifest.google_storage_bucket.manifests module.manifest_gcp[0].google_storage_bucket.manifests'
+    'module.manifest.google_storage_bucket_iam_binding.public_read module.manifest_gcp[0].google_storage_bucket_iam_binding.public_read'
+    'module.manifest.google_storage_bucket_object.global_manifest module.manifest_gcp[0].google_storage_bucket_object.global_manifest'
+    'module.monitoring.kubernetes_persistent_volume.prometheus_server module.monitoring.kubernetes_persistent_volume.prometheus_server_gcp[0]'
+)
+
+for RENAME in "${RESOURCE_RENAMES[@]}"; do
+    terraform state mv ${EXTRA_ARGS} --state=${STATEFILE} ${RENAME}
+done
+
+for NAMESPACE in ${NAMESPACES}; do
+    declare -a NAMESPACE_RESOURCE_RENAMES=(
+        'module.locality_kubernetes["'${NAMESPACE}'"].google_storage_bucket_iam_member.manifest_bucket_owner module.locality_kubernetes["'${NAMESPACE}'"].google_storage_bucket_iam_member.manifest_bucket_writer[0]'
+    )
+    for RENAME in "${NAMESPACE_RESOURCE_RENAMES[@]}"; do
+        terraform state mv ${EXTRA_ARGS} --state=${STATEFILE} ${RENAME}
+    done
+
+    for INGESTOR in ${INGESTORS}; do
+        INSTANCE_NAME="${NAMESPACE}-${INGESTOR}"
+        declare -a INSTANCE_RESOURCE_RENAMES=(
+            'module.data_share_processors["'${INSTANCE_NAME}'"].google_kms_crypto_key.bucket_encryption module.data_share_processors["'${INSTANCE_NAME}'"].module.cloud_storage_gcp[0].google_kms_crypto_key.bucket_encryption'
+            'module.data_share_processors["'${INSTANCE_NAME}'"].google_kms_crypto_key_iam_binding.bucket_encryption_key module.data_share_processors["'${INSTANCE_NAME}'"].module.cloud_storage_gcp[0].google_kms_crypto_key_iam_binding.bucket_encryption_key'
+            'module.data_share_processors["'${INSTANCE_NAME}'"].module.bucket.google_storage_bucket.bucket module.data_share_processors["'${INSTANCE_NAME}'"].module.cloud_storage_gcp[0].module.bucket["own_validation"].google_storage_bucket.bucket'
+            'module.data_share_processors["'${INSTANCE_NAME}'"].module.bucket.google_storage_bucket_iam_binding.bucket_reader module.data_share_processors["'${INSTANCE_NAME}'"].module.cloud_storage_gcp[0].module.bucket["own_validation"].google_storage_bucket_iam_binding.bucket_reader'
+            'module.data_share_processors["'${INSTANCE_NAME}'"].module.bucket.google_storage_bucket_iam_binding.bucket_writer module.data_share_processors["'${INSTANCE_NAME}'"].module.cloud_storage_gcp[0].module.bucket["own_validation"].google_storage_bucket_iam_binding.bucket_writer'
+            'module.data_share_processors["'${INSTANCE_NAME}'"].module.kubernetes.google_service_account_iam_binding.workflow_manager_token module.data_share_processors["'${INSTANCE_NAME}'"].module.kubernetes.module.account_mapping.google_service_account_iam_binding.workflow_manager_token[0]'
+        )
+        for RENAME in "${INSTANCE_RESOURCE_RENAMES[@]}"; do
+            terraform state mv ${EXTRA_ARGS} --state=${STATEFILE} ${RENAME}
+        done
+    done
+done


### PR DESCRIPTION
Adds a script, documentation and effectively a roll plan for migrating
`prod-us` (and any other existing `prio-server` environments) to the new
Terraform modules.

Part of #850