### PR TITLE
Add validations to manifest's UpdateKeys function

### DIFF
--- a/key-rotator/manifest/manifest.go
+++ b/key-rotator/manifest/manifest.go
@@ -137,7 +137,7 @@ func validateUpdatedManifest(m, oldM DataShareProcessorSpecificManifest) error {
 
 	// Post-update, manifests must have exactly one packet encryption key version.
 	if len(m.PacketEncryptionKeyCSRs) != 1 {
-		return fmt.Errorf("expected only one packet encryption public key (had %d)", len(m.PacketEncryptionKeyCSRs))
+		return fmt.Errorf("expected exactly one packet encryption public key (had %d)", len(m.PacketEncryptionKeyCSRs))
 	}
 
 	// Post-update, manifests' non-key data must match pre-update manifest data exactly.

--- a/key-rotator/manifest/manifest.go
+++ b/key-rotator/manifest/manifest.go
@@ -37,12 +37,16 @@ type DataShareProcessorSpecificManifest struct {
 	PacketEncryptionKeyCSRs PacketEncryptionKeyCSRs `json:"packet-encryption-keys"`
 }
 
-func (m DataShareProcessorSpecificManifest) Equal(o DataShareProcessorSpecificManifest) bool {
+func (m DataShareProcessorSpecificManifest) equalModuloKeys(o DataShareProcessorSpecificManifest) bool {
 	return m.Format == o.Format &&
 		m.IngestionIdentity == o.IngestionIdentity &&
 		m.IngestionBucket == o.IngestionBucket &&
 		m.PeerValidationIdentity == o.PeerValidationIdentity &&
-		m.PeerValidationBucket == o.PeerValidationBucket &&
+		m.PeerValidationBucket == o.PeerValidationBucket
+}
+
+func (m DataShareProcessorSpecificManifest) Equal(o DataShareProcessorSpecificManifest) bool {
+	return m.equalModuloKeys(o) &&
 		m.BatchSigningPublicKeys.Equal(o.BatchSigningPublicKeys) &&
 		m.PacketEncryptionKeyCSRs.Equal(o.PacketEncryptionKeyCSRs)
 }
@@ -119,7 +123,46 @@ func (m DataShareProcessorSpecificManifest) UpdateKeys(cfg UpdateKeysConfig) (Da
 	}
 	newM.PacketEncryptionKeyCSRs[kid] = newPEC
 
+	if err := validateUpdatedManifest(newM, m); err != nil {
+		return DataShareProcessorSpecificManifest{}, fmt.Errorf("manifest update validation error: %w", err)
+	}
 	return newM, nil
+}
+
+func validateUpdatedManifest(m, oldM DataShareProcessorSpecificManifest) error {
+	// Post-update, manifests must have at least one batch signing key version.
+	if len(m.BatchSigningPublicKeys) == 0 {
+		return errors.New("no batch signing public keys")
+	}
+
+	// Post-update, manifests must have exactly one packet encryption key version.
+	if len(m.PacketEncryptionKeyCSRs) != 1 {
+		return fmt.Errorf("expected only one packet encryption public key (had %d)", len(m.PacketEncryptionKeyCSRs))
+	}
+
+	// Post-update, manifests' non-key data must match pre-update manifest data exactly.
+	if !m.equalModuloKeys(oldM) {
+		return fmt.Errorf("non-key data modified")
+	}
+
+	// Post-update, manifests' key data for key versions that exist both pre- &
+	// post-update must match exactly.
+	for kid, key := range m.BatchSigningPublicKeys {
+		if oldKey, ok := oldM.BatchSigningPublicKeys[kid]; ok {
+			if key != oldKey {
+				return fmt.Errorf("pre-existing batch signing key %q modified", kid)
+			}
+		}
+	}
+	for kid, key := range m.PacketEncryptionKeyCSRs {
+		if oldKey, ok := oldM.PacketEncryptionKeyCSRs[kid]; ok {
+			if key != oldKey {
+				return fmt.Errorf("pre-existing packet encryption key %q modified", kid)
+			}
+		}
+	}
+
+	return nil
 }
 
 // IngestorGlobalManifest represents the global manifest file for an ingestor.

--- a/key-rotator/manifest/manifest_test.go
+++ b/key-rotator/manifest/manifest_test.go
@@ -277,6 +277,292 @@ func TestUpdateKeys(t *testing.T) {
 	}
 }
 
+func TestUpdateKeysValidations(t *testing.T) {
+	t.Parallel()
+
+	// We check only validation check failures here, and we do so by directly
+	// calling `validateUpdatedManifest` because there is no/should be no way
+	// to trigger these checks via UpdateKeys.
+
+	for _, test := range []struct {
+		name        string
+		manifest    DataShareProcessorSpecificManifest
+		oldManifest DataShareProcessorSpecificManifest // if unspecified, same as manifest
+		wantErrStr  string
+	}{
+		{
+			name: "no batch signing key",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "no batch signing",
+		},
+		{
+			name: "no packet encryption key",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{},
+			},
+			wantErrStr: "exactly one packet encryption",
+		},
+		{
+			name: "multiple packet encryption keys",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek-1": PacketEncryptionCertificate{CertificateSigningRequest: "csr-1"},
+					"pek-2": PacketEncryptionCertificate{CertificateSigningRequest: "csr-2"},
+				},
+			},
+			wantErrStr: "exactly one packet encryption",
+		},
+		{
+			name: "non-key data modified (format)",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 2,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "non-key data modified",
+		},
+		{
+			name: "non-key data modified (ingestion identity)",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "modified-ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "non-key data modified",
+		},
+		{
+			name: "non-key data modified (ingestion bucket)",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "modified-ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "non-key data modified",
+		},
+		{
+			name: "non-key data modified (peer validation identity)",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "modified-peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "non-key data modified",
+		},
+		{
+			name: "non-key data modified (peer validation bucket)",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "modified-peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "non-key data modified",
+		},
+		{
+			name: "existing batch signing key modified",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "modified-pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "pre-existing batch signing key",
+		},
+		{
+			name: "existing packet encryption key modified",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "modified-csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			oldM := test.oldManifest
+			if oldM.Equal(DataShareProcessorSpecificManifest{}) {
+				oldM = test.manifest
+			}
+			err := validateUpdatedManifest(test.manifest, oldM)
+			if err == nil || !strings.Contains(err.Error(), test.wantErrStr) {
+				t.Errorf("Wanted error containing %q, got: %v", test.wantErrStr, err)
+			}
+		})
+	}
+}
+
 // mustP256 creates a new random P256 key or dies trying.
 func mustP256() key.Material {
 	k, err := key.P256.New()


### PR DESCRIPTION
Specifically (from https://github.com/abetterinternet/prio-server/issues/24):
* When being used to update keys in a manifest, keys must have at least one version.
* Post-update, manifests must have exactly one packet encryption key version.
* Post-update, manifests must have at least one batch signing key version.
* Post-update, manifests' non-key data must match the pre-update manifest data exactly.
* Post-update, manifests' key data for key versions that exist both pre- & post-update must match exactly.

This PR does **not** implement one final check from https://github.com/abetterinternet/prio-server/issues/24: "When being used to update keys in a manifest, existing key versions' public portions should match with the public keys written to the manifest, matching by creation time/key ID (both of which would provide the same matching)." This is easy enough to implement, but is going to break a lot of tests, so I'm going to pursue it in a separate PR.

Stacked on https://github.com/abetterinternet/prio-server/pull/1128.