### PR TITLE
Key Rotator: terraform to allow controlling which localities have their keys rotated

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -249,6 +249,11 @@ variable "packet_encryption_key_rotation_policy" {
   }
 }
 
+variable "enable_key_rotation_localities" {
+  type    = list(string)
+  default = []
+}
+
 terraform {
   backend "gcs" {}
 
@@ -424,7 +429,7 @@ resource "kubernetes_secret" "ingestion_packet_decryption_keys" {
 
   lifecycle {
     ignore_changes = [
-      data["secret_key"]
+      data
     ]
   }
 }
@@ -548,6 +553,7 @@ module "kubernetes_locality" {
   certificate_fqdn                      = "${kubernetes_namespace.namespaces[each.key].metadata[0].name}.${var.environment}.certificates.${var.manifest_domain}"
   batch_signing_key_rotation_policy     = var.batch_signing_key_rotation_policy
   packet_encryption_key_rotation_policy = var.packet_encryption_key_rotation_policy
+  enable_key_rotator_localities         = toset(var.enable_key_rotation_localities)
 }
 
 module "data_share_processors" {

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -201,7 +201,7 @@ resource "kubernetes_secret" "batch_signing_key" {
 
   lifecycle {
     ignore_changes = [
-      data["secret_key"]
+      data
     ]
   }
 }


### PR DESCRIPTION
Also, fixup a few small issues:
  * Fix secret definitions so they don't try to modify _any_ secret
    data, rather than only leaving secret data at "secret_key" alone.
    (this is necessary because the new key rotation infra will also set
    the "key_versions" secret data)
  * Tweak key rotator AWS permissions to actually grant the necessary
    permissions on the Manifest bucket's objects.

Stacked on https://github.com/abetterinternet/prio-server/pull/1138.