### PR TITLE
Make key.Key immutable, rename key.Raw to key.Material.

### DIFF
--- a/key-rotator/key/key_test.go
+++ b/key-rotator/key/key_test.go
@@ -13,7 +13,7 @@ import (
 func TestKeyMarshal(t *testing.T) {
 	t.Parallel()
 
-	mustKey := func(r Raw, err error) Raw {
+	mustKey := func(r Material, err error) Material {
 		if err != nil {
 			t.Fatalf("Couldn't create key: %v", err)
 		}
@@ -21,20 +21,20 @@ func TestKeyMarshal(t *testing.T) {
 	}
 	wantKey := Key{
 		Version{
-			RawKey:       mustKey(Test.New()),
+			KeyMaterial:  mustKey(Test.New()),
 			CreationTime: time.Unix(100000, 0).UTC(),
 		},
 		Version{
-			RawKey:       mustKey(P256.New()),
+			KeyMaterial:  mustKey(P256.New()),
 			CreationTime: time.Unix(150000, 0).UTC(),
 		},
 		Version{
-			RawKey:       mustKey(Test.New()),
+			KeyMaterial:  mustKey(Test.New()),
 			CreationTime: time.Unix(200000, 0).UTC(),
 			Primary:      true,
 		},
 		Version{
-			RawKey:       mustKey(P256.New()),
+			KeyMaterial:  mustKey(P256.New()),
 			CreationTime: time.Unix(250000, 0).UTC(),
 		},
 	}
@@ -63,7 +63,7 @@ func TestKeyRotate(t *testing.T) {
 	const now = 100000
 
 	cfg := RotationConfig{
-		CreateKeyFunc: func() (Raw, error) { return newTestKey(now), nil },
+		CreateKeyFunc: func() (Material, error) { return newTestKey(now), nil },
 		CreateMinAge:  10000 * time.Second,
 
 		PrimaryMinAge: 1000 * time.Second,
@@ -135,7 +135,7 @@ func TestKeyRotate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Check that we get the wanted key from Rotate.
+			// Check that we get the desired key from Rotate.
 			gotKey, err := test.key.Rotate(time.Unix(now, 0), cfg)
 			if err != nil {
 				t.Fatalf("Unexpected error from Rotate: %v", err)
@@ -174,7 +174,7 @@ func TestKeyRotate(t *testing.T) {
 		t.Parallel()
 		const wantErrString = "bananas"
 		cfg := cfg
-		cfg.CreateKeyFunc = func() (Raw, error) { return Raw{}, errors.New(wantErrString) }
+		cfg.CreateKeyFunc = func() (Material, error) { return Material{}, errors.New(wantErrString) }
 		_, err := Key{}.Rotate(time.Unix(now, 0), cfg)
 		if err == nil || !strings.Contains(err.Error(), wantErrString) {
 			t.Errorf("Wanted error containing %q, got: %v", wantErrString, err)
@@ -185,7 +185,7 @@ func TestKeyRotate(t *testing.T) {
 // kv creates a non-primary key version with the given timestamp and bogus key material.
 func kv(ts int64) Version {
 	return Version{
-		RawKey:       newTestKey(ts),
+		KeyMaterial:  newTestKey(ts),
 		CreationTime: time.Unix(ts, 0),
 	}
 }

--- a/key-rotator/key/key_test.go
+++ b/key-rotator/key/key_test.go
@@ -3,6 +3,7 @@ package key
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -13,48 +14,68 @@ import (
 func TestKeyMarshal(t *testing.T) {
 	t.Parallel()
 
-	mustKey := func(r Material, err error) Material {
-		if err != nil {
-			t.Fatalf("Couldn't create key: %v", err)
+	t.Run("SerializeDeserialize", func(t *testing.T) {
+		mustKey := func(r Material, err error) Material {
+			if err != nil {
+				t.Fatalf("Couldn't create key: %v", err)
+			}
+			return r
 		}
-		return r
-	}
-	wantKey := Key{
-		Version{
-			KeyMaterial:  mustKey(Test.New()),
-			CreationTime: time.Unix(100000, 0).UTC(),
-		},
-		Version{
-			KeyMaterial:  mustKey(P256.New()),
-			CreationTime: time.Unix(150000, 0).UTC(),
-		},
-		Version{
-			KeyMaterial:  mustKey(Test.New()),
-			CreationTime: time.Unix(200000, 0).UTC(),
-			Primary:      true,
-		},
-		Version{
-			KeyMaterial:  mustKey(P256.New()),
-			CreationTime: time.Unix(250000, 0).UTC(),
-		},
-	}
+		wantKey := k(
+			Version{
+				KeyMaterial:  mustKey(Test.New()),
+				CreationTime: time.Unix(100000, 0).UTC(),
+			},
+			Version{
+				KeyMaterial:  mustKey(P256.New()),
+				CreationTime: time.Unix(150000, 0).UTC(),
+			},
+			Version{
+				KeyMaterial:  mustKey(Test.New()),
+				CreationTime: time.Unix(200000, 0).UTC(),
+				Primary:      true,
+			},
+			Version{
+				KeyMaterial:  mustKey(P256.New()),
+				CreationTime: time.Unix(250000, 0).UTC(),
+			},
+		)
 
-	buf, err := json.Marshal(wantKey)
-	if err != nil {
-		t.Fatalf("Couldn't JSON-marshal key: %v", err)
-	}
+		buf, err := json.Marshal(wantKey)
+		if err != nil {
+			t.Fatalf("Couldn't JSON-marshal key: %v", err)
+		}
 
-	var gotKey Key
-	if err := json.Unmarshal(buf, &gotKey); err != nil {
-		t.Fatalf("Couldn't JSON-unmarshal key: %v", err)
-	}
+		var gotKey Key
+		if err := json.Unmarshal(buf, &gotKey); err != nil {
+			t.Fatalf("Couldn't JSON-unmarshal key: %v", err)
+		}
 
-	diff := cmp.Diff(wantKey, gotKey)
-	if !wantKey.Equal(gotKey) {
-		t.Errorf("gotKey differs from wantKey (-want +got):\n%s", diff)
-	} else if diff != "" {
-		t.Errorf("gotKey is Equal to wantKey, but cmp.Diff disagrees (-want +got):\n%s", diff)
-	}
+		diff := cmp.Diff(wantKey, gotKey)
+		if !wantKey.Equal(gotKey) {
+			t.Errorf("gotKey differs from wantKey (-want +got):\n%s", diff)
+		} else if diff != "" {
+			t.Errorf("gotKey is Equal to wantKey, but cmp.Diff disagrees (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("DeserializeSerialize", func(t *testing.T) {
+		// wantKey generated from a run of the SerializeDeserialize test.
+		const wantKey = `[{"key":"ACdcLaKY8VsN","creation_time":"100000"},{"key":"AQMp62hRUAKqVHXfhwApjJPMV21kxQpb0OYqk7/IxU5etbiIdgHv1+d5EHApWJrCD0a/QI4RtPx0iOkjr1Pitwsp","creation_time":"150000"},{"key":"ACrYJ2YS9Oem","creation_time":"200000","primary":true},{"key":"AQKtg3k806wsd0ld/FUSjr+9B9ZjvNIjL4Thwp/olCLNTDIpxAWKwzYAuqyCcChbQ72AShRIQQOJgkSVT6kw/N9b","creation_time":"250000"}]`
+
+		var k Key
+		if err := json.Unmarshal([]byte(wantKey), &k); err != nil {
+			t.Fatalf("Couldn't JSON-unmarshal key: %v", err)
+		}
+		gotKey, err := json.Marshal(k)
+		if err != nil {
+			t.Fatalf("Couldn't JSON-marshal key: %v", err)
+		}
+
+		if diff := cmp.Diff([]byte(wantKey), gotKey); diff != "" {
+			t.Errorf("gotKey differs from wantKey (-want +got):\n%s", err)
+		}
+	})
 }
 
 func TestKeyRotate(t *testing.T) {
@@ -81,54 +102,54 @@ func TestKeyRotate(t *testing.T) {
 		// Basic creation tests.
 		{
 			name:    "no creation at boundary",
-			key:     Key{pkv(90000)},
-			wantKey: Key{pkv(90000)},
+			key:     k(pkv(90000)),
+			wantKey: k(pkv(90000)),
 		},
 		{
 			name:    "creation",
-			key:     Key{pkv(89999)},
-			wantKey: Key{pkv(89999), kv(now)},
+			key:     k(pkv(89999)),
+			wantKey: k(pkv(89999), kv(now)),
 		},
 
 		// Basic primary tests.
 		{
 			name:    "no new primary at boundary",
-			key:     Key{pkv(90000), kv(99000)},
-			wantKey: Key{pkv(90000), kv(99000)},
+			key:     k(pkv(90000), kv(99000)),
+			wantKey: k(pkv(90000), kv(99000)),
 		},
 		{
 			name:    "new primary",
-			key:     Key{pkv(90000), kv(98999)},
-			wantKey: Key{kv(90000), pkv(98999)},
+			key:     k(pkv(90000), kv(98999)),
+			wantKey: k(kv(90000), pkv(98999)),
 		},
 
 		// Basic deletion tests.
 		{
 			name:    "no deletion at boundary",
-			key:     Key{kv(80000), kv(97000), pkv(98000)},
-			wantKey: Key{kv(80000), kv(97000), pkv(98000)},
+			key:     k(kv(80000), kv(97000), pkv(98000)),
+			wantKey: k(kv(80000), kv(97000), pkv(98000)),
 		},
 		{
 			name:    "no deletion at min key count",
-			key:     Key{kv(79999), pkv(98000)},
-			wantKey: Key{kv(79999), pkv(98000)},
+			key:     k(kv(79999), pkv(98000)),
+			wantKey: k(kv(79999), pkv(98000)),
 		},
 		{
 			name:    "deletion",
-			key:     Key{kv(79999), kv(97000), pkv(98000)},
-			wantKey: Key{kv(97000), pkv(98000)},
+			key:     k(kv(79999), kv(97000), pkv(98000)),
+			wantKey: k(kv(97000), pkv(98000)),
 		},
 
 		// Miscellaneous tests.
 		{
 			name:    "empty key",
 			key:     Key{},
-			wantKey: Key{pkv(now)},
+			wantKey: k(pkv(now)),
 		},
 		{
 			name:    "creation, new primary, and deletion",
-			key:     Key{pkv(79999), kv(89999)},
-			wantKey: Key{pkv(89999), kv(100000)},
+			key:     k(pkv(79999), kv(89999)),
+			wantKey: k(pkv(89999), kv(100000)),
 		},
 	} {
 		test := test
@@ -165,7 +186,7 @@ func TestKeyRotate(t *testing.T) {
 	t.Run("key from the future", func(t *testing.T) {
 		t.Parallel()
 		const wantErrString = "after now"
-		_, err := Key{pkv(100001)}.Rotate(time.Unix(now, 0), cfg)
+		_, err := k(pkv(100001)).Rotate(time.Unix(now, 0), cfg)
 		if err == nil || !strings.Contains(err.Error(), wantErrString) {
 			t.Errorf("Wanted error containing %q, got: %v", wantErrString, err)
 		}
@@ -180,6 +201,15 @@ func TestKeyRotate(t *testing.T) {
 			t.Errorf("Wanted error containing %q, got: %v", wantErrString, err)
 		}
 	})
+}
+
+// k creates a new key or dies trying.
+func k(vs ...Version) Key {
+	k, err := FromVersions(vs...)
+	if err != nil {
+		panic(fmt.Sprintf("Couldn't create key from versions: %v", err))
+	}
+	return k
 }
 
 // kv creates a non-primary key version with the given timestamp and bogus key material.

--- a/key-rotator/key/material.go
+++ b/key-rotator/key/material.go
@@ -14,7 +14,7 @@ import (
 	"math/big"
 )
 
-// Type represents the type of a Raw key.
+// Type represents the kind of key represented by a key.Material.
 type Type uint8
 
 const (
@@ -23,9 +23,9 @@ const (
 )
 
 type typeInfo struct {
-	name             string              // string name of type
-	newRandom        func() (raw, error) // function returning a newly-initialized random key
-	newUninitialized func() raw          // function returning an uninitialized key of this type, e.g. for use in unmarshalling
+	name             string                   // string name of type
+	newRandom        func() (material, error) // function returning a newly-initialized random key
+	newUninitialized func() material          // function returning an uninitialized key of this type, e.g. for use in unmarshalling
 }
 
 var typeInfos = map[Type]*typeInfo{
@@ -40,38 +40,38 @@ func (t Type) String() string {
 }
 
 // New creates a new, randomly-initialized key.
-func (t Type) New() (Raw, error) {
+func (t Type) New() (Material, error) {
 	ti := typeInfos[t]
 	if ti == nil {
-		return Raw{}, fmt.Errorf("unknown key type %v (%d)", t, t)
+		return Material{}, fmt.Errorf("unknown key type %v (%d)", t, t)
 	}
-	k, err := ti.newRandom()
+	m, err := ti.newRandom()
 	if err != nil {
-		return Raw{}, fmt.Errorf("couldn't create %v key: %v", t, err)
+		return Material{}, fmt.Errorf("couldn't create %v key: %v", t, err)
 	}
-	return Raw{k}, nil
+	return Material{m}, nil
 }
 
-// Raw represents a raw (i.e. unversioned) asymmetric cryptographic key,
+// Material represents raw key material for an asymmetric cryptographic key,
 // including both the private & public portions. It has functionality related
 // to serialization of the key.
-type Raw struct{ k raw }
+type Material struct{ m material }
 
-// Verify that Raw satisfies the binary/text (Un)marshaler interfaces.
-var _ encoding.BinaryMarshaler = Raw{}
-var _ encoding.BinaryUnmarshaler = &Raw{}
-var _ encoding.TextMarshaler = Raw{}
-var _ encoding.TextUnmarshaler = &Raw{}
+// Verify that Material satisfies the binary/text (Un)marshaler interfaces.
+var _ encoding.BinaryMarshaler = Material{}
+var _ encoding.BinaryUnmarshaler = &Material{}
+var _ encoding.TextMarshaler = Material{}
+var _ encoding.TextUnmarshaler = &Material{}
 
-func (r Raw) MarshalBinary() ([]byte, error) {
-	kBytes, err := r.k.MarshalBinary()
+func (m Material) MarshalBinary() ([]byte, error) {
+	kBytes, err := m.m.MarshalBinary()
 	if err != nil {
-		return nil, fmt.Errorf("couldn't serialize %v key: %w", r.Type(), err)
+		return nil, fmt.Errorf("couldn't serialize %v key: %w", m.Type(), err)
 	}
-	return append([]byte{byte(r.Type())}, kBytes...), nil
+	return append([]byte{byte(m.Type())}, kBytes...), nil
 }
 
-func (r *Raw) UnmarshalBinary(data []byte) error {
+func (m *Material) UnmarshalBinary(data []byte) error {
 	if len(data) == 0 {
 		return errors.New("empty input")
 	}
@@ -81,16 +81,16 @@ func (r *Raw) UnmarshalBinary(data []byte) error {
 	if ti == nil {
 		return fmt.Errorf("unknown key type %v (%d)", t, t)
 	}
-	k := ti.newUninitialized()
-	if err := k.UnmarshalBinary(data[1:]); err != nil {
+	newM := ti.newUninitialized()
+	if err := newM.UnmarshalBinary(data[1:]); err != nil {
 		return fmt.Errorf("couldn't unmarshal %v key: %w", t, err)
 	}
-	*r = Raw{k}
+	*m = Material{newM}
 	return nil
 }
 
-func (r Raw) MarshalText() ([]byte, error) {
-	binBytes, err := r.MarshalBinary()
+func (m Material) MarshalText() ([]byte, error) {
+	binBytes, err := m.MarshalBinary()
 	if err != nil {
 		return nil, err
 	}
@@ -99,54 +99,54 @@ func (r Raw) MarshalText() ([]byte, error) {
 	return buf, nil
 }
 
-func (r *Raw) UnmarshalText(data []byte) error {
+func (m *Material) UnmarshalText(data []byte) error {
 	binBytes := make([]byte, base64.RawStdEncoding.DecodedLen(len(data)))
 	if _, err := base64.RawStdEncoding.Decode(binBytes, data); err != nil {
 		return fmt.Errorf("couldn't decode base64: %v", err)
 	}
-	return r.UnmarshalBinary(binBytes)
+	return m.UnmarshalBinary(binBytes)
 }
 
-func (r Raw) Equal(o Raw) bool {
-	if r.Type() != o.Type() {
+func (m Material) Equal(o Material) bool {
+	if m.Type() != o.Type() {
 		return false
 	}
-	return r.k.equal(o.k)
+	return m.m.equal(o.m)
 }
 
-// Type returns the type of the raw key.
-func (r Raw) Type() Type { return r.k.keyType() }
+// Type returns the type of the key material.
+func (m Material) Type() Type { return m.m.keyType() }
 
 // PublicAsCSR returns a PEM-encoding of the ASN.1 DER-encoding of a PKCS#10
 // (RFC 2986) CSR over the public portion of the key, signed using the private
 // portion of the key, using the provided FQDN as the common name for the
 // request.
-func (r Raw) PublicAsCSR(csrFQDN string) (string, error) { return r.k.publicAsCSR(csrFQDN) }
+func (m Material) PublicAsCSR(csrFQDN string) (string, error) { return m.m.publicAsCSR(csrFQDN) }
 
 // PublicAsPKIX returns a PEM-encoding of the ASN.1 DER-encoding of the
 // public portion of the key in PKIX (RFC 5280) format.
-func (r Raw) PublicAsPKIX() (string, error) { return r.k.publicAsPKIX() }
+func (m Material) PublicAsPKIX() (string, error) { return m.m.publicAsPKIX() }
 
 // AsX962Uncompressed returns a base64 encoding of the X9.62 uncompressed
 // encoding of the public portion of the key, concatenated with the secret
 // "D" scalar.
-func (r Raw) AsX962Uncompressed() (string, error) { return r.k.asX962Uncompressed() }
+func (m Material) AsX962Uncompressed() (string, error) { return m.m.asX962Uncompressed() }
 
 // AsPKCS8 returns a base64 encoding of the ASN.1 DER-encoding of the key
 // in PKCS#8 (RFC 5208) format.
-func (r Raw) AsPKCS8() (string, error) { return r.k.asPKCS8() }
+func (m Material) AsPKCS8() (string, error) { return m.m.asPKCS8() }
 
-// raw represents a raw key of one particular type.
-type raw interface {
+// material represents key material of one particular type.
+type material interface {
 	encoding.BinaryMarshaler
 	encoding.BinaryUnmarshaler
 
-	// keyType returns the type of the raw key.
+	// keyType returns the type of the key material.
 	keyType() Type
 
-	// equal determines if this raw is equal to the given raw, which can be
-	// assumed to be of the same key type.
-	equal(o raw) bool
+	// equal determines if this key material is equal to the given key
+	// material, which can be assumed to be of the same key type.
+	equal(o material) bool
 
 	// publicAsCSR returns a PEM-encoding of the ASN.1 DER-encoding of a
 	// PKCS#10 (RFC 2986) CSR over the public portion of the key, signed using
@@ -170,9 +170,9 @@ type raw interface {
 
 type p256 struct{ privKey *ecdsa.PrivateKey }
 
-var _ raw = &p256{} // verify p256 implements raw
+var _ material = &p256{} // verify p256 implements material
 
-func newRandomP256() (raw, error) {
+func newRandomP256() (material, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't generate new key: %w", err)
@@ -180,51 +180,51 @@ func newRandomP256() (raw, error) {
 	return &p256{key}, nil
 }
 
-func newUninitializedP256() raw { return &p256{} }
+func newUninitializedP256() material { return &p256{} }
 
 func (p256) keyType() Type { return P256 }
 
-func (k p256) equal(o raw) bool { return k.privKey.Equal(o.(*p256).privKey) }
+func (m p256) equal(o material) bool { return m.privKey.Equal(o.(*p256).privKey) }
 
-func (k p256) publicAsCSR(csrFQDN string) (string, error) {
+func (m p256) publicAsCSR(csrFQDN string) (string, error) {
 	tmpl := &x509.CertificateRequest{
 		SignatureAlgorithm: x509.ECDSAWithSHA256,
 		Subject:            pkix.Name{CommonName: csrFQDN},
 	}
-	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, tmpl, k.privKey)
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, tmpl, m.privKey)
 	if err != nil {
 		return "", fmt.Errorf("couldn't create certificate request: %w", err)
 	}
 	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})), nil
 }
 
-func (k p256) publicAsPKIX() (string, error) {
-	pubkeyBytes, err := x509.MarshalPKIXPublicKey(k.privKey.Public())
+func (m p256) publicAsPKIX() (string, error) {
+	pubkeyBytes, err := x509.MarshalPKIXPublicKey(m.privKey.Public())
 	if err != nil {
 		return "", fmt.Errorf("couldn't encode as PKIX: %w", err)
 	}
 	return string(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubkeyBytes})), nil
 }
 
-func (k p256) asX962Uncompressed() (string, error) {
-	return base64.StdEncoding.EncodeToString(append(elliptic.Marshal(elliptic.P256(), k.privKey.X, k.privKey.Y), k.privKey.D.Bytes()...)), nil
+func (m p256) asX962Uncompressed() (string, error) {
+	return base64.StdEncoding.EncodeToString(append(elliptic.Marshal(elliptic.P256(), m.privKey.X, m.privKey.Y), m.privKey.D.Bytes()...)), nil
 }
 
-func (k p256) asPKCS8() (string, error) {
-	keyBytes, err := x509.MarshalPKCS8PrivateKey(k.privKey)
+func (m p256) asPKCS8() (string, error) {
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(m.privKey)
 	if err != nil {
 		return "", fmt.Errorf("couldn't encode as PKCS#8: %w", err)
 	}
 	return base64.StdEncoding.EncodeToString(keyBytes), nil
 }
 
-func (k p256) MarshalBinary() ([]byte, error) {
+func (m p256) MarshalBinary() ([]byte, error) {
 	// P256's raw key format is the X9.62 compressed encoding of the public
 	// portion of the key, concatenated with the secret "D" scalar.
-	return append(elliptic.MarshalCompressed(elliptic.P256(), k.privKey.X, k.privKey.Y), k.privKey.D.Bytes()...), nil
+	return append(elliptic.MarshalCompressed(elliptic.P256(), m.privKey.X, m.privKey.Y), m.privKey.D.Bytes()...), nil
 }
 
-func (k *p256) UnmarshalBinary(data []byte) error {
+func (m *p256) UnmarshalBinary(data []byte) error {
 	const p256PubkeyCompressedLen = 33 // P256 uses 256-bit = 8-byte points; the length of MarshalCompressed is 1 + point_byte_length.
 
 	x, y := elliptic.UnmarshalCompressed(elliptic.P256(), data[:p256PubkeyCompressedLen])
@@ -233,7 +233,7 @@ func (k *p256) UnmarshalBinary(data []byte) error {
 	}
 	d := new(big.Int).SetBytes(data[p256PubkeyCompressedLen:])
 
-	*k = p256{&ecdsa.PrivateKey{
+	*m = p256{&ecdsa.PrivateKey{
 		PublicKey: ecdsa.PublicKey{
 			Curve: elliptic.P256(),
 			X:     x,

--- a/key-rotator/manifest/manifest.go
+++ b/key-rotator/manifest/manifest.go
@@ -63,7 +63,7 @@ func (m DataShareProcessorSpecificManifest) UpdateKeys(cfg UpdateKeysConfig) (Da
 		if bspk, ok := m.BatchSigningPublicKeys[kid]; ok {
 			newBSPK = bspk
 		} else {
-			pkix, err := v.RawKey.PublicAsPKIX()
+			pkix, err := v.KeyMaterial.PublicAsPKIX()
 			if err != nil {
 				return DataShareProcessorSpecificManifest{}, fmt.Errorf("couldn't create PKIX-encoding for batch signing key version created at %v (%d): %w", v.CreationTime.Format(time.RFC3339), v.CreationTime.Unix(), err)
 			}
@@ -87,7 +87,7 @@ func (m DataShareProcessorSpecificManifest) UpdateKeys(cfg UpdateKeysConfig) (Da
 		if pec, ok := m.PacketEncryptionKeyCSRs[kid]; ok {
 			newPEC = pec
 		} else {
-			csr, err := v.RawKey.PublicAsCSR(cfg.PacketEncryptionKeyCSRFQDN)
+			csr, err := v.KeyMaterial.PublicAsCSR(cfg.PacketEncryptionKeyCSRFQDN)
 			if err != nil {
 				return DataShareProcessorSpecificManifest{}, fmt.Errorf("couldn't create CSR for packet encryption key version created at %v (%d): %w", v.CreationTime.Format(time.RFC3339), v.CreationTime.Unix(), err)
 			}

--- a/key-rotator/manifest/manifest_test.go
+++ b/key-rotator/manifest/manifest_test.go
@@ -43,8 +43,8 @@ func TestUpdateKeys(t *testing.T) {
 		// Generic tests.
 		{
 			name:                "no keys at start (new environment rollout)",
-			batchSigningKey:     key.Key{kv(10, k0), pkv(15, k1), kv(20, k2)},
-			packetEncryptionKey: key.Key{kv(10, k3), kv(15, k4), pkv(20, k5)},
+			batchSigningKey:     k(kv(10, k0), pkv(15, k1), kv(20, k2)),
+			packetEncryptionKey: k(kv(10, k3), kv(15, k4), pkv(20, k5)),
 			wantBSKs: map[string]key.Material{
 				"bsk-10": k0,
 				"bsk-15": k1,
@@ -60,8 +60,8 @@ func TestUpdateKeys(t *testing.T) {
 			name:                "keys already populated, old key material kept",
 			initialBSKs:         map[string]key.Material{"bsk-10": k0},
 			initialPEKs:         map[string]key.Material{"pek-10": k1},
-			batchSigningKey:     key.Key{pkv(10, k2)},
-			packetEncryptionKey: key.Key{pkv(10, k3)},
+			batchSigningKey:     k(pkv(10, k2)),
+			packetEncryptionKey: k(pkv(10, k3)),
 			wantBSKs:            map[string]key.Material{"bsk-10": k0},
 			wantPEKs:            map[string]key.Material{"pek-10": k1},
 		},
@@ -70,49 +70,49 @@ func TestUpdateKeys(t *testing.T) {
 		{
 			name:            "BSK: before first rotation (0 timestamp)",
 			initialBSKs:     map[string]key.Material{"bsk": k0},
-			batchSigningKey: key.Key{noTimePKV(k0)},
+			batchSigningKey: k(noTimePKV(k0)),
 			wantBSKs:        map[string]key.Material{"bsk": k0},
 		},
 		{
 			name:            "BSK: first new key (0 timestamp)",
 			initialBSKs:     map[string]key.Material{"bsk": k0},
-			batchSigningKey: key.Key{noTimePKV(k0), kv(10, k1)},
+			batchSigningKey: k(noTimePKV(k0), kv(10, k1)),
 			wantBSKs:        map[string]key.Material{"bsk": k0, "bsk-10": k1},
 		},
 		{
 			name:            "BSK: first primary-key change (0 timestamp)",
 			initialBSKs:     map[string]key.Material{"bsk": k0, "bsk-10": k1},
-			batchSigningKey: key.Key{noTimeKV(k0), pkv(10, k1)},
+			batchSigningKey: k(noTimeKV(k0), pkv(10, k1)),
 			wantBSKs:        map[string]key.Material{"bsk": k0, "bsk-10": k1},
 		},
 		{
 			name:            "BSK: first key removal (0 timestamp)",
 			initialBSKs:     map[string]key.Material{"bsk": k0, "bsk-10": k1},
-			batchSigningKey: key.Key{pkv(10, k1)},
+			batchSigningKey: k(pkv(10, k1)),
 			wantBSKs:        map[string]key.Material{"bsk-10": k1},
 		},
 		{
 			name:            "BSK: stable state (before rotation)",
 			initialBSKs:     map[string]key.Material{"bsk-10": k0, "bsk-20": k1},
-			batchSigningKey: key.Key{kv(10, k0), pkv(20, k1)},
+			batchSigningKey: k(kv(10, k0), pkv(20, k1)),
 			wantBSKs:        map[string]key.Material{"bsk-10": k0, "bsk-20": k1},
 		},
 		{
 			name:            "BSK: new key",
 			initialBSKs:     map[string]key.Material{"bsk-10": k0, "bsk-20": k1},
-			batchSigningKey: key.Key{kv(10, k0), pkv(20, k1), kv(30, k2)},
+			batchSigningKey: k(kv(10, k0), pkv(20, k1), kv(30, k2)),
 			wantBSKs:        map[string]key.Material{"bsk-10": k0, "bsk-20": k1, "bsk-30": k2},
 		},
 		{
 			name:            "BSK: rotation",
 			initialBSKs:     map[string]key.Material{"bsk-10": k0, "bsk-20": k1, "bsk-30": k2},
-			batchSigningKey: key.Key{kv(10, k0), kv(20, k1), pkv(30, k2)},
+			batchSigningKey: k(kv(10, k0), kv(20, k1), pkv(30, k2)),
 			wantBSKs:        map[string]key.Material{"bsk-10": k0, "bsk-20": k1, "bsk-30": k2},
 		},
 		{
 			name:            "BSK: removal",
 			initialBSKs:     map[string]key.Material{"bsk-10": k0, "bsk-20": k1, "bsk-30": k2},
-			batchSigningKey: key.Key{kv(20, k1), pkv(30, k2)},
+			batchSigningKey: k(kv(20, k1), pkv(30, k2)),
 			wantBSKs:        map[string]key.Material{"bsk-20": k1, "bsk-30": k2},
 		},
 
@@ -120,49 +120,49 @@ func TestUpdateKeys(t *testing.T) {
 		{
 			name:                "PEK: before first rotation (0 timestamp)",
 			initialPEKs:         map[string]key.Material{"pek": k0},
-			packetEncryptionKey: key.Key{noTimePKV(k0)},
+			packetEncryptionKey: k(noTimePKV(k0)),
 			wantPEKs:            map[string]key.Material{"pek": k0},
 		},
 		{
 			name:                "PEK: first new key (0 timestamp)",
 			initialPEKs:         map[string]key.Material{"pek": k0},
-			packetEncryptionKey: key.Key{noTimePKV(k0), kv(10, k1)},
+			packetEncryptionKey: k(noTimePKV(k0), kv(10, k1)),
 			wantPEKs:            map[string]key.Material{"pek": k0},
 		},
 		{
 			name:                "PEK: first primary-key change (0 timestamp)",
 			initialPEKs:         map[string]key.Material{"pek": k0},
-			packetEncryptionKey: key.Key{noTimeKV(k0), pkv(10, k1)},
+			packetEncryptionKey: k(noTimeKV(k0), pkv(10, k1)),
 			wantPEKs:            map[string]key.Material{"pek-10": k1},
 		},
 		{
 			name:                "PEK: first key removal (0 timestamp)",
 			initialPEKs:         map[string]key.Material{"pek-10": k1},
-			packetEncryptionKey: key.Key{pkv(10, k1)},
+			packetEncryptionKey: k(pkv(10, k1)),
 			wantPEKs:            map[string]key.Material{"pek-10": k1},
 		},
 		{
 			name:                "PEK: stable state (before rotation)",
 			initialPEKs:         map[string]key.Material{"pek-20": k1},
-			packetEncryptionKey: key.Key{kv(10, k0), pkv(20, k1)},
+			packetEncryptionKey: k(kv(10, k0), pkv(20, k1)),
 			wantPEKs:            map[string]key.Material{"pek-20": k1},
 		},
 		{
 			name:                "PEK: new key",
 			initialPEKs:         map[string]key.Material{"pek-20": k1},
-			packetEncryptionKey: key.Key{kv(10, k0), pkv(20, k1), kv(30, k2)},
+			packetEncryptionKey: k(kv(10, k0), pkv(20, k1), kv(30, k2)),
 			wantPEKs:            map[string]key.Material{"pek-20": k1},
 		},
 		{
 			name:                "PEK: rotation",
 			initialPEKs:         map[string]key.Material{"pek-20": k1},
-			packetEncryptionKey: key.Key{kv(10, k0), kv(20, k1), pkv(30, k2)},
+			packetEncryptionKey: k(kv(10, k0), kv(20, k1), pkv(30, k2)),
 			wantPEKs:            map[string]key.Material{"pek-30": k2},
 		},
 		{
 			name:                "PEK: removal",
 			initialBSKs:         map[string]key.Material{"pek-30": k2},
-			packetEncryptionKey: key.Key{kv(20, k1), pkv(30, k2)},
+			packetEncryptionKey: k(kv(20, k1), pkv(30, k2)),
 			wantPEKs:            map[string]key.Material{"pek-30": k2},
 		},
 	} {
@@ -259,6 +259,15 @@ func mustP256() key.Material {
 	k, err := key.P256.New()
 	if err != nil {
 		panic(fmt.Sprintf("Couldn't create new P256 key: %v", err))
+	}
+	return k
+}
+
+// k creates a new key or dies trying.
+func k(vs ...key.Version) key.Key {
+	k, err := key.FromVersions(vs...)
+	if err != nil {
+		panic(fmt.Sprintf("Couldn't create key from versions: %v", err))
 	}
 	return k
 }

--- a/key-rotator/manifest/manifest_test.go
+++ b/key-rotator/manifest/manifest_test.go
@@ -29,28 +29,28 @@ func TestUpdateKeys(t *testing.T) {
 		name string
 
 		// Initial manifest parameters.
-		initialBSKs map[string]key.Raw
-		initialPEKs map[string]key.Raw
+		initialBSKs map[string]key.Material
+		initialPEKs map[string]key.Material
 
 		// UpdateKeys parameters.
 		batchSigningKey     key.Key
 		packetEncryptionKey key.Key
 
 		// Desired output manifest parameters.
-		wantBSKs map[string]key.Raw
-		wantPEKs map[string]key.Raw
+		wantBSKs map[string]key.Material
+		wantPEKs map[string]key.Material
 	}{
 		// Generic tests.
 		{
 			name:                "no keys at start (new environment rollout)",
 			batchSigningKey:     key.Key{kv(10, k0), pkv(15, k1), kv(20, k2)},
 			packetEncryptionKey: key.Key{kv(10, k3), kv(15, k4), pkv(20, k5)},
-			wantBSKs: map[string]key.Raw{
+			wantBSKs: map[string]key.Material{
 				"bsk-10": k0,
 				"bsk-15": k1,
 				"bsk-20": k2,
 			},
-			wantPEKs: map[string]key.Raw{
+			wantPEKs: map[string]key.Material{
 				"pek-20": k5,
 			},
 		},
@@ -58,112 +58,112 @@ func TestUpdateKeys(t *testing.T) {
 			// we purposefully use different keys at same timestamp to test
 			// that we keep old manifest data if the key IDs match up.
 			name:                "keys already populated, old key material kept",
-			initialBSKs:         map[string]key.Raw{"bsk-10": k0},
-			initialPEKs:         map[string]key.Raw{"pek-10": k1},
+			initialBSKs:         map[string]key.Material{"bsk-10": k0},
+			initialPEKs:         map[string]key.Material{"pek-10": k1},
 			batchSigningKey:     key.Key{pkv(10, k2)},
 			packetEncryptionKey: key.Key{pkv(10, k3)},
-			wantBSKs:            map[string]key.Raw{"bsk-10": k0},
-			wantPEKs:            map[string]key.Raw{"pek-10": k1},
+			wantBSKs:            map[string]key.Material{"bsk-10": k0},
+			wantPEKs:            map[string]key.Material{"pek-10": k1},
 		},
 
 		// BSK tests.
 		{
 			name:            "BSK: before first rotation (0 timestamp)",
-			initialBSKs:     map[string]key.Raw{"bsk": k0},
+			initialBSKs:     map[string]key.Material{"bsk": k0},
 			batchSigningKey: key.Key{noTimePKV(k0)},
-			wantBSKs:        map[string]key.Raw{"bsk": k0},
+			wantBSKs:        map[string]key.Material{"bsk": k0},
 		},
 		{
 			name:            "BSK: first new key (0 timestamp)",
-			initialBSKs:     map[string]key.Raw{"bsk": k0},
+			initialBSKs:     map[string]key.Material{"bsk": k0},
 			batchSigningKey: key.Key{noTimePKV(k0), kv(10, k1)},
-			wantBSKs:        map[string]key.Raw{"bsk": k0, "bsk-10": k1},
+			wantBSKs:        map[string]key.Material{"bsk": k0, "bsk-10": k1},
 		},
 		{
 			name:            "BSK: first primary-key change (0 timestamp)",
-			initialBSKs:     map[string]key.Raw{"bsk": k0, "bsk-10": k1},
+			initialBSKs:     map[string]key.Material{"bsk": k0, "bsk-10": k1},
 			batchSigningKey: key.Key{noTimeKV(k0), pkv(10, k1)},
-			wantBSKs:        map[string]key.Raw{"bsk": k0, "bsk-10": k1},
+			wantBSKs:        map[string]key.Material{"bsk": k0, "bsk-10": k1},
 		},
 		{
 			name:            "BSK: first key removal (0 timestamp)",
-			initialBSKs:     map[string]key.Raw{"bsk": k0, "bsk-10": k1},
+			initialBSKs:     map[string]key.Material{"bsk": k0, "bsk-10": k1},
 			batchSigningKey: key.Key{pkv(10, k1)},
-			wantBSKs:        map[string]key.Raw{"bsk-10": k1},
+			wantBSKs:        map[string]key.Material{"bsk-10": k1},
 		},
 		{
 			name:            "BSK: stable state (before rotation)",
-			initialBSKs:     map[string]key.Raw{"bsk-10": k0, "bsk-20": k1},
+			initialBSKs:     map[string]key.Material{"bsk-10": k0, "bsk-20": k1},
 			batchSigningKey: key.Key{kv(10, k0), pkv(20, k1)},
-			wantBSKs:        map[string]key.Raw{"bsk-10": k0, "bsk-20": k1},
+			wantBSKs:        map[string]key.Material{"bsk-10": k0, "bsk-20": k1},
 		},
 		{
 			name:            "BSK: new key",
-			initialBSKs:     map[string]key.Raw{"bsk-10": k0, "bsk-20": k1},
+			initialBSKs:     map[string]key.Material{"bsk-10": k0, "bsk-20": k1},
 			batchSigningKey: key.Key{kv(10, k0), pkv(20, k1), kv(30, k2)},
-			wantBSKs:        map[string]key.Raw{"bsk-10": k0, "bsk-20": k1, "bsk-30": k2},
+			wantBSKs:        map[string]key.Material{"bsk-10": k0, "bsk-20": k1, "bsk-30": k2},
 		},
 		{
 			name:            "BSK: rotation",
-			initialBSKs:     map[string]key.Raw{"bsk-10": k0, "bsk-20": k1, "bsk-30": k2},
+			initialBSKs:     map[string]key.Material{"bsk-10": k0, "bsk-20": k1, "bsk-30": k2},
 			batchSigningKey: key.Key{kv(10, k0), kv(20, k1), pkv(30, k2)},
-			wantBSKs:        map[string]key.Raw{"bsk-10": k0, "bsk-20": k1, "bsk-30": k2},
+			wantBSKs:        map[string]key.Material{"bsk-10": k0, "bsk-20": k1, "bsk-30": k2},
 		},
 		{
 			name:            "BSK: removal",
-			initialBSKs:     map[string]key.Raw{"bsk-10": k0, "bsk-20": k1, "bsk-30": k2},
+			initialBSKs:     map[string]key.Material{"bsk-10": k0, "bsk-20": k1, "bsk-30": k2},
 			batchSigningKey: key.Key{kv(20, k1), pkv(30, k2)},
-			wantBSKs:        map[string]key.Raw{"bsk-20": k1, "bsk-30": k2},
+			wantBSKs:        map[string]key.Material{"bsk-20": k1, "bsk-30": k2},
 		},
 
 		// PEK tests.
 		{
 			name:                "PEK: before first rotation (0 timestamp)",
-			initialPEKs:         map[string]key.Raw{"pek": k0},
+			initialPEKs:         map[string]key.Material{"pek": k0},
 			packetEncryptionKey: key.Key{noTimePKV(k0)},
-			wantPEKs:            map[string]key.Raw{"pek": k0},
+			wantPEKs:            map[string]key.Material{"pek": k0},
 		},
 		{
 			name:                "PEK: first new key (0 timestamp)",
-			initialPEKs:         map[string]key.Raw{"pek": k0},
+			initialPEKs:         map[string]key.Material{"pek": k0},
 			packetEncryptionKey: key.Key{noTimePKV(k0), kv(10, k1)},
-			wantPEKs:            map[string]key.Raw{"pek": k0},
+			wantPEKs:            map[string]key.Material{"pek": k0},
 		},
 		{
 			name:                "PEK: first primary-key change (0 timestamp)",
-			initialPEKs:         map[string]key.Raw{"pek": k0},
+			initialPEKs:         map[string]key.Material{"pek": k0},
 			packetEncryptionKey: key.Key{noTimeKV(k0), pkv(10, k1)},
-			wantPEKs:            map[string]key.Raw{"pek-10": k1},
+			wantPEKs:            map[string]key.Material{"pek-10": k1},
 		},
 		{
 			name:                "PEK: first key removal (0 timestamp)",
-			initialPEKs:         map[string]key.Raw{"pek-10": k1},
+			initialPEKs:         map[string]key.Material{"pek-10": k1},
 			packetEncryptionKey: key.Key{pkv(10, k1)},
-			wantPEKs:            map[string]key.Raw{"pek-10": k1},
+			wantPEKs:            map[string]key.Material{"pek-10": k1},
 		},
 		{
 			name:                "PEK: stable state (before rotation)",
-			initialPEKs:         map[string]key.Raw{"pek-20": k1},
+			initialPEKs:         map[string]key.Material{"pek-20": k1},
 			packetEncryptionKey: key.Key{kv(10, k0), pkv(20, k1)},
-			wantPEKs:            map[string]key.Raw{"pek-20": k1},
+			wantPEKs:            map[string]key.Material{"pek-20": k1},
 		},
 		{
 			name:                "PEK: new key",
-			initialPEKs:         map[string]key.Raw{"pek-20": k1},
+			initialPEKs:         map[string]key.Material{"pek-20": k1},
 			packetEncryptionKey: key.Key{kv(10, k0), pkv(20, k1), kv(30, k2)},
-			wantPEKs:            map[string]key.Raw{"pek-20": k1},
+			wantPEKs:            map[string]key.Material{"pek-20": k1},
 		},
 		{
 			name:                "PEK: rotation",
-			initialPEKs:         map[string]key.Raw{"pek-20": k1},
+			initialPEKs:         map[string]key.Material{"pek-20": k1},
 			packetEncryptionKey: key.Key{kv(10, k0), kv(20, k1), pkv(30, k2)},
-			wantPEKs:            map[string]key.Raw{"pek-30": k2},
+			wantPEKs:            map[string]key.Material{"pek-30": k2},
 		},
 		{
 			name:                "PEK: removal",
-			initialBSKs:         map[string]key.Raw{"pek-30": k2},
+			initialBSKs:         map[string]key.Material{"pek-30": k2},
 			packetEncryptionKey: key.Key{kv(20, k1), pkv(30, k2)},
-			wantPEKs:            map[string]key.Raw{"pek-30": k2},
+			wantPEKs:            map[string]key.Material{"pek-30": k2},
 		},
 	} {
 		test := test
@@ -255,7 +255,7 @@ func TestUpdateKeys(t *testing.T) {
 }
 
 // mustP256 creates a new random P256 key or dies trying.
-func mustP256() key.Raw {
+func mustP256() key.Material {
 	k, err := key.P256.New()
 	if err != nil {
 		panic(fmt.Sprintf("Couldn't create new P256 key: %v", err))
@@ -264,29 +264,29 @@ func mustP256() key.Raw {
 }
 
 // kv creates a non-primary key version with the given timestamp and raw key.
-func kv(ts int64, k key.Raw) key.Version {
+func kv(ts int64, k key.Material) key.Version {
 	return key.Version{
-		RawKey:       k,
+		KeyMaterial:  k,
 		CreationTime: time.Unix(ts, 0),
 	}
 }
 
 // pkv creates a primary key version with the given timestamp and raw key.
-func pkv(ts int64, k key.Raw) key.Version {
+func pkv(ts int64, k key.Material) key.Version {
 	kv := kv(ts, k)
 	kv.Primary = true
 	return kv
 }
 
-func noTimeKV(k key.Raw) key.Version { return key.Version{RawKey: k} }
+func noTimeKV(k key.Material) key.Version { return key.Version{KeyMaterial: k} }
 
-func noTimePKV(k key.Raw) key.Version {
+func noTimePKV(k key.Material) key.Version {
 	kv := noTimeKV(k)
 	kv.Primary = true
 	return kv
 }
 
-func pubkeyFromRaw(raw key.Raw) *ecdsa.PublicKey {
+func pubkeyFromRaw(raw key.Material) *ecdsa.PublicKey {
 	// A raw key won't give us its key material (even public) directly, but we
 	// can serialize it & parse it back.
 	pkix, err := raw.PublicAsPKIX()


### PR DESCRIPTION
Making key.Key immutable will allow me to add validations/invariants later, e.g. "a non-empty key must have exactly one primary version."

key.Material is a more commonly-seen name than key.Raw for "a bunch of secret bytes you feed to an algorithm created by a cryptographer". See e.g. https://crypto.stackexchange.com/questions/80540/meaning-of-the-term-key-material.