### PR TITLE
Facilitator: allow workers to self-terminate after working too long.

### DIFF
--- a/terraform/modules/fake_server_resources/fake_server_resources.tf
+++ b/terraform/modules/fake_server_resources/fake_server_resources.tf
@@ -223,7 +223,8 @@ resource "kubernetes_deployment" "integration-tester" {
             "--batch-end-time", "1000000100",
             "--dimension", "123",
             "--epsilon", "0.23",
-            "--generation-interval", "60"
+            "--generation-interval", "60",
+            "--worker-maximum-lifetime", "3600"
           ]
         }
       }

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -236,6 +236,7 @@ resource "kubernetes_config_map" "intake_batch_config_map" {
     AWS_SQS_REGION                                  = var.use_aws ? var.aws_region : ""
     GCP_PROJECT_ID                                  = var.use_aws ? "" : data.google_project.project.project_id
     GCP_WORKLOAD_IDENTITY_POOL_PROVIDER             = var.gcp_workload_identity_pool_provider
+    WORKER_MAXIMUM_LIFETIME                         = "3600"
   }
 }
 
@@ -269,6 +270,7 @@ resource "kubernetes_config_map" "aggregate_config_map" {
     GCP_PROJECT_ID                       = var.use_aws ? "" : data.google_project.project.project_id
     PERMIT_MALFORMED_BATCH               = "true"
     GCP_WORKLOAD_IDENTITY_POOL_PROVIDER  = var.gcp_workload_identity_pool_provider
+    WORKER_MAXIMUM_LIFETIME              = "3600"
   }
 }
 


### PR DESCRIPTION
This allows a poor man's version of config reloads, since the
newly-started pod will pick up any configuration changes (config map,
manifest contents, secret contents...).