### PR TITLE
workflow-manager: accept aggregation-window override.

### DIFF
--- a/workflow-manager/main_test.go
+++ b/workflow-manager/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"path"
 	"reflect"
 	"testing"
 	"time"
@@ -54,14 +55,14 @@ func (b *mockBucket) WriteTaskMarker(marker string) error {
 }
 
 func TestScheduleIntakeTasks(t *testing.T) {
-	batchTime, _ := time.Parse("2006/01/02/15/04", "2020/10/31/20/29")
-	within24Hours, _ := time.Parse("2006/01/02/15/04", "2020/10/31/23/29")
-	maxAge, _ := time.ParseDuration("24h")
-	aggregationPeriod, _ := time.ParseDuration("8h")
-	gracePeriod, _ := time.ParseDuration("4h")
+	batchTime := mustParseTime(t, "2020/10/31/20/29")
+	now := mustParseTime(t, "2020/10/31/23/29") // within 24 hours of batchTime
+	maxAge := 24 * time.Hour
+	aggregationPeriod := 8 * time.Hour
+	gracePeriod := 4 * time.Hour
 	intakeMarker := "intake-kittens-seen-2020-10-31-20-29-b8a5579a-f984-460a-a42d-2813cbf57771"
 
-	var testCases = []struct {
+	for _, testCase := range []struct {
 		name               string
 		taskMarkerExists   bool
 		expectedIntakeTask *task.IntakeBatch
@@ -84,11 +85,9 @@ func TestScheduleIntakeTasks(t *testing.T) {
 			expectedIntakeTask: nil,
 			expectedTaskMarker: "",
 		},
-	}
-
-	for _, testCase := range testCases {
+	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			clock := wftime.ClockWithFixedNow(within24Hours)
+			clock := wftime.ClockWithFixedNow(now)
 
 			intakeBucket := mockBucket{
 				aggregationIDs: []string{"kittens-seen"},
@@ -114,7 +113,7 @@ func TestScheduleIntakeTasks(t *testing.T) {
 			intakeTaskEnqueuer := mockEnqueuer{enqueuedTasks: []task.Task{}}
 			aggregateTaskEnqueuer := mockEnqueuer{enqueuedTasks: []task.Task{}}
 
-			err := scheduleTasks(scheduleTasksConfig{
+			if err := scheduleTasks(scheduleTasksConfig{
 				aggregationID:           "kittens-seen",
 				isFirst:                 false,
 				clock:                   clock,
@@ -124,10 +123,8 @@ func TestScheduleIntakeTasks(t *testing.T) {
 				intakeTaskEnqueuer:      &intakeTaskEnqueuer,
 				aggregationTaskEnqueuer: &aggregateTaskEnqueuer,
 				maxAge:                  maxAge,
-				aggregationPeriod:       aggregationPeriod,
-				gracePeriod:             gracePeriod,
-			})
-			if err != nil {
+				aggregationInterval:     standardAggregationWindow(aggregationPeriod, gracePeriod),
+			}); err != nil {
 				t.Errorf("unexpected error %q", err)
 			}
 
@@ -164,8 +161,9 @@ func TestScheduleIntakeTasks(t *testing.T) {
 				}
 			} else {
 				foundExpectedMarker := false
+				wantedObject := path.Join("task-markers", testCase.expectedTaskMarker)
 				for _, object := range ownValidationBucket.writtenObjectKeys {
-					if object == "task-markers/"+testCase.expectedTaskMarker {
+					if object == wantedObject {
 						foundExpectedMarker = true
 						break
 					}
@@ -179,80 +177,104 @@ func TestScheduleIntakeTasks(t *testing.T) {
 }
 
 func TestScheduleAggregationTasks(t *testing.T) {
-	batchTime, _ := time.Parse("2006/01/02/15/04", "2020/10/31/20/29")
-	aggregationStart, _ := time.Parse("2006/01/02/15/04", "2020/10/31/16/00")
-	aggregationEnd, _ := time.Parse("2006/01/02/15/04", "2020/11/01/00/00")
-	withinWindow, _ := time.Parse("2006/01/02/15/04", "2020/11/01/04/01")
-	maxAge, _ := time.ParseDuration("24h")
-	aggregationPeriod, _ := time.ParseDuration("8h")
-	gracePeriod, _ := time.ParseDuration("4h")
+	batchTime := mustParseTime(t, "2020/10/31/20/29")
+	aggregationStart := mustParseTime(t, "2020/10/31/16/00")
+	aggregationEnd := mustParseTime(t, "2020/11/01/00/00")
+	aggregationMidpoint := aggregationStart.Add(aggregationEnd.Sub(aggregationStart) / 2)
+	now := mustParseTime(t, "2020/11/01/04/01")
+	maxAge := 24 * time.Hour
+	aggregationPeriod := 8 * time.Hour
+	gracePeriod := 4 * time.Hour
 	aggregationMarker := "aggregate-kittens-seen-2020-10-31-16-00-2020-11-01-00-00"
 	expectedAggregationTask := &task.Aggregation{
 		TraceID:          expectedUuid,
 		AggregationID:    "kittens-seen",
 		AggregationStart: wftime.Timestamp(aggregationStart),
 		AggregationEnd:   wftime.Timestamp(aggregationEnd),
-		Batches: []task.Batch{
-			task.Batch{
-				ID:   "b8a5579a-f984-460a-a42d-2813cbf57771",
-				Time: wftime.Timestamp(batchTime),
-			},
-		},
+		Batches: []task.Batch{{
+			ID:   "b8a5579a-f984-460a-a42d-2813cbf57771",
+			Time: wftime.Timestamp(batchTime),
+		}},
 	}
 
-	var testCases = []struct {
+	for _, testCase := range []struct {
 		name                    string
 		hasOwnValidation        bool
 		hasPeerValidation       bool
 		taskMarkerExists        bool
+		aggregationInterval     aggregationIntervalFunc
 		expectedAggregationTask *task.Aggregation
 		expectedTaskMarker      string
 	}{
+		// Standard aggregation window tests.
 		{
-			name:                    "within-window-no-own-no-peer",
+			name:                    "standard-within-window-no-own-no-peer",
 			hasOwnValidation:        false,
 			hasPeerValidation:       false,
 			taskMarkerExists:        false,
+			aggregationInterval:     standardAggregationWindow(aggregationPeriod, gracePeriod),
 			expectedAggregationTask: nil,
 			expectedTaskMarker:      "",
 		},
 		{
-			name:                    "within-window-no-own-has-peer",
+			name:                    "standard-within-window-no-own-has-peer",
 			hasOwnValidation:        false,
 			hasPeerValidation:       true,
 			taskMarkerExists:        false,
+			aggregationInterval:     standardAggregationWindow(aggregationPeriod, gracePeriod),
 			expectedAggregationTask: nil,
 			expectedTaskMarker:      "",
 		},
 		{
-			name:                    "within-window-has-own-no-peer",
+			name:                    "standard-within-window-has-own-no-peer",
 			hasOwnValidation:        true,
 			hasPeerValidation:       false,
 			taskMarkerExists:        false,
+			aggregationInterval:     standardAggregationWindow(aggregationPeriod, gracePeriod),
 			expectedAggregationTask: nil,
 			expectedTaskMarker:      "",
 		},
 		{
-			name:                    "within-window-no-marker",
+			name:                    "standard-within-window-no-marker",
 			hasOwnValidation:        true,
 			hasPeerValidation:       true,
 			taskMarkerExists:        false,
+			aggregationInterval:     standardAggregationWindow(aggregationPeriod, gracePeriod),
 			expectedAggregationTask: expectedAggregationTask,
 			expectedTaskMarker:      aggregationMarker,
 		},
 		{
-			name:                    "within-window-has-marker",
+			name:                    "standard-within-window-has-marker",
 			hasOwnValidation:        true,
 			hasPeerValidation:       true,
 			taskMarkerExists:        true,
+			aggregationInterval:     standardAggregationWindow(aggregationPeriod, gracePeriod),
 			expectedAggregationTask: nil,
 			expectedTaskMarker:      "",
 		},
-	}
 
-	for _, testCase := range testCases {
+		// Override aggregation window tests.
+		{
+			name:                    "override-within-window-no-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			taskMarkerExists:        false,
+			aggregationInterval:     overrideAggregationWindow(aggregationMidpoint, aggregationPeriod),
+			expectedAggregationTask: expectedAggregationTask,
+			expectedTaskMarker:      aggregationMarker,
+		},
+		{
+			name:                    "override-within-window-has-marker",
+			hasOwnValidation:        true,
+			hasPeerValidation:       true,
+			taskMarkerExists:        true,
+			aggregationInterval:     overrideAggregationWindow(aggregationMidpoint, aggregationPeriod),
+			expectedAggregationTask: nil,
+			expectedTaskMarker:      "",
+		},
+	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			clock := wftime.ClockWithFixedNow(withinWindow)
+			clock := wftime.ClockWithFixedNow(now)
 
 			intakeBucket := mockBucket{
 				aggregationIDs: []string{"kittens-seen"},
@@ -295,7 +317,7 @@ func TestScheduleAggregationTasks(t *testing.T) {
 			intakeTaskEnqueuer := mockEnqueuer{enqueuedTasks: []task.Task{}}
 			aggregateTaskEnqueuer := mockEnqueuer{enqueuedTasks: []task.Task{}}
 
-			err := scheduleTasks(scheduleTasksConfig{
+			if err := scheduleTasks(scheduleTasksConfig{
 				aggregationID:           "kittens-seen",
 				isFirst:                 false,
 				clock:                   clock,
@@ -305,20 +327,18 @@ func TestScheduleAggregationTasks(t *testing.T) {
 				intakeTaskEnqueuer:      &intakeTaskEnqueuer,
 				aggregationTaskEnqueuer: &aggregateTaskEnqueuer,
 				maxAge:                  maxAge,
-				aggregationPeriod:       aggregationPeriod,
-				gracePeriod:             gracePeriod,
-			})
-			if err != nil {
-				t.Errorf("unexpected error: %q", err)
+				aggregationInterval:     testCase.aggregationInterval,
+			}); err != nil {
+				t.Errorf("Unexpected error: %q", err)
 			}
 
 			if len(intakeTaskEnqueuer.enqueuedTasks) != 0 {
-				t.Errorf("unexpected intake tasks scheduled: %q", intakeTaskEnqueuer.enqueuedTasks)
+				t.Errorf("Unexpected intake tasks scheduled: %q", intakeTaskEnqueuer.enqueuedTasks)
 			}
 
 			if testCase.expectedAggregationTask == nil {
 				if len(aggregateTaskEnqueuer.enqueuedTasks) != 0 {
-					t.Errorf("unexpected aggregation tasks scheduled: %q", aggregateTaskEnqueuer.enqueuedTasks)
+					t.Errorf("Unexpected aggregation tasks scheduled: %q", aggregateTaskEnqueuer.enqueuedTasks)
 				}
 			} else {
 				foundExpectedTask := false
@@ -335,26 +355,35 @@ func TestScheduleAggregationTasks(t *testing.T) {
 					}
 				}
 				if !foundExpectedTask {
-					t.Errorf("did not find expected aggregate task among %q", aggregateTaskEnqueuer.enqueuedTasks)
+					t.Errorf("Did not find expected aggregate task among %q", aggregateTaskEnqueuer.enqueuedTasks)
 				}
 			}
 
 			if testCase.expectedTaskMarker == "" {
 				if len(ownValidationBucket.writtenObjectKeys) != 0 {
-					t.Errorf("unexpected task marker written: %q", ownValidationBucket.writtenObjectKeys)
+					t.Errorf("Unexpected task marker written: %q", ownValidationBucket.writtenObjectKeys)
 				}
 			} else {
 				foundExpectedMarker := false
+				wantedObject := path.Join("task-markers", testCase.expectedTaskMarker)
 				for _, object := range ownValidationBucket.writtenObjectKeys {
-					if object == "task-markers/"+testCase.expectedTaskMarker {
+					if object == wantedObject {
 						foundExpectedMarker = true
 						break
 					}
 				}
 				if !foundExpectedMarker {
-					t.Errorf("did not find expected task marker among %q", ownValidationBucket.writtenObjectKeys)
+					t.Errorf("Did not find expected task marker among %q", ownValidationBucket.writtenObjectKeys)
 				}
 			}
 		})
 	}
+}
+
+func mustParseTime(t *testing.T, value string) time.Time {
+	when, err := time.Parse("2006/01/02/15/04", value)
+	if err != nil {
+		t.Fatalf("Couldn't parse %q as time: %v", value, err)
+	}
+	return when
 }

--- a/workflow-manager/time/time.go
+++ b/workflow-manager/time/time.go
@@ -48,11 +48,20 @@ type Interval struct {
 // AggregationInterval calculates the interval we want to run an aggregation
 // for, if any. That is whatever interval is `gracePeriod` earlier than now and
 // aligned on multiples of `aggregationPeriod` (relative to the zero time).
-func AggregationInterval(clock Clock, aggregationPeriod, gracePeriod time.Duration) Interval {
-	var output Interval
-	output.End = clock.Now().Add(-gracePeriod).Truncate(aggregationPeriod)
-	output.Begin = output.End.Add(-aggregationPeriod)
-	return output
+func AggregationInterval(now time.Time, aggregationPeriod, gracePeriod time.Duration) Interval {
+	return AggregationIntervalIncluding(now.Add(-gracePeriod).Add(-aggregationPeriod), aggregationPeriod)
+}
+
+// AggregationIntervalIncluding calculates an interval of aggregation, given a point of time inside
+// that interval.
+// The start of the returned interval will be the given point in time, truncated to the nearest
+// multiple of the aggregation period (relative to the zero time).
+func AggregationIntervalIncluding(when time.Time, aggregationPeriod time.Duration) Interval {
+	start := when.Truncate(aggregationPeriod)
+	return Interval{
+		Begin: start,
+		End:   start.Add(aggregationPeriod),
+	}
 }
 
 func (i Interval) String() string {


### PR DESCRIPTION
This is implemented by the new `--aggregation-override-timestamp` flag.
Normally (without this flag), the most recently completed aggregation
window (shifted by a grace period) will be aggregated. With this flag,
the aggregation window containing the override timestamp will be
aggregated instead.

Note that for an aggregation to actually be triggered, it still must
pass the other requirements. Specifically, the relevant validations must
have been written, and no task marker must exist for the window.