### PR TITLE
terraform: deploy prod-intl/mx-{coa,jal,yuc,pue}

### DIFF
--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -1,7 +1,7 @@
 environment     = "prod-intl"
 gcp_region      = "us-west1"
 gcp_project     = "prio-intl-prod"
-localities      = ["mn-mn"]
+localities      = ["mn-mn", "mx-coa", "mx-jal", "mx-pue", "mx-yuc"]
 aws_region      = "us-west-2"
 manifest_domain = "isrg-prio.org"
 ingestors = {
@@ -12,12 +12,44 @@ ingestors = {
         intake_worker_count    = 3
         aggregate_worker_count = 3
       }
+      mx-coa = {
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
+      }
+      mx-jal = {
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
+      }
+      mx-pue = {
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
+      }
+      mx-yuc = {
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
+      }
     }
   }
   apple = {
     manifest_base_url = "exposure-notification.apple.com/manifest"
     localities = {
       mn-mn = {
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
+      }
+      mx-coa = {
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
+      }
+      mx-jal = {
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
+      }
+      mx-pue = {
+        intake_worker_count    = 3
+        aggregate_worker_count = 3
+      }
+      mx-yuc = {
         intake_worker_count    = 3
         aggregate_worker_count = 3
       }


### PR DESCRIPTION
Adds four Mexican states to `prod-intl` deployment.