### PR TITLE
Update variables to release 0.6.17 to prod-{intl,us}.

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -106,6 +106,21 @@ apply: prep ## Have terraform do the things. This will cost money.
 		-var-file="$(VARS)"
 	echo "If that succeeded, run 'terraform output --json | (cd ../deploy-tool/ ; go run main.go )'"
 
+.PHONY: plan-bootstrap
+plan-bootstrap: prep ## Show what terraform thinks it will do
+	@terraform plan \
+		-lock=true \
+		-input=false \
+		-refresh=true \
+		-var-file="$(VARS)" \
+		-target=module.manifest_gcp \
+		-target=module.manifest_aws \
+		-target=module.fake_server_resources \
+		-target=module.portal_server_resources \
+		-target=module.gke \
+		-target=module.eks \
+		-target=module.custom_metrics
+
 .PHONY: apply-bootstrap
 apply-bootstrap: prep ## Have terraform bring up the minimal resources needed to bootstrap an env and permit peers to begin deploying
 	@terraform apply \

--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -34,8 +34,8 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-facilitator_version      = "0.6.16"
-workflow_manager_version = "0.6.16"
+facilitator_version      = "0.6.17"
+workflow_manager_version = "0.6.17"
 victorops_routing_key    = "prio-prod-intl"
 
 default_aggregation_period       = "8h"

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -161,8 +161,8 @@ is_first                                  = false
 use_aws                                   = false
 default_aggregation_period                = "8h"
 default_aggregation_grace_period          = "4h"
-workflow_manager_version                  = "0.6.16"
-facilitator_version                       = "0.6.16"
+workflow_manager_version                  = "0.6.17"
+facilitator_version                       = "0.6.17"
 prometheus_server_persistent_disk_size_gb = 1000
 victorops_routing_key                     = "prio-prod-us"
 


### PR DESCRIPTION
Also, add a `make plan-bootstrap` for a safe(r) way to view what `make
apply-bootstrap` will do. This is needed because we need to run `make
apply-bootstrap` to create the custom metrics CRD before we run `make
apply` to set up the HPA metrics.