### PR TITLE
use not-deprecated zap APIs

### DIFF
--- a/deploy-operator/controllers/suite_test.go
+++ b/deploy-operator/controllers/suite_test.go
@@ -50,7 +50,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+	logf.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{


### PR DESCRIPTION
This fixes staticcheck SA1019 because zap has deprecated the other
method call.