### PR TITLE
prod-intl: bump Kubernetes cluster from 6 -> 9 nodes.

### DIFF
--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -57,9 +57,9 @@ ingestors = {
   }
 }
 cluster_settings = {
-  initial_node_count = 6
-  min_node_count     = 3
-  max_node_count     = 6
+  initial_node_count = 9
+  min_node_count     = 9
+  max_node_count     = 9
   gcp_machine_type   = "e2-standard-2"
   aws_machine_types  = ["t3.large"]
 }


### PR DESCRIPTION
(no rush on review, just keeping our committed config in line with what's actually deployed to production)