### PR TITLE
Staging-facil: bump container versions `0.6.18` -> `0.6.19`.

### DIFF
--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -58,8 +58,9 @@ test_peer_environment = {
 }
 is_first                 = false
 use_aws                  = false
-workflow_manager_version = "0.6.18"
-facilitator_version      = "0.6.18"
+workflow_manager_version = "latest-main"
+facilitator_version      = "latest-main"
+key_rotator_version      = "latest-main"
 victorops_routing_key    = "prio-staging"
 
 intake_max_age             = "75m"

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -58,9 +58,9 @@ test_peer_environment = {
 }
 is_first                 = false
 use_aws                  = false
-workflow_manager_version = "latest-main"
-facilitator_version      = "latest-main"
-key_rotator_version      = "latest-main"
+workflow_manager_version = "0.6.19"
+facilitator_version      = "0.6.19"
+key_rotator_version      = "0.6.19"
 victorops_routing_key    = "prio-staging"
 
 intake_max_age             = "75m"


### PR DESCRIPTION
This enables key rotation. Already deployed; this PR brings the committed configuration state in line with what's deployed.