### PR TITLE
Key rotator: add flags to force writing keys back to storage.

### DIFF
--- a/key-rotator/main_test.go
+++ b/key-rotator/main_test.go
@@ -31,19 +31,23 @@ func TestRotateKeys(t *testing.T) {
 		ingestors:       []string{"ingestor-1", "ingestor-2"},
 		prioEnvironment: "prio-env",
 		csrFQDN:         "some.fqdn",
-		batchRotationCFG: key.RotationConfig{
-			CreateKeyFunc:     key.P256.New,
-			CreateMinAge:      10000 * time.Second,
-			PrimaryMinAge:     1000 * time.Second,
-			DeleteMinAge:      20000 * time.Second,
-			DeleteMinKeyCount: 2,
+		batchCFG: rotateKeyConfig{
+			rotationCFG: key.RotationConfig{
+				CreateKeyFunc:     key.P256.New,
+				CreateMinAge:      10000 * time.Second,
+				PrimaryMinAge:     1000 * time.Second,
+				DeleteMinAge:      20000 * time.Second,
+				DeleteMinKeyCount: 2,
+			},
 		},
-		packetRotationCFG: key.RotationConfig{
-			CreateKeyFunc:     key.P256.New,
-			CreateMinAge:      1000 * time.Second,
-			PrimaryMinAge:     0,
-			DeleteMinAge:      2000 * time.Second,
-			DeleteMinKeyCount: 3,
+		packetCFG: rotateKeyConfig{
+			rotationCFG: key.RotationConfig{
+				CreateKeyFunc:     key.P256.New,
+				CreateMinAge:      1000 * time.Second,
+				PrimaryMinAge:     0,
+				DeleteMinAge:      2000 * time.Second,
+				DeleteMinKeyCount: 3,
+			},
 		},
 	}
 


### PR DESCRIPTION
Normally, we only write keys to storage if we detect that they have
actually changed, e.g. the rotation policy caused a new key version to
be created, a new primary version to be elected, etc. Being able to
force a write even when there are no changes would be useful in some
circumstances, e.g. to force a backup, or a re-serialization of existing
keys.