### PR TITLE
terraform: force 3 nodes in staging-intl

### DIFF
--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -25,8 +25,8 @@ ingestors = {
   }
 }
 cluster_settings = {
-  initial_node_count = 2
-  min_node_count     = 1
+  initial_node_count = 3
+  min_node_count     = 3
   max_node_count     = 3
   gcp_machine_type   = "e2-standard-2"
   aws_machine_types  = ["t3.large"]


### PR DESCRIPTION
`prometheus-server` and `prometheus-alertmanager` use
`PersistentVolumeClaim`s bound to `PersistentVolume`s backed by EBS
volumes in `us-west-2a`. We force the EKS cluster node pool to be at
least 3 VMs to guarantee that at least one node will be scheduled into
`us-west-2a`, without which we cannot run the metrics stack.