### PR TITLE
GH actions: work around `grcov` build break

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -43,7 +43,7 @@ jobs:
           override: true
           default: true
       - name: Install grcov
-        run: cargo install grcov
+        run: cargo install --locked grcov
       - name: Test
         run: cargo test --all-features --no-fail-fast
         env:


### PR DESCRIPTION
A recent release of crate `tera` [breaks builds of
`grcov`](https://github.com/Keats/tera/issues/689). Until [`grcov` takes
a change to adopt the new
`tera`](https://github.com/mozilla/grcov/pull/697), we can work around
it by pinning the crate versions from the lockfile when installing
`grcov`.