### PR TITLE
change dependabot interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,28 +4,28 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/deploy-tool"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "cargo"
     directory: "/facilitator"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "docker"
     directory: "/facilitator"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "terraform"
     directory: "/terraform"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/workflow-manager"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "docker"
     directory: "/workflow-manager"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/task-replayer"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
Daily dependabot checks yields _a lot_ of PRs, many of which are
obsoleted by the time we get around to merging them. As our release
cadence slows, we can afford to take dependency updates less often and
generate less noise and integration overhead for maintainers.