### PR TITLE
Key rotator: add Key.Diff, use it to describe why we are writing keys.

### DIFF
--- a/key-rotator/key/key.go
+++ b/key-rotator/key/key.go
@@ -79,12 +79,12 @@ func (k Key) Equal(o Key) bool {
 // string if and only if the two keys are equal.
 func (k Key) Diff(o Key) string {
 	// Build up structures allowing easy generation of diffs.
-	var newPKTS, oldPKTS *int64
+	var newPrimaryKeyTS, oldPrimaryKeyTS *int64
 	infos := map[int64]struct{ oldMat, newMat *Material }{}
 	for i, v := range k.v {
 		v := v
 		if i == 0 {
-			newPKTS = &v.CreationTimestamp
+			newPrimaryKeyTS = &v.CreationTimestamp
 		}
 		info := infos[v.CreationTimestamp]
 		info.newMat = &v.KeyMaterial
@@ -93,33 +93,33 @@ func (k Key) Diff(o Key) string {
 	for i, v := range o.v {
 		v := v
 		if i == 0 {
-			oldPKTS = &v.CreationTimestamp
+			oldPrimaryKeyTS = &v.CreationTimestamp
 		}
 		info := infos[v.CreationTimestamp]
 		info.oldMat = &v.KeyMaterial
 		infos[v.CreationTimestamp] = info
 	}
-	tss := make([]int64, 0, len(infos))
+	timestamps := make([]int64, 0, len(infos))
 	for ts := range infos {
-		tss = append(tss, ts)
+		timestamps = append(timestamps, ts)
 	}
-	sort.Slice(tss, func(i, j int) bool { return tss[i] < tss[j] })
+	sort.Slice(timestamps, func(i, j int) bool { return timestamps[i] < timestamps[j] })
 
 	// Generate primary-version diffs.
 	var diffs []string
 	switch {
-	case newPKTS == nil && oldPKTS == nil:
+	case newPrimaryKeyTS == nil && oldPrimaryKeyTS == nil:
 		// no diff if both keys are empty
-	case oldPKTS == nil:
-		diffs = append(diffs, fmt.Sprintf("changed primary version none → %d", *newPKTS))
-	case newPKTS == nil:
-		diffs = append(diffs, fmt.Sprintf("changed primary version %d → none", *oldPKTS))
-	case *oldPKTS != *newPKTS:
-		diffs = append(diffs, fmt.Sprintf("changed primary version %d → %d", *oldPKTS, *newPKTS))
+	case oldPrimaryKeyTS == nil:
+		diffs = append(diffs, fmt.Sprintf("changed primary version none → %d", *newPrimaryKeyTS))
+	case newPrimaryKeyTS == nil:
+		diffs = append(diffs, fmt.Sprintf("changed primary version %d → none", *oldPrimaryKeyTS))
+	case *oldPrimaryKeyTS != *newPrimaryKeyTS:
+		diffs = append(diffs, fmt.Sprintf("changed primary version %d → %d", *oldPrimaryKeyTS, *newPrimaryKeyTS))
 	}
 
 	// Generate key version diffs.
-	for _, ts := range tss {
+	for _, ts := range timestamps {
 		info := infos[ts]
 		switch {
 		case info.oldMat == nil:

--- a/key-rotator/key/key.go
+++ b/key-rotator/key/key.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -71,6 +72,65 @@ func (k Key) Equal(o Key) bool {
 		}
 	}
 	return true
+}
+
+// Diff returns a human-readable string describing the differences from the
+// given `o` key to this key, suitable for logging. Diff returns the empty
+// string if and only if the two keys are equal.
+func (k Key) Diff(o Key) string {
+	// Build up structures allowing easy generation of diffs.
+	var newPKTS, oldPKTS *int64
+	infos := map[int64]struct{ oldMat, newMat *Material }{}
+	for i, v := range k.v {
+		v := v
+		if i == 0 {
+			newPKTS = &v.CreationTimestamp
+		}
+		info := infos[v.CreationTimestamp]
+		info.newMat = &v.KeyMaterial
+		infos[v.CreationTimestamp] = info
+	}
+	for i, v := range o.v {
+		v := v
+		if i == 0 {
+			oldPKTS = &v.CreationTimestamp
+		}
+		info := infos[v.CreationTimestamp]
+		info.oldMat = &v.KeyMaterial
+		infos[v.CreationTimestamp] = info
+	}
+	tss := make([]int64, 0, len(infos))
+	for ts := range infos {
+		tss = append(tss, ts)
+	}
+	sort.Slice(tss, func(i, j int) bool { return tss[i] < tss[j] })
+
+	// Generate primary-version diffs.
+	var diffs []string
+	switch {
+	case newPKTS == nil && oldPKTS == nil:
+		// no diff if both keys are empty
+	case oldPKTS == nil:
+		diffs = append(diffs, fmt.Sprintf("changed primary version none → %d", *newPKTS))
+	case newPKTS == nil:
+		diffs = append(diffs, fmt.Sprintf("changed primary version %d → none", *oldPKTS))
+	case *oldPKTS != *newPKTS:
+		diffs = append(diffs, fmt.Sprintf("changed primary version %d → %d", *oldPKTS, *newPKTS))
+	}
+
+	// Generate key version diffs.
+	for _, ts := range tss {
+		info := infos[ts]
+		switch {
+		case info.oldMat == nil:
+			diffs = append(diffs, fmt.Sprintf("added version %d", ts))
+		case info.newMat == nil:
+			diffs = append(diffs, fmt.Sprintf("removed version %d", ts))
+		case !info.oldMat.Equal(*info.newMat):
+			diffs = append(diffs, fmt.Sprintf("modified key material for version %d", ts))
+		}
+	}
+	return strings.Join(diffs, "; ")
 }
 
 // IsEmpty returns true if and only if this is the empty key, i.e. the key with

--- a/key-rotator/main.go
+++ b/key-rotator/main.go
@@ -336,8 +336,10 @@ func writeKeys(ctx context.Context, keyStore storage.Key, locality string,
 	// Write packet encryption key.
 	eg.Go(func() error {
 		if oldPacketEncryptionKey.Equal(newPacketEncryptionKey) {
+			log.Debug().Msgf("Skipping write for packet encryption key for %q: key unchanged", locality)
 			return nil
 		}
+		log.Info().Msgf("Writing packet encryption key for %q due to changes to key: %s", locality, newPacketEncryptionKey.Diff(oldPacketEncryptionKey))
 		if err := keyStore.PutPacketEncryptionKey(ctx, locality, newPacketEncryptionKey); err != nil {
 			return fmt.Errorf("couldn't write packet encryption key for %q: %w", locality, err)
 		}
@@ -349,8 +351,10 @@ func writeKeys(ctx context.Context, keyStore storage.Key, locality string,
 		ingestor, oldKey, newKey := ingestor, oldKey, newBatchSigningKeyByIngestor[ingestor]
 		eg.Go(func() error {
 			if oldKey.Equal(newKey) {
+				log.Debug().Msgf("Skipping write for batch signing key for (%q, %q): key unchanged", locality, ingestor)
 				return nil
 			}
+			log.Info().Msgf("Writing batch signing key for (%q, %q) due to changes to key: %s", locality, ingestor, newKey.Diff(oldKey))
 			if err := keyStore.PutBatchSigningKey(ctx, locality, ingestor, newKey); err != nil {
 				return fmt.Errorf("couldn't write batch signing key for (%q, %q): %w", locality, ingestor, err)
 			}

--- a/key-rotator/main.go
+++ b/key-rotator/main.go
@@ -336,10 +336,10 @@ func writeKeys(ctx context.Context, keyStore storage.Key, locality string,
 	// Write packet encryption key.
 	eg.Go(func() error {
 		if oldPacketEncryptionKey.Equal(newPacketEncryptionKey) {
-			log.Debug().Msgf("Skipping write for packet encryption key for %q: key unchanged", locality)
+			log.Debug().Str("locality", locality).Msgf("Skipping write for packet encryption key for %q: key unchanged", locality)
 			return nil
 		}
-		log.Info().Msgf("Writing packet encryption key for %q due to changes to key: %s", locality, newPacketEncryptionKey.Diff(oldPacketEncryptionKey))
+		log.Info().Str("locality", locality).Msgf("Writing packet encryption key for %q due to changes to key: %s", locality, newPacketEncryptionKey.Diff(oldPacketEncryptionKey))
 		if err := keyStore.PutPacketEncryptionKey(ctx, locality, newPacketEncryptionKey); err != nil {
 			return fmt.Errorf("couldn't write packet encryption key for %q: %w", locality, err)
 		}
@@ -351,10 +351,10 @@ func writeKeys(ctx context.Context, keyStore storage.Key, locality string,
 		ingestor, oldKey, newKey := ingestor, oldKey, newBatchSigningKeyByIngestor[ingestor]
 		eg.Go(func() error {
 			if oldKey.Equal(newKey) {
-				log.Debug().Msgf("Skipping write for batch signing key for (%q, %q): key unchanged", locality, ingestor)
+				log.Debug().Str("locality", locality).Str("ingestor", ingestor).Msgf("Skipping write for batch signing key for (%q, %q): key unchanged", locality, ingestor)
 				return nil
 			}
-			log.Info().Msgf("Writing batch signing key for (%q, %q) due to changes to key: %s", locality, ingestor, newKey.Diff(oldKey))
+			log.Info().Str("locality", locality).Str("ingestor", ingestor).Msgf("Writing batch signing key for (%q, %q) due to changes to key: %s", locality, ingestor, newKey.Diff(oldKey))
 			if err := keyStore.PutBatchSigningKey(ctx, locality, ingestor, newKey); err != nil {
 				return fmt.Errorf("couldn't write batch signing key for (%q, %q): %w", locality, ingestor, err)
 			}


### PR DESCRIPTION
I think this is useful for debugging/observability. (I plan to add
similar functionality to manifests in an upcoming PR.)