### PR TITLE
prod-intl: force node group to 6 nodes

### DIFF
--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -57,9 +57,9 @@ ingestors = {
   }
 }
 cluster_settings = {
-  initial_node_count = 3
+  initial_node_count = 6
   min_node_count     = 3
-  max_node_count     = 3
+  max_node_count     = 6
   gcp_machine_type   = "e2-standard-2"
   aws_machine_types  = ["t3.large"]
 }


### PR DESCRIPTION
Our deploy of the four Mexican states got stuck because we ran out of
cores onto which to schedule pods, so we bump the max size of the node
group to 6. Further, we learned today that EKS doesn't automatically
deploy a cluster autoscaler for you (#1091), so we force the cluster to
six nodes.