### PR TITLE
terraform: update Grafana, Prometheus, exporters

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -259,6 +259,28 @@ variable "enable_key_rotation_localities" {
   default = []
 }
 
+variable "prometheus_helm_chart_version" {
+  type = string
+  # The default is the empty string, which uses the latest available version at
+  # the time of apply
+  default = ""
+}
+
+variable "grafana_helm_chart_version" {
+  type    = string
+  default = ""
+}
+
+variable "cloudwatch_exporter_helm_chart_version" {
+  type    = string
+  default = ""
+}
+
+variable "stackdriver_exporter_helm_chart_version" {
+  type    = string
+  default = ""
+}
+
 terraform {
   backend "gcs" {}
 
@@ -742,6 +764,11 @@ module "monitoring" {
   eks_oidc_provider     = var.use_aws ? module.eks[0].oidc_provider : { url = "", arn = "" }
 
   prometheus_server_persistent_disk_size_gb = var.prometheus_server_persistent_disk_size_gb
+
+  prometheus_helm_chart_version           = var.prometheus_helm_chart_version
+  grafana_helm_chart_version              = var.grafana_helm_chart_version
+  cloudwatch_exporter_helm_chart_version  = var.cloudwatch_exporter_helm_chart_version
+  stackdriver_exporter_helm_chart_version = var.stackdriver_exporter_helm_chart_version
 }
 
 output "manifest_bucket" {

--- a/terraform/modules/monitoring/monitoring.tf
+++ b/terraform/modules/monitoring/monitoring.tf
@@ -36,6 +36,22 @@ variable "aggregation_period" {
   type = string
 }
 
+variable "prometheus_helm_chart_version" {
+  type = string
+}
+
+variable "grafana_helm_chart_version" {
+  type = string
+}
+
+variable "cloudwatch_exporter_helm_chart_version" {
+  type = string
+}
+
+variable "stackdriver_exporter_helm_chart_version" {
+  type = string
+}
+
 terraform {
   required_providers {
     helm = {
@@ -231,6 +247,7 @@ resource "helm_release" "prometheus" {
   chart      = "prometheus"
   repository = "https://prometheus-community.github.io/helm-charts"
   namespace  = kubernetes_namespace.monitoring.metadata[0].name
+  version    = var.prometheus_helm_chart_version
 
   set {
     name  = "alertmanager.configFromSecret"
@@ -316,6 +333,7 @@ resource "helm_release" "grafana" {
   chart      = "grafana"
   repository = "https://grafana.github.io/helm-charts"
   namespace  = kubernetes_namespace.monitoring.metadata[0].name
+  version    = var.grafana_helm_chart_version
 
   set {
     name  = "sidecar.datasources.enabled"
@@ -339,6 +357,7 @@ resource "helm_release" "cloudwatch_exporter" {
   chart      = "prometheus-cloudwatch-exporter"
   repository = "https://prometheus-community.github.io/helm-charts"
   namespace  = kubernetes_namespace.monitoring.metadata[0].name
+  version    = var.cloudwatch_exporter_helm_chart_version
 
   set {
     name  = "serviceAccount.create"
@@ -386,6 +405,7 @@ resource "helm_release" "stackdriver_exporter" {
   chart      = "prometheus-stackdriver-exporter"
   repository = "https://prometheus-community.github.io/helm-charts"
   namespace  = kubernetes_namespace.monitoring.metadata[0].name
+  version    = var.stackdriver_exporter_helm_chart_version
 
   set {
     name  = "stackdriver.projectId"

--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -77,3 +77,7 @@ default_aggregation_grace_period = "4h"
 
 default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-enpa-g-prod-manifests"
 default_portal_server_manifest_base_url        = "manifest.global.enpa-pha.io"
+
+prometheus_helm_chart_version          = "14.8.1"
+grafana_helm_chart_version             = "6.16.12"
+cloudwatch_exporter_helm_chart_version = "0.16.0"

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -168,3 +168,7 @@ victorops_routing_key                     = "prio-prod-us"
 
 default_peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
 default_portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+
+prometheus_helm_chart_version           = "11.12.1"
+grafana_helm_chart_version              = "6.1.16"
+stackdriver_exporter_helm_chart_version = "1.8.0"

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -89,3 +89,7 @@ batch_signing_key_rotation_policy = {
   delete_min_age   = "9360h" // 9360 hours = 13 months (w/ 30-day months, 24-hour days)
   delete_min_count = 2
 }
+
+prometheus_helm_chart_version           = "15.0.1"
+grafana_helm_chart_version              = "6.18.2"
+stackdriver_exporter_helm_chart_version = "1.12.0"

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -48,3 +48,7 @@ default_aggregation_grace_period = "10m"
 
 default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-server-manifests"
 default_portal_server_manifest_base_url        = "manifest.int.enpa-pha.io"
+
+prometheus_helm_chart_version          = "15.0.1"
+grafana_helm_chart_version             = "6.18.2"
+cloudwatch_exporter_helm_chart_version = "0.17.1"


### PR DESCRIPTION
Adds support for plumbing Helm chart versions for Grafana, Prometheus
and the Stackdriver (GCP) and Cloudwatch (AWS) metrics exporters from
.tfvars into `monitoring.tf`. This commit only updates the versions in
staging environments. Once we observe that this is stable, a later PR
will update prod.

Part of #1196