### PR TITLE
facilitator: move `rusoto-mock` to dev-dependency

### DIFF
--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -35,7 +35,6 @@ rand = "0.8"
 regex = "^1.5.4"
 ring = { version = "0.16.20", features = ["std"] }
 rusoto_core = { version = "^0.47", default_features = false, features = ["rustls"] }
-rusoto_mock = { version = "^0.47", default_features = false, features = ["rustls"] }
 rusoto_s3 = { version = "^0.47", default_features = false, features = ["rustls"] }
 rusoto_sqs = { version = "^0.47", default_features = false, features = ["rustls"] }
 rusoto_sts = { version = "^0.47", default_features = false, features = ["rustls"] }
@@ -59,4 +58,5 @@ xml-rs = "0.8"
 [dev-dependencies]
 assert_matches = "1.5.0"
 mockito = "0.30.0"
+rusoto_mock = { version = "^0.47", default_features = false, features = ["rustls"] }
 serde_test = "1.0"


### PR DESCRIPTION
With some targeted use of `#[cfg(test)]`, we can omit
`aws_credentials::Provider::Mock` from the binary target of
`facilitator`, since it is only actually used in test targets. This
reduces binary size in the `release` configuration by 58,600 bytes
(`facilitator` is 27233040 bytes before, 27174440 after).