### PR TITLE
Use correct key ID for batch signing private key.

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -315,6 +315,20 @@ impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {
                     corresponding to an entry in this server's global \
                     or specific manifest. Used to construct \
                     PrioBatchSignature messages.",
+                ),
+        )
+        .arg(
+            Arg::with_name("batch-signing-private-key-default-identifier")
+                .long("batch-signing-private-key-default-identifier")
+                .env("BATCH_SIGNING_PRIVATE_KEY_DEFAULT_IDENTIFIER")
+                .value_name("ID")
+                .help("Batch signing private key default identifier")
+                .long_help(
+                    "Identifier for the default batch signing keypair to use, \
+                    corresponding to an entry in this server's global or \
+                    specific manifest. Used only if \
+                    --batch-signing-private-key-identifier is not specified. \
+                    Used to construct PrioBatchSignature messages.",
                 )
                 .required(required),
         )
@@ -1862,7 +1876,11 @@ fn batch_signing_key_from_arg(matches: &ArgMatches) -> Result<BatchSigningKey> {
     let key_bytes = decode_base64_key(matches.value_of("batch-signing-private-key").unwrap())?;
     let key_identifier = matches
         .value_of("batch-signing-private-key-identifier")
-        .unwrap();
+        .unwrap_or_else(|| {
+            matches
+                .value_of("batch-signing-private-key-default-identifier")
+                .unwrap()
+        });
     Ok(BatchSigningKey {
         key: EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_ASN1_SIGNING, &key_bytes)
             .context("failed to parse pkcs8 key for batch signing key")?,

--- a/key-rotator/storage/key_test.go
+++ b/key-rotator/storage/key_test.go
@@ -30,6 +30,7 @@ func TestKubernetesKey(t *testing.T) {
 
 		// wantSecretKey taken directly from a dev environment secret
 		// store. Other values derived from wantSecretKey.
+		const secretName = "$ENV-$LOCALITY-$INGESTOR-batch-signing-key"
 		wantKey := k(kv(0, mustP256From(&ecdsa.PrivateKey{
 			PublicKey: ecdsa.PublicKey{
 				Curve: elliptic.P256(),
@@ -43,13 +44,13 @@ func TestKubernetesKey(t *testing.T) {
 
 		t.Run("Put", func(t *testing.T) {
 			t.Parallel()
-			wantSD := map[string][]byte{"secret_key": []byte(wantSecretKey), "key_versions": []byte(wantKeyVersions)}
+			wantSD := map[string][]byte{"secret_key": []byte(wantSecretKey), "key_versions": []byte(wantKeyVersions), "primary_kid": []byte(secretName)}
 			store, sd := newK8sKey(env)
-			putEmpty(sd, "$ENV-$LOCALITY-$INGESTOR-batch-signing-key")
+			putEmpty(sd, secretName)
 			if err := store.PutBatchSigningKey(ctx, locality, ingestor, wantKey); err != nil {
 				t.Fatalf("Unexpected error from PutBatchSigningKey: %v", err)
 			}
-			gotSD := sd["$ENV-$LOCALITY-$INGESTOR-batch-signing-key"]
+			gotSD := sd[secretName]
 			if diff := cmp.Diff(wantSD, gotSD); diff != "" {
 				t.Errorf("Batch signing key secret data differs from expected (-want +got):\n%s", diff)
 			}
@@ -60,7 +61,7 @@ func TestKubernetesKey(t *testing.T) {
 			t.Run("FromSecretKey", func(t *testing.T) {
 				t.Parallel()
 				store, sd := newK8sKey(env)
-				putSecretKey(sd, "$ENV-$LOCALITY-$INGESTOR-batch-signing-key", []byte(wantSecretKey))
+				putSecretKey(sd, secretName, []byte(wantSecretKey))
 				gotKey, err := store.GetBatchSigningKey(ctx, locality, ingestor)
 				if err != nil {
 					t.Fatalf("Unexpected error from GetBatchSigningKey: %v", err)
@@ -73,7 +74,7 @@ func TestKubernetesKey(t *testing.T) {
 			t.Run("FromKeyVersions", func(t *testing.T) {
 				t.Parallel()
 				store, sd := newK8sKey(env)
-				putKeyVersions(sd, "$ENV-$LOCALITY-$INGESTOR-batch-signing-key", []byte(wantKeyVersions))
+				putKeyVersions(sd, secretName, []byte(wantKeyVersions))
 				gotKey, err := store.GetBatchSigningKey(ctx, locality, ingestor)
 				if err != nil {
 					t.Fatalf("Unexpected error from GetBatchSigningKey: %v", err)
@@ -87,7 +88,7 @@ func TestKubernetesKey(t *testing.T) {
 				t.Parallel()
 				var wantKey key.Key // empty key
 				store, sd := newK8sKey(env)
-				putEmpty(sd, "$ENV-$LOCALITY-$INGESTOR-batch-signing-key")
+				putEmpty(sd, secretName)
 				gotKey, err := store.GetBatchSigningKey(ctx, locality, ingestor)
 				if err != nil {
 					t.Fatalf("Unexpected error from GetBatchSigningKey: %v", err)
@@ -102,7 +103,7 @@ func TestKubernetesKey(t *testing.T) {
 		t.Run("RoundTrip", func(t *testing.T) {
 			t.Parallel()
 			store, sd := newK8sKey(env)
-			putEmpty(sd, "$ENV-$LOCALITY-$INGESTOR-batch-signing-key")
+			putEmpty(sd, secretName)
 			if err := store.PutBatchSigningKey(ctx, locality, ingestor, wantKey); err != nil {
 				t.Fatalf("Unexpected error from PutBatchSigningKey: %v", err)
 			}
@@ -122,6 +123,7 @@ func TestKubernetesKey(t *testing.T) {
 
 		// wantSecretKey taken directly from a dev environment secret
 		// store. Other values derived from wantSecretKey.
+		const secretName = "$ENV-$LOCALITY-ingestion-packet-decryption-key"
 		wantKey := k(kv(0, mustP256From(&ecdsa.PrivateKey{
 			PublicKey: ecdsa.PublicKey{
 				Curve: elliptic.P256(),
@@ -135,13 +137,13 @@ func TestKubernetesKey(t *testing.T) {
 
 		t.Run("Put", func(t *testing.T) {
 			t.Parallel()
-			wantSD := map[string][]byte{"secret_key": []byte(wantSecretKey), "key_versions": []byte(wantKeyVersions)}
+			wantSD := map[string][]byte{"secret_key": []byte(wantSecretKey), "key_versions": []byte(wantKeyVersions), "primary_kid": []byte(secretName)}
 			store, sd := newK8sKey(env)
-			putEmpty(sd, "$ENV-$LOCALITY-ingestion-packet-decryption-key")
+			putEmpty(sd, secretName)
 			if err := store.PutPacketEncryptionKey(ctx, locality, wantKey); err != nil {
 				t.Fatalf("Unexpected error from PutPacketEncryptionKey: %v", err)
 			}
-			gotSD := sd["$ENV-$LOCALITY-ingestion-packet-decryption-key"]
+			gotSD := sd[secretName]
 			if diff := cmp.Diff(wantSD, gotSD); diff != "" {
 				t.Errorf("Packet encryption key secret data differs from expected (-want +got):\n%s", diff)
 			}
@@ -152,7 +154,7 @@ func TestKubernetesKey(t *testing.T) {
 			t.Run("FromSecretKey", func(t *testing.T) {
 				t.Parallel()
 				store, sd := newK8sKey(env)
-				putSecretKey(sd, "$ENV-$LOCALITY-ingestion-packet-decryption-key", []byte(wantSecretKey))
+				putSecretKey(sd, secretName, []byte(wantSecretKey))
 				gotKey, err := store.GetPacketEncryptionKey(ctx, locality)
 				if err != nil {
 					t.Fatalf("Unexpected error from GetPacketEncryptionKey: %v", err)
@@ -165,7 +167,7 @@ func TestKubernetesKey(t *testing.T) {
 			t.Run("FromKeyVersions", func(t *testing.T) {
 				t.Parallel()
 				store, sd := newK8sKey(env)
-				putKeyVersions(sd, "$ENV-$LOCALITY-ingestion-packet-decryption-key", []byte(wantKeyVersions))
+				putKeyVersions(sd, secretName, []byte(wantKeyVersions))
 				gotKey, err := store.GetPacketEncryptionKey(ctx, locality)
 				if err != nil {
 					t.Fatalf("Unexpected error from GetPacketEncryptionKey: %v", err)
@@ -179,7 +181,7 @@ func TestKubernetesKey(t *testing.T) {
 				t.Parallel()
 				var wantKey key.Key // empty key
 				store, sd := newK8sKey(env)
-				putEmpty(sd, "$ENV-$LOCALITY-ingestion-packet-decryption-key")
+				putEmpty(sd, secretName)
 				gotKey, err := store.GetPacketEncryptionKey(ctx, locality)
 				if err != nil {
 					t.Fatalf("Unexpected error from GetPacketEncryptionKey: %v", err)
@@ -194,7 +196,7 @@ func TestKubernetesKey(t *testing.T) {
 		t.Run("RoundTrip", func(t *testing.T) {
 			t.Parallel()
 			store, sd := newK8sKey(env)
-			putEmpty(sd, "$ENV-$LOCALITY-ingestion-packet-decryption-key")
+			putEmpty(sd, secretName)
 			if err := store.PutPacketEncryptionKey(ctx, locality, wantKey); err != nil {
 				t.Fatalf("Unexpected error from PutPacketEncryptionKey: %v", err)
 			}

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -221,7 +221,7 @@ resource "kubernetes_config_map" "intake_batch_config_map" {
     # PACKET_DECRYPTION_KEYS is a Kubernetes secret
     # BATCH_SIGNING_PRIVATE_KEY is a Kubernetes secret
     IS_FIRST                                        = var.is_first ? "true" : "false"
-    BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER            = kubernetes_secret.batch_signing_key.metadata[0].name
+    BATCH_SIGNING_PRIVATE_KEY_DEFAULT_IDENTIFIER    = kubernetes_secret.batch_signing_key.metadata[0].name
     INGESTOR_INPUT                                  = var.ingestion_bucket
     INGESTOR_MANIFEST_BASE_URL                      = "https://${var.ingestor_manifest_base_url}"
     INSTANCE_NAME                                   = var.data_share_processor_name
@@ -251,26 +251,26 @@ resource "kubernetes_config_map" "aggregate_config_map" {
   data = {
     # PACKET_DECRYPTION_KEYS is a Kubernetes secret
     # BATCH_SIGNING_PRIVATE_KEY is a Kubernetes secret
-    IS_FIRST                             = var.is_first ? "true" : "false"
-    BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER = kubernetes_secret.batch_signing_key.metadata[0].name
-    INGESTOR_INPUT                       = var.ingestion_bucket
-    INGESTOR_MANIFEST_BASE_URL           = "https://${var.ingestor_manifest_base_url}"
-    INSTANCE_NAME                        = var.data_share_processor_name
-    PEER_INPUT                           = var.peer_validation_bucket
-    PEER_MANIFEST_BASE_URL               = "https://${var.peer_manifest_base_url}"
-    PORTAL_IDENTITY                      = var.sum_part_bucket_service_account_email
-    PORTAL_MANIFEST_BASE_URL             = "https://${var.portal_server_manifest_base_url}"
-    RUST_LOG                             = "info"
-    RUST_BACKTRACE                       = "1"
-    PUSHGATEWAY                          = var.pushgateway
-    TASK_QUEUE_KIND                      = var.aggregate_queue.subscription_kind
-    TASK_QUEUE_NAME                      = var.aggregate_queue.subscription
-    GCP_PROJECT_ID                       = data.google_project.project.project_id
-    AWS_SQS_REGION                       = var.use_aws ? var.aws_region : ""
-    GCP_PROJECT_ID                       = var.use_aws ? "" : data.google_project.project.project_id
-    PERMIT_MALFORMED_BATCH               = "true"
-    GCP_WORKLOAD_IDENTITY_POOL_PROVIDER  = var.gcp_workload_identity_pool_provider
-    WORKER_MAXIMUM_LIFETIME              = "3600"
+    IS_FIRST                                     = var.is_first ? "true" : "false"
+    BATCH_SIGNING_PRIVATE_KEY_DEFAULT_IDENTIFIER = kubernetes_secret.batch_signing_key.metadata[0].name
+    INGESTOR_INPUT                               = var.ingestion_bucket
+    INGESTOR_MANIFEST_BASE_URL                   = "https://${var.ingestor_manifest_base_url}"
+    INSTANCE_NAME                                = var.data_share_processor_name
+    PEER_INPUT                                   = var.peer_validation_bucket
+    PEER_MANIFEST_BASE_URL                       = "https://${var.peer_manifest_base_url}"
+    PORTAL_IDENTITY                              = var.sum_part_bucket_service_account_email
+    PORTAL_MANIFEST_BASE_URL                     = "https://${var.portal_server_manifest_base_url}"
+    RUST_LOG                                     = "info"
+    RUST_BACKTRACE                               = "1"
+    PUSHGATEWAY                                  = var.pushgateway
+    TASK_QUEUE_KIND                              = var.aggregate_queue.subscription_kind
+    TASK_QUEUE_NAME                              = var.aggregate_queue.subscription
+    GCP_PROJECT_ID                               = data.google_project.project.project_id
+    AWS_SQS_REGION                               = var.use_aws ? var.aws_region : ""
+    GCP_PROJECT_ID                               = var.use_aws ? "" : data.google_project.project.project_id
+    PERMIT_MALFORMED_BATCH                       = "true"
+    GCP_WORKLOAD_IDENTITY_POOL_PROVIDER          = var.gcp_workload_identity_pool_provider
+    WORKER_MAXIMUM_LIFETIME                      = "3600"
   }
 }
 
@@ -437,6 +437,16 @@ resource "kubernetes_deployment" "intake_batch" {
                 name     = kubernetes_secret.batch_signing_key.metadata[0].name
                 key      = "secret_key"
                 optional = false
+              }
+            }
+          }
+          env {
+            name = "BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER"
+            value_from {
+              secret_key_ref {
+                name     = kubernetes_secret.batch_signing_key.metadata[0].name
+                key      = "primary_kid"
+                optional = true
               }
             }
           }
@@ -633,6 +643,16 @@ resource "kubernetes_deployment" "aggregate" {
                 name     = kubernetes_secret.batch_signing_key.metadata[0].name
                 key      = "secret_key"
                 optional = false
+              }
+            }
+          }
+          env {
+            name = "BATCH_SIGNING_PRIVATE_KEY_IDENTIFIER"
+            value_from {
+              secret_key_ref {
+                name     = kubernetes_secret.batch_signing_key.metadata[0].name
+                key      = "primary_kid"
+                optional = true
               }
             }
           }


### PR DESCRIPTION
Previously, the facilitator would always write the key identifier for
the "original" (e.g. old-style) key. This commit creates the necessary
plumbing for the correct key identifier to make it into the facilitator,
while still allowing fallback for "old-style" keys that have not yet
been rotated.

I'm still experimenting with/testing this, but I think it's ready for
review.