### PR TITLE
tell gosec to ignore G101 on okay variables

### DIFF
--- a/deploy-tool/key/key_backup.go
+++ b/deploy-tool/key/key_backup.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	// #nosec G101
 	secretUIDLabel = "kubernetes_uid"
 )
 

--- a/manifest-updater/secrets/secret.go
+++ b/manifest-updater/secrets/secret.go
@@ -71,6 +71,7 @@ func NewKube(namespace string, ingestors []string, batchSigningKeySpec, packetEn
 }
 
 func (k *Kube) ReconcilePacketEncryptionKey() ([]*PrioKey, error) {
+	// #nosec G101
 	secretSelector := "type=packet-decryption-key"
 
 	secrets, err := k.getSortedSecretsWithLabel(secretSelector)


### PR DESCRIPTION
gosec tries very hard to look for hardcoded credentials, and it can be a
bit broad.

This is perhaps the most controversial PR towards #294. We might prefer
to silence this error globallly in the golangci-lint config, but it's
only in a couple of places.