### PR TITLE
terraform: configure alert for prometheus disk

### DIFF
--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -99,3 +99,13 @@ groups:
       summary: "Undelivered messages in dead letter queue {{ $labels.queue_name }}"
       description: "There are undelivered messages in the dead letter queue for
         SQS queue {{ $labels.queue_name }} in environment ${environment}."
+  - alert: prometheus_disk_utilization
+    expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim="prometheus-server-claim"}
+      / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim="prometheus-server-claim"} < 0.3
+    for: 5m
+    labels:
+      severity: page
+      environment: ${environment}
+    annotations:
+      summary: "prometheus-server low disk space"
+      description: "There is less than 30% available disk space on the prometheus-server PersistentVolumeClaim"


### PR DESCRIPTION
We now alert if there is there is less than 30% free space on the
persistent disk used by Prometheus to store metrics.

Resolves #364