### PR TITLE
facilitator: add `rust-toolchain.toml`

### DIFF
--- a/facilitator/rust-toolchain.toml
+++ b/facilitator/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.56.1"
+components = [ "rustc", "rustfmt", "clippy" ]


### PR DESCRIPTION
[`rust-toolchain.toml`](https://rust-lang.github.io/rustup/concepts/components.html)
allows us to pin a Rust toolchain version, guaranteeing that we are
using a compiler that supports recent language features we need (for
instance we might adopt the 2021 edition soon) or security fixes like
[CVE-2021-42574](https://blog.rust-lang.org/2021/11/01/cve-2021-42574.html).