### PR TITLE
facilitator: stop writing validation packets to our own storage.

### DIFF
--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -57,6 +57,7 @@ xml-rs = "0.8"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
+hex = "0.4.3"
 mockito = "0.30.0"
 rusoto_mock = { version = "^0.47", default_features = false, features = ["rustls"] }
 serde_test = "1.0"

--- a/facilitator/src/aggregation.rs
+++ b/facilitator/src/aggregation.rs
@@ -1,5 +1,6 @@
 use crate::{
     batch::{Batch, BatchReader, BatchWriter},
+    generate_validation_packet,
     idl::{
         IngestionDataSharePacket, IngestionHeader, InvalidPacket, Packet, SumPart,
         ValidationHeader, ValidationPacket,
@@ -31,7 +32,6 @@ pub struct BatchAggregator<'a> {
     aggregation_name: &'a str,
     aggregation_start: &'a NaiveDateTime,
     aggregation_end: &'a NaiveDateTime,
-    own_validation_transport: &'a mut VerifiableTransport,
     peer_validation_transport: &'a mut VerifiableTransport,
     ingestion_transport: &'a mut VerifiableAndDecryptableTransport,
     aggregation_batch: BatchWriter<'a, SumPart, InvalidPacket>,
@@ -52,7 +52,6 @@ impl<'a> BatchAggregator<'a> {
         is_first: bool,
         permit_malformed_batch: bool,
         ingestion_transport: &'a mut VerifiableAndDecryptableTransport,
-        own_validation_transport: &'a mut VerifiableTransport,
         peer_validation_transport: &'a mut VerifiableTransport,
         aggregation_transport: &'a mut SignableTransport,
         parent_logger: &Logger,
@@ -61,7 +60,6 @@ impl<'a> BatchAggregator<'a> {
             event::TRACE_ID => trace_id.to_string(),
             event::AGGREGATION_NAME => aggregation_name.to_owned(),
             event::INGESTION_PATH => ingestion_transport.transport.transport.path(),
-            event::OWN_VALIDATION_PATH => own_validation_transport.transport.path(),
             event::PEER_VALIDATION_PATH => peer_validation_transport.transport.path(),
         ));
         Ok(BatchAggregator {
@@ -71,7 +69,6 @@ impl<'a> BatchAggregator<'a> {
             aggregation_name,
             aggregation_start,
             aggregation_end,
-            own_validation_transport,
             peer_validation_transport,
             ingestion_transport,
             aggregation_batch: BatchWriter::new(
@@ -225,14 +222,6 @@ impl<'a> BatchAggregator<'a> {
                 self.trace_id,
                 &self.logger,
             );
-        let mut own_validation_batch: BatchReader<'_, ValidationHeader, ValidationPacket> =
-            BatchReader::new(
-                Batch::new_validation(self.aggregation_name, batch_id, batch_date, self.is_first),
-                &mut *self.own_validation_transport.transport,
-                self.permit_malformed_batch,
-                self.trace_id,
-                &self.logger,
-            );
         let mut peer_validation_batch: BatchReader<'_, ValidationHeader, ValidationPacket> =
             BatchReader::new(
                 Batch::new_validation(self.aggregation_name, batch_id, batch_date, !self.is_first),
@@ -243,8 +232,6 @@ impl<'a> BatchAggregator<'a> {
             );
 
         if let Some(collector) = self.metrics_collector {
-            own_validation_batch
-                .set_metrics_collector(&collector.own_validation_batches_reader_metrics);
             peer_validation_batch
                 .set_metrics_collector(&collector.peer_validation_batches_reader_metrics);
         }
@@ -252,20 +239,10 @@ impl<'a> BatchAggregator<'a> {
         let peer_validation_header = peer_validation_batch
             .header(&self.peer_validation_transport.batch_signing_public_keys)?;
 
-        let own_validation_header = own_validation_batch
-            .header(&self.own_validation_transport.batch_signing_public_keys)?;
-
         let ingestion_header = ingestion_batch
             .header(&self.ingestion_transport.transport.batch_signing_public_keys)?;
 
         // Make sure all the parameters in the headers line up
-        if !peer_validation_header.check_parameters(&own_validation_header) {
-            return Err(anyhow!(
-                "validation headers do not match. Peer: {:?}\nOwn: {:?}",
-                peer_validation_header,
-                own_validation_header
-            ));
-        }
         if !ingestion_header.check_parameters(&peer_validation_header) {
             return Err(anyhow!(
                 "ingestion header does not match peer validation header. Ingestion: {:?}\nPeer:{:?}",
@@ -287,12 +264,6 @@ impl<'a> BatchAggregator<'a> {
             peer_validation_batch.packet_file_reader(&peer_validation_header)?;
         let peer_validation_packets: HashMap<Uuid, ValidationPacket> =
             validation_packet_map(&mut peer_validation_packet_file_reader)?;
-
-        let mut own_validation_packet_file_reader =
-            own_validation_batch.packet_file_reader(&own_validation_header)?;
-
-        let own_validation_packets: HashMap<Uuid, ValidationPacket> =
-            validation_packet_map(&mut own_validation_packet_file_reader)?;
 
         // Keep track of the ingestion packets we have seen so we can reject
         // duplicates.
@@ -330,22 +301,12 @@ impl<'a> BatchAggregator<'a> {
                 invalid_uuids,
                 logger,
             );
-            let peer_validation_packet: &ValidationPacket = match peer_validation_packet {
+            let peer_validation_packet = match peer_validation_packet {
                 Some(p) => p,
                 None => continue,
             };
 
-            let own_validation_packet = get_validation_packet(
-                &ingestion_packet.uuid,
-                &own_validation_packets,
-                "own",
-                invalid_uuids,
-                logger,
-            );
-            let own_validation_packet: &ValidationPacket = match own_validation_packet {
-                Some(p) => p,
-                None => continue,
-            };
+            let own_validation_packet = generate_validation_packet(servers, &ingestion_packet)?;
 
             processed_ingestion_packets.insert(ingestion_packet.uuid);
 
@@ -355,7 +316,7 @@ impl<'a> BatchAggregator<'a> {
                 match server.aggregate(
                     &ingestion_packet.encrypted_payload,
                     &VerificationMessage::try_from(peer_validation_packet)?,
-                    &VerificationMessage::try_from(own_validation_packet)?,
+                    &VerificationMessage::try_from(&own_validation_packet)?,
                 ) {
                     Ok(valid) => {
                         if !valid {

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -1343,22 +1343,6 @@ where
         batch_signing_key: batch_signing_key_from_arg(sub_matches)?,
     };
 
-    // We created the bucket to which we write copies of our validation
-    // shares, so it is simply provided by argument.
-    let mut own_validation_transport = SignableTransport {
-        transport: transport_from_args(
-            value_t!(
-                sub_matches.value_of(Entity::Own.suffix("-identity")),
-                Identity
-            )?,
-            Entity::Own,
-            PathOrInOut::InOut(InOut::Output),
-            sub_matches,
-            parent_logger,
-        )?,
-        batch_signing_key: batch_signing_key_from_arg(sub_matches)?,
-    };
-
     let batch_id: Uuid = Uuid::parse_str(batch_id).unwrap();
 
     let date: NaiveDateTime = NaiveDateTime::parse_from_str(date, DATE_FORMAT).unwrap();
@@ -1370,7 +1354,6 @@ where
         &date,
         &mut intake_transport,
         &mut peer_validation_transport,
-        &mut own_validation_transport,
         is_first_from_arg(sub_matches),
         Some("true") == sub_matches.value_of("permit-malformed-batch"),
         parent_logger,
@@ -1499,46 +1482,6 @@ where
 
     let mut intake_transport = intake_transport_from_args(sub_matches, logger)?;
 
-    // We created the bucket to which we wrote copies of our validation
-    // shares, so it is simply provided by argument.
-    let own_validation_transport = transport_from_args(
-        value_t!(
-            sub_matches.value_of(Entity::Own.suffix("-identity")),
-            Identity
-        )?,
-        Entity::Own,
-        PathOrInOut::InOut(InOut::Input),
-        sub_matches,
-        logger,
-    )?;
-
-    // To read our own validation shares, we require our own public keys which
-    // we discover in our own specific manifest. If no manifest is provided, use
-    // the public portion of the provided batch signing private key.
-    let own_public_key_map = match (
-        sub_matches.value_of("own-manifest-base-url"),
-        sub_matches.value_of("batch-signing-private-key"),
-        sub_matches.value_of("batch-signing-private-key-identifier"),
-    ) {
-        (Some(manifest_base_url), _, _) => DataShareProcessorSpecificManifest::from_https(
-            manifest_base_url,
-            instance_name,
-            logger,
-        )?
-        .batch_signing_public_keys()?,
-
-        (_, Some(private_key), Some(private_key_identifier)) => {
-            public_key_map_from_arg(private_key, private_key_identifier)?
-        }
-        _ => {
-            return Err(anyhow!(
-                "batch-signing-private-key and \
-                batch-signing-private-key-identifier are required if \
-                own-manifest-base-url is not provided."
-            ));
-        }
-    };
-
     // We created the bucket that peers wrote validations into, and so
     // it is simply provided via argument.
     let peer_validation_transport = transport_from_args(
@@ -1614,10 +1557,6 @@ where
     let start: NaiveDateTime = NaiveDateTime::parse_from_str(start, DATE_FORMAT).unwrap();
     let end: NaiveDateTime = NaiveDateTime::parse_from_str(end, DATE_FORMAT).unwrap();
 
-    let mut own_validation_transport = VerifiableTransport {
-        transport: own_validation_transport,
-        batch_signing_public_keys: own_public_key_map,
-    };
     let mut peer_validation_transport = VerifiableTransport {
         transport: peer_validation_transport,
         batch_signing_public_keys: peer_share_processor_pub_key_map,
@@ -1644,7 +1583,6 @@ where
         is_first,
         Some("true") == sub_matches.value_of("permit-malformed-batch"),
         &mut intake_transport,
-        &mut own_validation_transport,
         &mut peer_validation_transport,
         &mut aggregation_transport,
         logger,

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -1,5 +1,11 @@
-use anyhow::Result;
+use crate::idl::{IngestionDataSharePacket, ValidationPacket};
+use anyhow::{anyhow, Context, Result};
+use prio::{
+    field::Field32,
+    server::{Server, ServerError},
+};
 use ring::{digest, signature::EcdsaKeyPair};
+use std::convert::TryFrom;
 use std::io::Write;
 
 pub mod aggregation;
@@ -39,15 +45,57 @@ pub enum Error {
     HttpError(#[from] ureq::Error),
 }
 
-/// An implementation of transport::TransportWriter that computes a SHA256
-/// digest over the content it is provided.
-pub struct DigestWriter {
+pub fn generate_validation_packet(
+    servers: &mut Vec<Server<Field32>>,
+    packet: &IngestionDataSharePacket,
+) -> Result<ValidationPacket> {
+    let r_pit = Field32::from(
+        u32::try_from(packet.r_pit)
+            .with_context(|| format!("illegal r_pit value {}", packet.r_pit))?,
+    );
+
+    // TODO(timg): if this fails for a non-empty subset of the
+    // ingestion packets, do we abort handling of the entire
+    // batch (as implemented currently) or should we record it
+    // as an invalid UUID and emit a validation batch for the
+    // other packets?
+    for server in servers.iter_mut() {
+        let validation_message = match server
+            .generate_verification_message(r_pit, &packet.encrypted_payload)
+        {
+            Ok(m) => m,
+            Err(ServerError::Encrypt(_)) => {
+                continue;
+            }
+            Err(e) => {
+                return Err(anyhow::Error::new(e).context("error generating verification message"));
+            }
+        };
+
+        return Ok(ValidationPacket {
+            uuid: packet.uuid,
+            f_r: u32::from(validation_message.f_r) as i64,
+            g_r: u32::from(validation_message.g_r) as i64,
+            h_r: u32::from(validation_message.h_r) as i64,
+        });
+    }
+
+    return Err(anyhow!(
+        "failed to construct validation message for packet {} because all decryption attempts failed (key mismatch?)",
+        packet.uuid
+    ));
+}
+
+/// A wrapper-writer that computes a SHA256 digest over the content it is provided.
+pub struct DigestWriter<W: Write> {
+    writer: W,
     context: digest::Context,
 }
 
-impl DigestWriter {
-    fn new() -> DigestWriter {
+impl<W: Write> DigestWriter<W> {
+    fn new(writer: W) -> DigestWriter<W> {
         DigestWriter {
+            writer,
             context: digest::Context::new(&digest::SHA256),
         }
     }
@@ -58,46 +106,17 @@ impl DigestWriter {
     }
 }
 
-impl Write for DigestWriter {
+impl<W: Write> Write for DigestWriter<W> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
-        self.context.update(buf);
-        Ok(buf.len())
+        let rslt = self.writer.write(buf);
+        if let Ok(n) = rslt {
+            self.context.update(&buf[..n]);
+        }
+        rslt
     }
 
     fn flush(&mut self) -> Result<(), std::io::Error> {
-        Ok(())
-    }
-}
-
-/// SidecarWriter wraps a vector of std::io::Writes of one type and writes all
-/// provided buffers to them. It also writes all buffers to an additional
-/// instance of std::io:Write that may be of a different type than the ones in
-/// the vector.
-pub struct SidecarWriter<T: Write, W: Write> {
-    writers: Vec<T>,
-    sidecar: W,
-}
-
-impl<T: Write, W: Write> SidecarWriter<T, W> {
-    fn new(writers: Vec<T>, sidecar: W) -> SidecarWriter<T, W> {
-        SidecarWriter { writers, sidecar }
-    }
-}
-
-impl<T: Write, W: Write> Write for SidecarWriter<T, W> {
-    fn write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
-        for writer in &mut self.writers {
-            writer.write_all(buf)?;
-        }
-        self.sidecar.write_all(buf)?;
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> Result<(), std::io::Error> {
-        for writer in &mut self.writers {
-            writer.flush()?;
-        }
-        self.sidecar.flush()
+        self.writer.flush()
     }
 }
 
@@ -129,22 +148,17 @@ mod tests {
 
     #[test]
     fn digest_writer_test() {
-        let mut writer = DigestWriter::new();
-        let written = writer
-            .write("I expect to be written into sha256".to_string().as_bytes())
-            .unwrap();
+        const TEST_STR: &[u8] = b"I expect to be written into sha256";
+        const TEST_STR_DIGEST: &str =
+            "b1b64ca32c118bfd5d1f40fdb25314468f82c0e9427f4f107ddfa89ce357a3ec"; // verified via sha256sum
 
-        assert_eq!(written, 34);
+        let mut written: Vec<u8> = Vec::new();
+        let mut writer = DigestWriter::new(&mut written);
+        let written_cnt = writer.write(TEST_STR).unwrap();
+        let digest = hex::encode(writer.finish().as_ref());
 
-        let digest = writer.finish();
-        let sha = digest.as_ref();
-
-        let hexed_sha = format!("{:02x?}", sha);
-        let hexed_sha = hexed_sha.replace(|ch| !char::is_alphanumeric(ch), "");
-
-        assert_eq!(
-            hexed_sha,
-            "b1b64ca32c118bfd5d1f40fdb25314468f82c0e9427f4f107ddfa89ce357a3ec".to_string()
-        )
+        assert_eq!(written_cnt, TEST_STR.len());
+        assert_eq!(&written[..], TEST_STR);
+        assert_eq!(&digest, TEST_STR_DIGEST);
     }
 }

--- a/facilitator/src/logging.rs
+++ b/facilitator/src/logging.rs
@@ -26,8 +26,6 @@ pub mod event {
     pub(crate) const AGGREGATION_NAME: EventKey = "aggregation_name";
     /// The storage path from which ingestion batches are read/written
     pub(crate) const INGESTION_PATH: EventKey = "ingestion_path";
-    /// The storage path from which own validation batches are read/written
-    pub(crate) const OWN_VALIDATION_PATH: EventKey = "own_validation_path";
     /// The storage path from which peer validation batches are read/written
     pub(crate) const PEER_VALIDATION_PATH: EventKey = "peer_validation_path";
     /// The UUID of a packet that something happened to


### PR DESCRIPTION
Instead, we recompute them as needed during aggregation--this works
because our validation packet is a function of the ingestion packet,
which we already read during aggregation. We still write validation
packet to our peer's storage, since knowing your peer's validation
packets is a requirement to perform validation.