### PR TITLE
Workflow manager: bounds-check date components.

### DIFF
--- a/workflow-manager/batchpath/batchpath.go
+++ b/workflow-manager/batchpath/batchpath.go
@@ -2,6 +2,7 @@ package batchpath
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -87,8 +88,13 @@ func New(batchName string) (*BatchPath, error) {
 	var dateComponents []int
 	for _, c := range batchDate {
 		parsed, err := strconv.ParseInt(c, 10, 64)
-		if err != nil {
+		switch {
+		case err != nil:
 			return nil, fmt.Errorf("parsing date component %q in %q: %w", c, batchName, err)
+		case parsed > math.MaxInt:
+			return nil, fmt.Errorf("parsing date component %q in %q: parsed value (%d) larger than maximum allowed value (%d)", c, batchName, parsed, math.MaxInt)
+		case parsed < 0:
+			return nil, fmt.Errorf("parsing date component %q in %q: parsed value (%d) smaller than minimum allowed value (%d)", c, batchName, parsed, 0)
 		}
 		dateComponents = append(dateComponents, int(parsed))
 	}


### PR DESCRIPTION
This fixes an issue found by the "lgtm.com" continuous security analysis: https://lgtm.com/projects/g/abetterinternet/prio-server/?mode=list. Noticed by Amir.

(For some date components like "month" or "day", the logical lower bound is actually 1 rather than 0. Looking to the code, this would be "normalized" against other date components, which might lead to a somewhat unexpected date output, but not to e.g. a crash or a panic.)