### PR TITLE
Key rotator: fix bug with packet encryption key deserialization.

### DIFF
--- a/key-rotator/key/material.go
+++ b/key-rotator/key/material.go
@@ -101,10 +101,11 @@ func (m Material) MarshalText() ([]byte, error) {
 
 func (m *Material) UnmarshalText(data []byte) error {
 	binBytes := make([]byte, base64.RawStdEncoding.DecodedLen(len(data)))
-	if _, err := base64.RawStdEncoding.Decode(binBytes, data); err != nil {
+	n, err := base64.RawStdEncoding.Decode(binBytes, data)
+	if err != nil {
 		return fmt.Errorf("couldn't decode base64: %w", err)
 	}
-	return m.UnmarshalBinary(binBytes)
+	return m.UnmarshalBinary(binBytes[:n])
 }
 
 func (m Material) Equal(o Material) bool {

--- a/key-rotator/storage/key.go
+++ b/key-rotator/storage/key.go
@@ -123,10 +123,11 @@ func (k k8sKey) getKey(ctx context.Context, secretName string, parseSecretKey fu
 	// Parse as an "old" secret_key-serialized key.
 	if liveVersion, ok := s.Data[liveVersionsSecretKey]; ok && string(liveVersion) != secretKeyUnfilledValue {
 		keyMaterialBytes := make([]byte, base64.StdEncoding.DecodedLen(len(liveVersion)))
-		if _, err := base64.StdEncoding.Decode(keyMaterialBytes, liveVersion); err != nil {
+		n, err := base64.StdEncoding.Decode(keyMaterialBytes, liveVersion)
+		if err != nil {
 			return key.Key{}, fmt.Errorf("couldn't interpret secret %q secret key as base64: %w", secretName, err)
 		}
-		keyMaterial, err := parseSecretKey(keyMaterialBytes)
+		keyMaterial, err := parseSecretKey(keyMaterialBytes[:n])
 		if err != nil {
 			return key.Key{}, fmt.Errorf("couldn't interpret secret %q secret key as key: %w", secretName, err)
 		}

--- a/key-rotator/storage/key_test.go
+++ b/key-rotator/storage/key_test.go
@@ -125,13 +125,13 @@ func TestKubernetesKey(t *testing.T) {
 		wantKey := k(kv(0, mustP256From(&ecdsa.PrivateKey{
 			PublicKey: ecdsa.PublicKey{
 				Curve: elliptic.P256(),
-				X:     mustInt("78527022544260903523204947018872622072202784880351210249668611210032537819764"),
-				Y:     mustInt("22745617558975184728664387250484621262807351942545566697101728810261708479900"),
+				X:     mustInt("30176607170335032169658242164164128826835373272126183526750106092296931195595"),
+				Y:     mustInt("108357461753906582253786936365593814628895529785013716760654244774460420655478"),
 			},
-			D: mustInt("7417359065569682521889946159093475243201835077729681597084399613736246477746929664"),
+			D: mustInt("79147076814969273829273941581782929461090592164040248130581241256142186071590"),
 		})))
-		const wantSecretKey = "BK2cuD4p1h6OEMMwaBh1UfJq7PAK8HgnQ/ztl3PFIlp0MkmQNYJkekvodLyqcte2t3WQoejx0J9/QqhZ19/fHZz6OZAo45m1iEaeq0f20adSOgf53w/5jvPwlLE/Tss3EQAA" // taken from a dev environment's actual secret
-		const wantKeyVersions = `[{"key":"AQKtnLg+KdYejhDDMGgYdVHyauzwCvB4J0P87ZdzxSJadPo5kCjjmbWIRp6rR/bRp1I6B/nfD/mO8/CUsT9OyzcRAAA","creation_time":"0","primary":true}]`
+		const wantSecretKey = "BEK3Wrk7GOIkNmFqgbSN/P0eDFexXgSLWm7SrcPitTrL75AmZBrL3IoNy4CdrFJt5br2jA0RSkrnFLh5FAvuCXau+6hxT2U6N4c8sTbUJIRQe25MQ1peZQ4J0FZuChXGJg==" // taken from a dev environment's actual secret
+		const wantKeyVersions = `[{"key":"AQJCt1q5OxjiJDZhaoG0jfz9HgxXsV4Ei1pu0q3D4rU6y677qHFPZTo3hzyxNtQkhFB7bkxDWl5lDgnQVm4KFcYm","creation_time":"0","primary":true}]`
 
 		t.Run("Put", func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Previously, we weren't checking the number of bytes returned from
`Decode`; in practice, this meant packet encryption keys that
round-tripped through serialization would end up with a `D` value that
was a few bytes too long. This didn't actually break anything for the
key rotator itself, since it doesn't use the key, but as one might
imagine the facilitator was none-too-happy about receiving these
malformed keys.

Sadly, this wasn't caught by tests... because the test that would have
caught it was set up to use a "bad" key. :cry: