### PR TITLE
Add (bogus) expiry date to manifests' batch signing public key.

### DIFF
--- a/key-rotator/manifest/manifest.go
+++ b/key-rotator/manifest/manifest.go
@@ -357,7 +357,7 @@ type BatchSigningPublicKey struct {
 	// PublicKey is the PEM armored base64 encoding of the ASN.1 encoding of the
 	// PKIX SubjectPublicKeyInfo structure. It must be an ECDSA P256 key.
 	PublicKey string `json:"public-key"`
-	// Expiration is the RFC3339-encoded UTC date at which this key expires.
+	// Expiration is the ISO 8601 encoded UTC date at which this key expires.
 	Expiration string `json:"expiration"`
 }
 

--- a/key-rotator/manifest/manifest_test.go
+++ b/key-rotator/manifest/manifest_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -198,6 +199,9 @@ func TestUpdateKeys(t *testing.T) {
 				if err != nil {
 					t.Errorf("Batch signing key ID %q was unparseable: %v", kid, err)
 					continue
+				}
+				if _, err := time.Parse(time.RFC3339, bsk.Expiration); err != nil {
+					t.Errorf("Batch singing key ID %q had unparseable expiration %q: %v", kid, bsk.Expiration, err)
 				}
 				gotBSKPubkeys[kid] = pub
 			}
@@ -681,7 +685,10 @@ func manifestBSK(tss ...int64) BatchSigningPublicKeys {
 		if err != nil {
 			panic(fmt.Sprintf("Couldn't serialize key material as PKIX: %v", err))
 		}
-		rslt[kid] = BatchSigningPublicKey{PublicKey: pkix}
+		rslt[kid] = BatchSigningPublicKey{
+			PublicKey:  pkix,
+			Expiration: time.Now().Format(time.RFC3339),
+		}
 	}
 	return rslt
 }


### PR DESCRIPTION
This field is evidently not respected by any parties in the current ENPA
deployment (most/all of the expiration dates in the production
deployment are now in the past). But per discussion with ENPA team
members, we want to continue populating this with *something* in case
one of the parties is parsing this value & then ignoring it.

I also switch to specifying the dates as RFC 3339 rather than ISO 8601.
The populated data may very well fit both specs, but our current tooling
writes in RFC3339 format, so update the comment to be sure:
https://github.com/abetterinternet/prio-server/blob/f8e9707bb94471e6d9d7abcb9afda3216e652adc/deploy-tool/main.go#L186-L195