### PR TITLE
staging-us: reduce intake-max-age from (default) 6h to 30m.

### DIFF
--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -62,7 +62,7 @@ workflow_manager_version = "0.6.17"
 facilitator_version      = "0.6.17"
 victorops_routing_key    = "prio-staging"
 
-intake_max_age             = "60m"
+intake_max_age             = "75m"
 default_aggregation_period = "30m"
 
 default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -62,7 +62,7 @@ workflow_manager_version = "0.6.17"
 facilitator_version      = "0.6.17"
 victorops_routing_key    = "prio-staging"
 
-intake_max_age             = "60m"
+intake_max_age             = "75m"
 default_aggregation_period = "30m"
 
 default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"


### PR DESCRIPTION
This is currently deployed in staging-facil (& NOT deployed in staging-pha).