### PR TITLE
terraform: use optionals in per-locality config

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -43,14 +43,18 @@ variable "ingestors" {
     localities = map(object({
       intake_worker_count                    = number
       aggregate_worker_count                 = number
-      peer_share_processor_manifest_base_url = string
-      portal_server_manifest_base_url        = string
+      peer_share_processor_manifest_base_url = optional(string)
+      portal_server_manifest_base_url        = optional(string)
       aggregation_period                     = optional(string)
       aggregation_grace_period               = optional(string)
     }))
   }))
   description = <<DESCRIPTION
 Map of ingestor names to per-ingestor configuration.
+peer_share_processor_manifest_base_url is optional and overrides
+default_peer_share_processor_manifest_base_url for the locality.
+portal_server_manifest_base_url is optional and overrides
+default_portal_server_manifest_base_url for the locality.
 aggregation_period and aggregation_grace_period values are optional and override
 default_aggregation_period and default_aggregation_grace_period, respectively,
 for the locality. The values should be strings parseable by Go's
@@ -128,6 +132,22 @@ variable "default_aggregation_grace_period" {
 Aggregation grace period used by workflow manager if none is provided by the locality
 configuration. The value should be a string parseable by Go's
 time.ParseDuration.
+DESCRIPTION
+}
+
+variable "default_peer_share_processor_manifest_base_url" {
+  type        = string
+  description = <<DESCRIPTION
+Base URL relative to which the peer share processor's manifests can be found, if
+none is provided by the locality configuration.
+DESCRIPTION
+}
+
+variable "default_portal_server_manifest_base_url" {
+  type        = string
+  description = <<DESCRIPTION
+Base URL relative to which the portal server's manifests can be found, if none
+is provided by the locality configuration.
 DESCRIPTION
 }
 
@@ -403,8 +423,14 @@ locals {
       ingestor_manifest_base_url              = var.ingestors[pair[1]].manifest_base_url
       intake_worker_count                     = var.ingestors[pair[1]].localities[pair[0]].intake_worker_count
       aggregate_worker_count                  = var.ingestors[pair[1]].localities[pair[0]].aggregate_worker_count
-      peer_share_processor_manifest_base_url  = var.ingestors[pair[1]].localities[pair[0]].peer_share_processor_manifest_base_url
-      portal_server_manifest_base_url         = var.ingestors[pair[1]].localities[pair[0]].portal_server_manifest_base_url
+      peer_share_processor_manifest_base_url = coalesce(
+        var.ingestors[pair[1]].localities[pair[0]].peer_share_processor_manifest_base_url,
+        var.default_peer_share_processor_manifest_base_url
+      )
+      portal_server_manifest_base_url = coalesce(
+        var.ingestors[pair[1]].localities[pair[0]].portal_server_manifest_base_url,
+        var.default_portal_server_manifest_base_url
+      )
       aggregation_period = coalesce(
         var.ingestors[pair[1]].localities[pair[0]].aggregation_period,
         var.default_aggregation_period

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,9 +45,17 @@ variable "ingestors" {
       aggregate_worker_count                 = number
       peer_share_processor_manifest_base_url = string
       portal_server_manifest_base_url        = string
+      aggregation_period                     = optional(string)
+      aggregation_grace_period               = optional(string)
     }))
   }))
-  description = "Map of ingestor names to per-ingestor configuration."
+  description = <<DESCRIPTION
+Map of ingestor names to per-ingestor configuration.
+aggregation_period and aggregation_grace_period values are optional and override
+default_aggregation_period and default_aggregation_grace_period, respectively,
+for the locality. The values should be strings parseable by Go's
+time.ParseDuration.
+DESCRIPTION
 }
 
 variable "manifest_domain" {
@@ -103,21 +111,23 @@ for. The value should be a string parseable by Go's time.ParseDuration.
 DESCRIPTION
 }
 
-variable "aggregation_period" {
+variable "default_aggregation_period" {
   type        = string
   default     = "3h"
   description = <<DESCRIPTION
-Aggregation period used by workflow manager. The value should be a string
-parseable by Go's time.ParseDuration.
+Aggregation period used by workflow manager if none is provided by the locality
+configuration. The value should be a string parseable by Go's
+time.ParseDuration.
 DESCRIPTION
 }
 
-variable "aggregation_grace_period" {
+variable "default_aggregation_grace_period" {
   type        = string
   default     = "1h"
   description = <<DESCRIPTION
-Aggregation grace period used by workflow manager. The value should be a string
-parseable by Go's time.ParseDuration.
+Aggregation grace period used by workflow manager if none is provided by the locality
+configuration. The value should be a string parseable by Go's
+time.ParseDuration.
 DESCRIPTION
 }
 
@@ -202,6 +212,9 @@ terraform {
   backend "gcs" {}
 
   required_version = ">= 0.14.4"
+
+  # https://www.terraform.io/docs/language/expressions/type-constraints.html#experimental-optional-object-type-attributes
+  experiments = [module_variable_optional_attrs]
 
   required_providers {
     aws = {
@@ -392,6 +405,14 @@ locals {
       aggregate_worker_count                  = var.ingestors[pair[1]].localities[pair[0]].aggregate_worker_count
       peer_share_processor_manifest_base_url  = var.ingestors[pair[1]].localities[pair[0]].peer_share_processor_manifest_base_url
       portal_server_manifest_base_url         = var.ingestors[pair[1]].localities[pair[0]].portal_server_manifest_base_url
+      aggregation_period = coalesce(
+        var.ingestors[pair[1]].localities[pair[0]].aggregation_period,
+        var.default_aggregation_period
+      )
+      aggregation_grace_period = coalesce(
+        var.ingestors[pair[1]].localities[pair[0]].aggregation_grace_period,
+        var.default_aggregation_grace_period
+      )
     }
   }
   # Are we in a paired env deploy that uses a test ingestor?
@@ -482,8 +503,8 @@ module "data_share_processors" {
   own_manifest_base_url                          = local.manifest.base_url
   is_first                                       = var.is_first
   intake_max_age                                 = var.intake_max_age
-  aggregation_period                             = var.aggregation_period
-  aggregation_grace_period                       = var.aggregation_grace_period
+  aggregation_period                             = each.value.aggregation_period
+  aggregation_grace_period                       = each.value.aggregation_grace_period
   kms_keyring                                    = var.use_aws ? "" : module.gke[0].kms_keyring
   pushgateway                                    = var.pushgateway
   workflow_manager_image                         = var.workflow_manager_image
@@ -628,7 +649,7 @@ module "monitoring" {
     project = var.gcp_project
   }
   victorops_routing_key = var.victorops_routing_key
-  aggregation_period    = var.aggregation_period
+  aggregation_period    = var.default_aggregation_period
   eks_oidc_provider     = var.use_aws ? module.eks[0].oidc_provider : { url = "", arn = "" }
 
   prometheus_server_persistent_disk_size_gb = var.prometheus_server_persistent_disk_size_gb

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -23,82 +23,56 @@ ingestors = {
         aggregation_grace_period               = "30m"
       }
       us-ct = {
-        intake_worker_count                    = 8
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 8
+        aggregate_worker_count = 3
       }
       us-md = {
-        intake_worker_count                    = 8
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 8
+        aggregate_worker_count = 3
       }
       us-va = {
-        intake_worker_count                    = 8
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 8
+        aggregate_worker_count = 3
       }
       us-wa = {
-        intake_worker_count                    = 10
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 10
+        aggregate_worker_count = 3
       }
       us-ca = {
-        intake_worker_count                    = 25
-        aggregate_worker_count                 = 7
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 25
+        aggregate_worker_count = 7
       }
       us-ut = {
-        intake_worker_count                    = 10
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 10
+        aggregate_worker_count = 3
       }
       us-wi = {
-        intake_worker_count                    = 12
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 12
+        aggregate_worker_count = 3
       }
       us-ma = {
-        intake_worker_count                    = 12
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 12
+        aggregate_worker_count = 3
       }
       us-nm = {
-        intake_worker_count                    = 5
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 5
+        aggregate_worker_count = 3
       }
       us-hi = {
-        intake_worker_count                    = 5
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 5
+        aggregate_worker_count = 3
       }
       us-co = {
-        intake_worker_count                    = 8
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 8
+        aggregate_worker_count = 3
       }
       us-dc = {
-        intake_worker_count                    = 5
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 5
+        aggregate_worker_count = 3
       }
       us-la = {
-        intake_worker_count                    = 5
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 5
+        aggregate_worker_count = 3
       }
     }
   }
@@ -114,82 +88,56 @@ ingestors = {
         portal_server_manifest_base_url        = "manifest.int.enpa-pha.io"
       }
       us-ct = {
-        intake_worker_count                    = 3
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-md = {
-        intake_worker_count                    = 3
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-va = {
-        intake_worker_count                    = 3
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-wa = {
-        intake_worker_count                    = 3
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-ca = {
-        intake_worker_count                    = 15
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 15
+        aggregate_worker_count = 3
       }
       us-ut = {
-        intake_worker_count                    = 3
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-wi = {
-        intake_worker_count                    = 3
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-ma = {
-        intake_worker_count                    = 3
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-nm = {
-        intake_worker_count                    = 3
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-hi = {
-        intake_worker_count                    = 3
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-co = {
-        intake_worker_count                    = 3
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-dc = {
-        intake_worker_count                    = 3
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
       us-la = {
-        intake_worker_count                    = 3
-        aggregate_worker_count                 = 3
-        peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
-        portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
       }
     }
   }
@@ -210,3 +158,6 @@ facilitator_version                       = "0.6.13"
 pushgateway                               = "prometheus-pushgateway.monitoring:9091"
 prometheus_server_persistent_disk_size_gb = 1000
 victorops_routing_key                     = "prio-prod-us"
+
+default_peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
+default_portal_server_manifest_base_url        = "manifest.enpa-pha.io"

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -19,6 +19,8 @@ ingestors = {
         aggregate_worker_count                 = 1
         peer_share_processor_manifest_base_url = "test-en-analytics.cancer.gov"
         portal_server_manifest_base_url        = "manifest.int.enpa-pha.io"
+        aggregation_period                     = "30m"
+        aggregation_grace_period               = "30m"
       }
       us-ct = {
         intake_worker_count                    = 8
@@ -201,8 +203,8 @@ cluster_settings = {
 }
 is_first                                  = false
 use_aws                                   = false
-aggregation_period                        = "8h"
-aggregation_grace_period                  = "4h"
+default_aggregation_period                = "8h"
+default_aggregation_grace_period          = "4h"
 workflow_manager_version                  = "0.6.13"
 facilitator_version                       = "0.6.13"
 pushgateway                               = "prometheus-pushgateway.monitoring:9091"

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -74,4 +74,5 @@ workflow_manager_version = "0.6.16"
 facilitator_version      = "0.6.16"
 pushgateway              = "prometheus-pushgateway.monitoring:9091"
 victorops_routing_key    = "prio-staging"
-aggregation_period       = "30m"
+
+default_aggregation_period = "30m"

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -13,22 +13,16 @@ ingestors = {
     manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests/singleton-ingestor"
     localities = {
       narnia = {
-        intake_worker_count                    = 1
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
-        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
       }
       gondor = {
-        intake_worker_count                    = 2
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
-        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
+        intake_worker_count    = 2
+        aggregate_worker_count = 1
       }
       asgard = {
-        intake_worker_count                    = 1
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
-        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
       }
     }
   }
@@ -36,22 +30,16 @@ ingestors = {
     manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests/singleton-ingestor"
     localities = {
       narnia = {
-        intake_worker_count                    = 2
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
-        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
+        intake_worker_count    = 2
+        aggregate_worker_count = 1
       }
       gondor = {
-        intake_worker_count                    = 1
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
-        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
       }
       asgard = {
-        intake_worker_count                    = 1
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
-        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
       }
     }
   }
@@ -76,3 +64,6 @@ pushgateway              = "prometheus-pushgateway.monitoring:9091"
 victorops_routing_key    = "prio-staging"
 
 default_aggregation_period = "30m"
+
+default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
+default_portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -41,5 +41,6 @@ pure_gcp                 = true
 facilitator_version      = "0.6.15"
 workflow_manager_version = "0.6.15"
 pushgateway              = "prometheus-pushgateway.monitoring:9091"
-aggregation_period       = "30m"
-aggregation_grace_period = "10m"
+
+default_aggregation_period       = "30m"
+default_aggregation_grace_period = "10m"

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -9,10 +9,8 @@ ingestors = {
     manifest_base_url = "storage.googleapis.com/prio-manifests"
     localities = {
       na-na = {
-        intake_worker_count                    = 1
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-server-manifests"
-        portal_server_manifest_base_url        = "isrg-prio-staging-intl-manifest.s3.us-west-2.amazonaws.com/portal-server"
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
       }
     }
   }
@@ -20,10 +18,8 @@ ingestors = {
     manifest_base_url = "exposure-notification.apple.com/manifest"
     localities = {
       na-na = {
-        intake_worker_count                    = 1
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-server-manifests"
-        portal_server_manifest_base_url        = "isrg-prio-staging-intl-manifest.s3.us-west-2.amazonaws.com/portal-server"
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
       }
     }
   }
@@ -44,3 +40,6 @@ pushgateway              = "prometheus-pushgateway.monitoring:9091"
 
 default_aggregation_period       = "30m"
 default_aggregation_grace_period = "10m"
+
+default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-server-manifests"
+default_portal_server_manifest_base_url        = "isrg-prio-staging-intl-manifest.s3.us-west-2.amazonaws.com/portal-server"

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -13,22 +13,16 @@ ingestors = {
     manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests/singleton-ingestor"
     localities = {
       narnia = {
-        intake_worker_count                    = 1
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
-        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
       }
       gondor = {
-        intake_worker_count                    = 2
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
-        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
+        intake_worker_count    = 2
+        aggregate_worker_count = 1
       }
       asgard = {
-        intake_worker_count                    = 1
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
-        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
       }
     }
   }
@@ -36,22 +30,16 @@ ingestors = {
     manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests/singleton-ingestor"
     localities = {
       narnia = {
-        intake_worker_count                    = 2
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
-        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
+        intake_worker_count    = 2
+        aggregate_worker_count = 1
       }
       gondor = {
-        intake_worker_count                    = 1
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
-        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
       }
       asgard = {
-        intake_worker_count                    = 1
-        aggregate_worker_count                 = 1
-        peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
-        portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
+        intake_worker_count    = 1
+        aggregate_worker_count = 1
       }
     }
   }
@@ -76,3 +64,6 @@ pushgateway              = "prometheus-pushgateway.monitoring:9091"
 victorops_routing_key    = "prio-staging"
 
 default_aggregation_period = "30m"
+
+default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
+default_portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -74,4 +74,5 @@ workflow_manager_version = "0.6.13"
 facilitator_version      = "0.6.13"
 pushgateway              = "prometheus-pushgateway.monitoring:9091"
 victorops_routing_key    = "prio-staging"
-aggregation_period       = "30m"
+
+default_aggregation_period = "30m"


### PR DESCRIPTION
This series of commits makes use of [optional object fields](https://www.terraform.io/docs/language/expressions/type-constraints.html#experimental-optional-object-type-attributes) so that peer server manifest URLs and aggregation period parameters can optionally be set per-locality, defaulting to environment-wide variables set in tfvars. This allows us to have individual localities behave differently (e.g., the `ta-ta` locality in `prod-us` which uses different parameters than other localities) without repetitive config blocks in tfvars files.

Resolves #789