### PR TITLE
GH actions: push `key-rotator` from build step

### DIFF
--- a/.github/workflows/push-docker-image-main.yml
+++ b/.github/workflows/push-docker-image-main.yml
@@ -74,7 +74,4 @@ jobs:
       with:
         file: ./key-rotator/Dockerfile
         tags: letsencrypt/prio-key-rotator:${{ steps.get_hash.outputs.HASH }},letsencrypt/prio-key-rotator:latest-main
-    - name: push hash
-      run: docker push letsencrypt/prio-key-rotator:${{ steps.get_hash.outputs.HASH }}
-    - name: push latest-main
-      run: docker push letsencrypt/prio-key-rotator:latest-main
+        push: true

--- a/.github/workflows/push-docker-image-release.yml
+++ b/.github/workflows/push-docker-image-release.yml
@@ -76,7 +76,4 @@ jobs:
       with:
         file: ./key-rotator/Dockerfile
         tags: letsencrypt/prio-key-rotator:${{ steps.get_version.outputs.VERSION }},letsencrypt/prio-key-rotator:latest
-    - name: push
-      run: docker push letsencrypt/prio-key-rotator:${{ steps.get_version.outputs.VERSION }}
-    - name: push-latest
-      run: docker push letsencrypt/prio-key-rotator:latest
+        push: true


### PR DESCRIPTION
Pushing `prio-key-rotator` container images from a step separate from
the build doesn't work because the build cache gets cleaned up between
GH action steps, and so the built image is not visible to the push
steps. We could be clever about exporting the build image, but it's
easier to just push to dockerhub from the `build` step.