### PR TITLE
terraform: configure staging-intl for MITRE server

### DIFF
--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -34,12 +34,12 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-facilitator_version      = "0.6.15"
-workflow_manager_version = "0.6.15"
+facilitator_version      = "0.6.16"
+workflow_manager_version = "0.6.16"
 pushgateway              = "prometheus-pushgateway.monitoring:9091"
 
 default_aggregation_period       = "30m"
 default_aggregation_grace_period = "10m"
 
 default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-server-manifests"
-default_portal_server_manifest_base_url        = "isrg-prio-staging-intl-manifest.s3.us-west-2.amazonaws.com/portal-server"
+default_portal_server_manifest_base_url        = "manifest.int.enpa-pha.io"


### PR DESCRIPTION
Following discussion in the 2021/08/11 international ENPA sync, we are
configuring the staging-intl environment to send sum parts to the
staging MITRE portal server instance. We also take the opportunity to
deploy the latest `prio-facilitator` and `prio-workflow-manager` images
into that environment.
