### PR TITLE
Add further validations to manifest's UpdateKeys function

### DIFF
--- a/key-rotator/key/material.go
+++ b/key-rotator/key/material.go
@@ -117,6 +117,10 @@ func (m Material) Equal(o Material) bool {
 // Type returns the type of the key material.
 func (m Material) Type() Type { return m.m.keyType() }
 
+// Public returns the public key associated with this key material as an
+// ecdsa.PublicKey.
+func (m Material) Public() ecdsa.PublicKey { return m.m.public() }
+
 // PublicAsCSR returns a PEM-encoding of the ASN.1 DER-encoding of a PKCS#10
 // (RFC 2986) CSR over the public portion of the key, signed using the private
 // portion of the key, using the provided FQDN as the common name for the
@@ -147,6 +151,10 @@ type material interface {
 	// equal determines if this key material is equal to the given key
 	// material, which can be assumed to be of the same key type.
 	equal(o material) bool
+
+	// public returns the public key associated with this key material as an
+	// ecdsa.PublicKey.
+	public() ecdsa.PublicKey
 
 	// publicAsCSR returns a PEM-encoding of the ASN.1 DER-encoding of a
 	// PKCS#10 (RFC 2986) CSR over the public portion of the key, signed using
@@ -194,6 +202,8 @@ func newUninitializedP256() material { return &p256{} }
 func (p256) keyType() Type { return P256 }
 
 func (m p256) equal(o material) bool { return m.privKey.Equal(o.(*p256).privKey) }
+
+func (m p256) public() ecdsa.PublicKey { return m.privKey.PublicKey }
 
 func (m p256) publicAsCSR(csrFQDN string) (string, error) {
 	tmpl := &x509.CertificateRequest{

--- a/key-rotator/key/material.go
+++ b/key-rotator/key/material.go
@@ -47,7 +47,7 @@ func (t Type) New() (Material, error) {
 	}
 	m, err := ti.newRandom()
 	if err != nil {
-		return Material{}, fmt.Errorf("couldn't create %v key: %v", t, err)
+		return Material{}, fmt.Errorf("couldn't create %v key: %w", t, err)
 	}
 	return Material{m}, nil
 }
@@ -102,7 +102,7 @@ func (m Material) MarshalText() ([]byte, error) {
 func (m *Material) UnmarshalText(data []byte) error {
 	binBytes := make([]byte, base64.RawStdEncoding.DecodedLen(len(data)))
 	if _, err := base64.RawStdEncoding.Decode(binBytes, data); err != nil {
-		return fmt.Errorf("couldn't decode base64: %v", err)
+		return fmt.Errorf("couldn't decode base64: %w", err)
 	}
 	return m.UnmarshalBinary(binBytes)
 }

--- a/key-rotator/key/material.go
+++ b/key-rotator/key/material.go
@@ -119,7 +119,7 @@ func (m Material) Type() Type { return m.m.keyType() }
 
 // Public returns the public key associated with this key material as an
 // ecdsa.PublicKey.
-func (m Material) Public() ecdsa.PublicKey { return m.m.public() }
+func (m Material) Public() *ecdsa.PublicKey { return m.m.public() }
 
 // PublicAsCSR returns a PEM-encoding of the ASN.1 DER-encoding of a PKCS#10
 // (RFC 2986) CSR over the public portion of the key, signed using the private
@@ -153,8 +153,8 @@ type material interface {
 	equal(o material) bool
 
 	// public returns the public key associated with this key material as an
-	// ecdsa.PublicKey.
-	public() ecdsa.PublicKey
+	// *ecdsa.PublicKey.
+	public() *ecdsa.PublicKey
 
 	// publicAsCSR returns a PEM-encoding of the ASN.1 DER-encoding of a
 	// PKCS#10 (RFC 2986) CSR over the public portion of the key, signed using
@@ -203,7 +203,7 @@ func (p256) keyType() Type { return P256 }
 
 func (m p256) equal(o material) bool { return m.privKey.Equal(o.(*p256).privKey) }
 
-func (m p256) public() ecdsa.PublicKey { return m.privKey.PublicKey }
+func (m p256) public() *ecdsa.PublicKey { return &m.privKey.PublicKey }
 
 func (m p256) publicAsCSR(csrFQDN string) (string, error) {
 	tmpl := &x509.CertificateRequest{

--- a/key-rotator/key/material_test.go
+++ b/key-rotator/key/material_test.go
@@ -61,6 +61,14 @@ func TestP256(t *testing.T) {
 		}
 	})
 
+	t.Run("Public", func(t *testing.T) {
+		t.Parallel()
+		gotKey := key.Public()
+		if !gotKey.Equal(wantPK.Public()) {
+			t.Errorf("Public key does not match generated public key")
+		}
+	})
+
 	t.Run("PublicAsCSR", func(t *testing.T) {
 		t.Parallel()
 		const fqdn = "my.bogus.fqdn"
@@ -223,6 +231,8 @@ func newUninitializedTestKey() material { return &testKey{} }
 func (testKey) keyType() Type { return Test }
 
 func (k testKey) equal(o material) bool { return k.privKey == o.(*testKey).privKey }
+
+func (k testKey) public() ecdsa.PublicKey { panic("unimplemented") }
 
 func (k testKey) publicAsCSR(csrFQDN string) (string, error) { return "", errors.New("unimplemented") }
 

--- a/key-rotator/key/material_test.go
+++ b/key-rotator/key/material_test.go
@@ -232,7 +232,7 @@ func (testKey) keyType() Type { return Test }
 
 func (k testKey) equal(o material) bool { return k.privKey == o.(*testKey).privKey }
 
-func (k testKey) public() ecdsa.PublicKey { panic("unimplemented") }
+func (k testKey) public() *ecdsa.PublicKey { panic("unimplemented") }
 
 func (k testKey) publicAsCSR(csrFQDN string) (string, error) { return "", errors.New("unimplemented") }
 

--- a/key-rotator/key/test/material.go
+++ b/key-rotator/key/test/material.go
@@ -1,0 +1,33 @@
+// Package test provides test utilities for working with keys.
+package test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"fmt"
+	"hash/fnv"
+	"math/rand"
+
+	"github.com/abetterinternet/prio-server/key-rotator/key"
+)
+
+// Material generates deterministic key material based on the given `kid`. It
+// is very likely that different `kid` values will produce different key
+// material. Not secure, for testing use only.
+func Material(kid string) key.Material {
+	// Stretch `kid` into a deterministic, arbitrary stream of bytes.
+	h := fnv.New64()
+	h.Write([]byte(kid))
+	rnd := rand.New(rand.NewSource(int64(h.Sum64()))) // nolint:gosec // Use of non-cryptographic RNG is purposeful here.
+
+	// Use byte stream to generate a P256 key, and wrap it into a key.Material.
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rnd)
+	if err != nil {
+		panic(fmt.Sprintf("Couldn't create new P256 key: %v", err))
+	}
+	m, err := key.P256MaterialFrom(privKey)
+	if err != nil {
+		panic(fmt.Sprintf("Couldn't create P256 material: %v", err))
+	}
+	return m
+}

--- a/key-rotator/manifest/manifest.go
+++ b/key-rotator/manifest/manifest.go
@@ -261,7 +261,7 @@ func validateKeyMaterialAgainstManifest(cfg UpdateKeysConfig, m DataShareProcess
 		}
 		manifestPubkey, err := bsk.toPublicKey()
 		if err != nil {
-			return fmt.Errorf("couldn't parse batch signing key version %q from manifest: %v", kid, err)
+			return fmt.Errorf("couldn't parse batch signing key version %q from manifest: %w", kid, err)
 		}
 		if !manifestPubkey.Equal(v.KeyMaterial.Public()) {
 			return fmt.Errorf("public key mismatch in batch signing key version %q", kid)
@@ -280,7 +280,7 @@ func validateKeyMaterialAgainstManifest(cfg UpdateKeysConfig, m DataShareProcess
 		}
 		manifestPubkey, err := pek.toPublicKey()
 		if err != nil {
-			return fmt.Errorf("couldn't parse packet encryption key version %q from manifest: %v", kid, err)
+			return fmt.Errorf("couldn't parse packet encryption key version %q from manifest: %w", kid, err)
 		}
 		if !manifestPubkey.Equal(v.KeyMaterial.Public()) {
 			return fmt.Errorf("public key mismatch in packet encryption key version %q", kid)
@@ -363,7 +363,7 @@ func (k BatchSigningPublicKey) toPublicKey() (*ecdsa.PublicKey, error) {
 	}
 	pkix, err := x509.ParsePKIXPublicKey(pemPKIX.Bytes)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't parse as PKIX: %v", err)
+		return nil, fmt.Errorf("couldn't parse as PKIX: %w", err)
 	}
 	pub, ok := pkix.(*ecdsa.PublicKey)
 	if !ok {
@@ -386,7 +386,7 @@ func (k PacketEncryptionCertificate) toPublicKey() (*ecdsa.PublicKey, error) {
 	}
 	csr, err := x509.ParseCertificateRequest(pemCSR.Bytes)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't parse as CSR: %v", err)
+		return nil, fmt.Errorf("couldn't parse as CSR: %w", err)
 	}
 	pub, ok := csr.PublicKey.(*ecdsa.PublicKey)
 	if !ok {

--- a/key-rotator/manifest/manifest.go
+++ b/key-rotator/manifest/manifest.go
@@ -137,7 +137,7 @@ func validateUpdatedManifest(m, oldM DataShareProcessorSpecificManifest) error {
 
 	// Post-update, manifests must have exactly one packet encryption key version.
 	if len(m.PacketEncryptionKeyCSRs) != 1 {
-		return fmt.Errorf("expected only one packet encryption public key (had %d)", len(m.PacketEncryptionKeyCSRs))
+		return fmt.Errorf("expected exactly one packet encryption public key (had %d)", len(m.PacketEncryptionKeyCSRs))
 	}
 
 	// Post-update, manifests' non-key data must match pre-update manifest data exactly.

--- a/key-rotator/manifest/manifest.go
+++ b/key-rotator/manifest/manifest.go
@@ -37,12 +37,16 @@ type DataShareProcessorSpecificManifest struct {
 	PacketEncryptionKeyCSRs PacketEncryptionKeyCSRs `json:"packet-encryption-keys"`
 }
 
-func (m DataShareProcessorSpecificManifest) Equal(o DataShareProcessorSpecificManifest) bool {
+func (m DataShareProcessorSpecificManifest) equalModuloKeys(o DataShareProcessorSpecificManifest) bool {
 	return m.Format == o.Format &&
 		m.IngestionIdentity == o.IngestionIdentity &&
 		m.IngestionBucket == o.IngestionBucket &&
 		m.PeerValidationIdentity == o.PeerValidationIdentity &&
-		m.PeerValidationBucket == o.PeerValidationBucket &&
+		m.PeerValidationBucket == o.PeerValidationBucket
+}
+
+func (m DataShareProcessorSpecificManifest) Equal(o DataShareProcessorSpecificManifest) bool {
+	return m.equalModuloKeys(o) &&
 		m.BatchSigningPublicKeys.Equal(o.BatchSigningPublicKeys) &&
 		m.PacketEncryptionKeyCSRs.Equal(o.PacketEncryptionKeyCSRs)
 }
@@ -119,7 +123,46 @@ func (m DataShareProcessorSpecificManifest) UpdateKeys(cfg UpdateKeysConfig) (Da
 	}
 	newM.PacketEncryptionKeyCSRs[kid] = newPEC
 
+	if err := validateUpdatedManifest(newM, m); err != nil {
+		return DataShareProcessorSpecificManifest{}, fmt.Errorf("manifest update validation error: %w", err)
+	}
 	return newM, nil
+}
+
+func validateUpdatedManifest(m, oldM DataShareProcessorSpecificManifest) error {
+	// Post-update, manifests must have at least one batch signing key version.
+	if len(m.BatchSigningPublicKeys) == 0 {
+		return errors.New("no batch signing public keys")
+	}
+
+	// Post-update, manifests must have exactly one packet encryption key version.
+	if len(m.PacketEncryptionKeyCSRs) != 1 {
+		return fmt.Errorf("expected only one packet encryption public key (had %d)", len(m.PacketEncryptionKeyCSRs))
+	}
+
+	// Post-update, manifests' non-key data must match pre-update manifest data exactly.
+	if !m.equalModuloKeys(oldM) {
+		return fmt.Errorf("non-key data modified")
+	}
+
+	// Post-update, manifests' key data for key versions that exist both pre- &
+	// post-update must match exactly.
+	for kid, key := range m.BatchSigningPublicKeys {
+		if oldKey, ok := oldM.BatchSigningPublicKeys[kid]; ok {
+			if key != oldKey {
+				return fmt.Errorf("pre-existing batch signing key %q modified", kid)
+			}
+		}
+	}
+	for kid, key := range m.PacketEncryptionKeyCSRs {
+		if oldKey, ok := oldM.PacketEncryptionKeyCSRs[kid]; ok {
+			if key != oldKey {
+				return fmt.Errorf("pre-existing packet encryption key %q modified", kid)
+			}
+		}
+	}
+
+	return nil
 }
 
 // IngestorGlobalManifest represents the global manifest file for an ingestor.

--- a/key-rotator/manifest/manifest_test.go
+++ b/key-rotator/manifest/manifest_test.go
@@ -277,6 +277,292 @@ func TestUpdateKeys(t *testing.T) {
 	}
 }
 
+func TestUpdateKeysValidations(t *testing.T) {
+	t.Parallel()
+
+	// We check only validation check failures here, and we do so by directly
+	// calling `validateUpdatedManifest` because there is no/should be no way
+	// to trigger these checks via UpdateKeys.
+
+	for _, test := range []struct {
+		name        string
+		manifest    DataShareProcessorSpecificManifest
+		oldManifest DataShareProcessorSpecificManifest // if unspecified, same as manifest
+		wantErrStr  string
+	}{
+		{
+			name: "no batch signing key",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "no batch signing",
+		},
+		{
+			name: "no packet encryption key",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{},
+			},
+			wantErrStr: "exactly one packet encryption",
+		},
+		{
+			name: "multiple packet encryption keys",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek-1": PacketEncryptionCertificate{CertificateSigningRequest: "csr-1"},
+					"pek-2": PacketEncryptionCertificate{CertificateSigningRequest: "csr-2"},
+				},
+			},
+			wantErrStr: "exactly one packet encryption",
+		},
+		{
+			name: "non-key data modified (format)",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 2,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "non-key data modified",
+		},
+		{
+			name: "non-key data modified (ingestion identity)",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "modified-ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "non-key data modified",
+		},
+		{
+			name: "non-key data modified (ingestion bucket)",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "modified-ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "non-key data modified",
+		},
+		{
+			name: "non-key data modified (peer validation identity)",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "modified-peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "non-key data modified",
+		},
+		{
+			name: "non-key data modified (peer validation bucket)",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "modified-peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "non-key data modified",
+		},
+		{
+			name: "existing batch signing key modified",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "modified-pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+			wantErrStr: "pre-existing batch signing key",
+		},
+		{
+			name: "existing packet encryption key modified",
+			manifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "modified-csr"},
+				},
+			},
+			oldManifest: DataShareProcessorSpecificManifest{
+				Format:                 1,
+				IngestionIdentity:      "ingestion-identity",
+				IngestionBucket:        "ingestion-bucket",
+				PeerValidationIdentity: "peer-validation-identity",
+				PeerValidationBucket:   "peer-validation-bucket",
+				BatchSigningPublicKeys: BatchSigningPublicKeys{
+					"bsk": BatchSigningPublicKey{PublicKey: "pubkey"},
+				},
+				PacketEncryptionKeyCSRs: PacketEncryptionKeyCSRs{
+					"pek": PacketEncryptionCertificate{CertificateSigningRequest: "csr"},
+				},
+			},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			oldM := test.oldManifest
+			if oldM.Equal(DataShareProcessorSpecificManifest{}) {
+				oldM = test.manifest
+			}
+			err := validateUpdatedManifest(test.manifest, oldM)
+			if err == nil || !strings.Contains(err.Error(), test.wantErrStr) {
+				t.Errorf("Wanted error containing %q, got: %v", test.wantErrStr, err)
+			}
+		})
+	}
+}
+
 // mustP256 creates a new random P256 key or dies trying.
 func mustP256() key.Material {
 	k, err := key.P256.New()


### PR DESCRIPTION
Specifically (from https://github.com/abetterinternet/prio-server/issues/24):
* When being used to update keys in a manifest, existing key versions' public portions should match with the public keys written to the manifest, matching by creation time/key ID (both of which would provide the same matching).
* Detection for: "if a batch signing key got so far ahead of its related manifests that the primary key was not included in the manifest, we would be trying to sign data with a key that we do not recognize as valid for verification."
* Detection for: "if a packet encryption key got so far ahead of its related manifests that the key did not include the version advertised as primary in the manifest, we would be asking clients to encrypt with a key we no longer consider valid for decryption."

Stacked on https://github.com/abetterinternet/prio-server/pull/1135.