### PR TITLE
Enable key rotator in staging-facil environment.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -249,6 +249,11 @@ variable "packet_encryption_key_rotation_policy" {
   }
 }
 
+variable "key_rotator_schedule" {
+  type    = string
+  default = "0 20 * * MON-THU" # 8 PM (UTC) daily, Monday thru Thursday
+}
+
 variable "enable_key_rotation_localities" {
   type    = list(string)
   default = []
@@ -555,6 +560,7 @@ module "kubernetes_locality" {
   batch_signing_key_rotation_policy     = var.batch_signing_key_rotation_policy
   packet_encryption_key_rotation_policy = var.packet_encryption_key_rotation_policy
   enable_key_rotator_localities         = toset(var.enable_key_rotation_localities)
+  key_rotator_schedule                  = var.key_rotator_schedule
 }
 
 module "data_share_processors" {

--- a/terraform/modules/kubernetes_locality/kubernetes_locality.tf
+++ b/terraform/modules/kubernetes_locality/kubernetes_locality.tf
@@ -76,6 +76,10 @@ variable "packet_encryption_key_rotation_policy" {
   })
 }
 
+variable "key_rotator_schedule" {
+  type = string
+}
+
 variable "enable_key_rotator_localities" {
   type        = set(string)
   description = <<DESCRIPTION
@@ -175,7 +179,7 @@ resource "kubernetes_cron_job" "key_rotator" {
   }
 
   spec {
-    schedule                      = "0 20 * * MON-THU" # 8 PM (UTC) daily, Monday thru Thursday
+    schedule                      = var.key_rotator_schedule
     concurrency_policy            = "Forbid"
     successful_jobs_history_limit = 5
     failed_jobs_history_limit     = 5

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -67,3 +67,12 @@ default_aggregation_period = "30m"
 
 default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-pha-manifests"
 default_portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-facil-manifests/portal-server"
+
+key_rotator_schedule           = "*/10 * * * *" // once per ten minutes
+enable_key_rotation_localities = ["*"]
+batch_signing_key_rotation_policy = {
+  create_min_age   = "6480h" // 6480 hours = 9 months (w/ 30-day months, 24-hour days)
+  primary_min_age  = "6h"    // 6 hours
+  delete_min_age   = "9360h" // 9360 hours = 13 months (w/ 30-day months, 24-hour days)
+  delete_min_count = 2
+}


### PR DESCRIPTION
I set it up at a rapid pace: the rotator runs once per ten minutes
rather than once per day, and will allow a new batch signing key version
to become primary after 6 hours rather than a week.

Haven't applied yet, but similar changes work for my dev environment. Will apply once this passes review.