### PR TITLE
Updates based on Staging release.

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -118,7 +118,8 @@ apply-bootstrap: prep ## Have terraform bring up the minimal resources needed to
 		-target=module.fake_server_resources \
 		-target=module.portal_server_resources \
 		-target=module.gke \
-		-target=module.eks
+		-target=module.eks \
+		-target=module.custom_metrics
 	echo "If that succeeded, run 'terraform output --json | (cd ../deploy-tool/ ; go run main.go )'"
 
 .PHONY: destroy-bootstrap
@@ -133,7 +134,8 @@ destroy-bootstrap: prep ## Have terraform destroy the resources brought up by ap
 		-target=module.fake_server_resources \
 		-target=module.portal_server_resources \
 		-target=module.gke \
-		-target=module.eks
+		-target=module.eks \
+		-target=module.custom_metrics
 
 .PHONY: apply-target
 apply-target: prep ## Have terraform do the things for a specific resource. This will cost money.

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -58,8 +58,8 @@ test_peer_environment = {
 }
 is_first                 = false
 use_aws                  = false
-workflow_manager_version = "0.6.16"
-facilitator_version      = "0.6.16"
+workflow_manager_version = "0.6.17"
+facilitator_version      = "0.6.17"
 victorops_routing_key    = "prio-staging"
 
 default_aggregation_period = "30m"

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -34,8 +34,8 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-facilitator_version      = "0.6.16"
-workflow_manager_version = "0.6.16"
+facilitator_version      = "0.6.17"
+workflow_manager_version = "0.6.17"
 victorops_routing_key    = "prio-staging"
 
 default_aggregation_period       = "30m"

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -58,8 +58,8 @@ test_peer_environment = {
 }
 is_first                 = true
 use_aws                  = true
-workflow_manager_version = "0.6.13"
-facilitator_version      = "0.6.13"
+workflow_manager_version = "0.6.17"
+facilitator_version      = "0.6.17"
 victorops_routing_key    = "prio-staging"
 
 default_aggregation_period = "30m"


### PR DESCRIPTION
* Move "custom metric" setup into the apply-bootstrap phase. This is
  required because the AWS metric config depends on the CRD in the
  custom metrics module, but this dependency isn't expressed in
  terraform.
* Update staging variable files to use the latest version.