### PR TITLE
workflow-manager: fix determination of aggregatable batches.

### DIFF
--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -80,13 +80,28 @@ var (
 	ingestionBatchesFound = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "workflow_manager_ingestions_found",
-			Help: "The number of ingestion batches found in the current aggregation interval",
+			Help: "The number of ingestion batches found in the current intake interval",
 		},
 		[]string{"aggregation_id"},
 	)
 	incompleteIngestionBatchesFound = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "workflow_manager_incomplete_ingestions_found",
+			Help: "The number of incomplete ingestion batches found in the current intake interval",
+		},
+		[]string{"aggregation_id"},
+	)
+
+	aggregateIngestionBatchesFound = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "workflow_manager_aggregate_ingestions_found",
+			Help: "The number of ingestion batches found in the current aggregation interval",
+		},
+		[]string{"aggregation_id"},
+	)
+	aggregateIncompleteIngestionBatchesFound = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "workflow_manager_aggregate_incomplete_ingestions_found",
 			Help: "The number of incomplete ingestion batches found in the current aggregation interval",
 		},
 		[]string{"aggregation_id"},
@@ -415,6 +430,8 @@ func scheduleTasks(config scheduleTasksConfig) error {
 		return fmt.Errorf("couldn't determine ready intake batches for aggregation task generation: %w", err)
 	}
 
+	aggregateIngestionBatchesFound.WithLabelValues(config.aggregationID).Set(float64(intakeBatches.Batches.Len()))
+	aggregateIncompleteIngestionBatchesFound.WithLabelValues(config.aggregationID).Set(float64(intakeBatches.IncompleteBatchCount))
 	log.Info().
 		Int("ingestion batches", intakeBatches.Batches.Len()).
 		Int("incomplete ingestion batches", intakeBatches.IncompleteBatchCount).


### PR DESCRIPTION
Previously, we were using the set of intake batches *over the intake
window* to determine which batches to include in an aggregation.
Instead, we should have been using the set of intake batches *over the
aggregation window* -- there is not necessarily any overlap between
these two windows!

In some cases we might be able to elide the second read of intake
batches, depending on whether there is an overlape between the intake &
aggregation windows; I leave that for future work.