### PR TITLE
correct error usage in manifest-tests

### DIFF
--- a/manifest-updater/secrets/types_test.go
+++ b/manifest-updater/secrets/types_test.go
@@ -14,7 +14,7 @@ func TestPrioKeyMarshallAndUnmarshall(t *testing.T) {
 	p256Key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 
 	if err != nil {
-		t.Errorf("error generating key: %w", err)
+		t.Errorf("error generating key: %s", err)
 	}
 
 	key := PrioKey{key: p256Key}


### PR DESCRIPTION
After updating to the very latest golangci-lint, this error cropped up.