### PR TITLE
Facilitator: add `PrioValidityBatch` message with serialization support

### DIFF
--- a/avro-schema/validation-batch.avsc
+++ b/avro-schema/validation-batch.avsc
@@ -1,0 +1,22 @@
+{
+    "namespace": "org.abetterinternet.prio.v1",
+    "type": "record",
+    "name": "PrioValidityBatch",
+    "fields": [
+        {
+            "name": "sig",
+            "type": "org.abetterinternet.prio.v1.PrioBatchSignature",
+            "doc": "A signature over the header field."
+        },
+        {
+            "name": "header",
+            "type": "bytes",
+            "doc": "A serialized PrioValidityHeader for the batch."
+        },
+        {
+            "name": "packets",
+            "type": "bytes",
+            "doc": "A serialized sequence of PrioValidityPackets making up the batch."
+        }
+    ]
+}

--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -627,6 +627,7 @@ dependencies = [
  "k8s-openapi",
  "kube",
  "kube-runtime",
+ "lazy_static",
  "mockito",
  "p256",
  "pem 1.0.1",

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -26,6 +26,7 @@ jsonwebtoken = "7"
 k8s-openapi = { version = "0.12.0", default-features = false, features = ["v1_20"] }
 kube = "0.57.0"
 kube-runtime = "0.57.0"
+lazy_static = "1"
 p256 = "0.9.0"
 pem = "1.0"
 pkix = "0.1.1"

--- a/facilitator/src/idl.rs
+++ b/facilitator/src/idl.rs
@@ -1328,11 +1328,14 @@ mod tests {
 
     #[test]
     fn read_data_share_packet() {
-        let schema = IngestionDataSharePacket::schema();
         for (want_data_share_packet, data_share_packet_bytes) in
             &*GOLDEN_INGESTION_DATA_SHARE_PACKETS
         {
-            let mut reader = Reader::with_schema(&schema, &data_share_packet_bytes[..]).unwrap();
+            let mut reader = Reader::with_schema(
+                IngestionDataSharePacket::schema(),
+                &data_share_packet_bytes[..],
+            )
+            .unwrap();
             let data_share_packet = IngestionDataSharePacket::read(&mut reader).unwrap();
             assert_eq!(want_data_share_packet, &data_share_packet);
         }
@@ -1342,15 +1345,15 @@ mod tests {
     fn roundtrip_data_share_packet() {
         let mut record_vec = Vec::new();
 
-        let schema = IngestionDataSharePacket::schema();
-        let mut writer = Writer::new(&schema, &mut record_vec);
+        let mut writer = Writer::new(IngestionDataSharePacket::schema(), &mut record_vec);
 
         for (packet, _) in &*GOLDEN_INGESTION_DATA_SHARE_PACKETS {
             packet.write(&mut writer).expect("write error");
         }
         writer.flush().unwrap();
 
-        let mut reader = Reader::with_schema(&schema, &record_vec[..]).unwrap();
+        let mut reader =
+            Reader::with_schema(IngestionDataSharePacket::schema(), &record_vec[..]).unwrap();
         for (packet, _) in &*GOLDEN_INGESTION_DATA_SHARE_PACKETS {
             let packet_again = IngestionDataSharePacket::read(&mut reader).expect("read error");
             assert_eq!(packet_again, *packet);
@@ -1450,9 +1453,10 @@ mod tests {
 
     #[test]
     fn read_validation_packet() {
-        let schema = ValidationPacket::schema();
         for (want_validation_packet, validation_packet_bytes) in &*GOLDEN_VALIDATION_PACKETS {
-            let mut reader = Reader::with_schema(&schema, &validation_packet_bytes[..]).unwrap();
+            let mut reader =
+                Reader::with_schema(ValidationPacket::schema(), &validation_packet_bytes[..])
+                    .unwrap();
             let data_share_packet = ValidationPacket::read(&mut reader).unwrap();
             assert_eq!(want_validation_packet, &data_share_packet);
         }
@@ -1462,15 +1466,14 @@ mod tests {
     fn roundtrip_validation_packet() {
         let mut record_vec = Vec::new();
 
-        let schema = ValidationPacket::schema();
-        let mut writer = Writer::new(&schema, &mut record_vec);
+        let mut writer = Writer::new(ValidationPacket::schema(), &mut record_vec);
 
         for (packet, _) in &*GOLDEN_VALIDATION_PACKETS {
             packet.write(&mut writer).expect("write error");
         }
         writer.flush().unwrap();
 
-        let mut reader = Reader::with_schema(&schema, &record_vec[..]).unwrap();
+        let mut reader = Reader::with_schema(ValidationPacket::schema(), &record_vec[..]).unwrap();
         for (packet, _) in &*GOLDEN_VALIDATION_PACKETS {
             let packet_again = ValidationPacket::read(&mut reader).expect("read error");
             assert_eq!(packet_again, *packet);
@@ -1569,9 +1572,9 @@ mod tests {
 
     #[test]
     fn read_invalid_packet() {
-        let schema = InvalidPacket::schema();
         for (want_invalid_packet, invalid_packet_bytes) in &*GOLDEN_INVALID_PACKETS {
-            let mut reader = Reader::with_schema(&schema, &invalid_packet_bytes[..]).unwrap();
+            let mut reader =
+                Reader::with_schema(InvalidPacket::schema(), &invalid_packet_bytes[..]).unwrap();
             let invalid_packet = InvalidPacket::read(&mut reader).unwrap();
             assert_eq!(want_invalid_packet, &invalid_packet);
         }
@@ -1581,15 +1584,14 @@ mod tests {
     fn roundtrip_invalid_packet() {
         let mut record_vec = Vec::new();
 
-        let schema = InvalidPacket::schema();
-        let mut writer = Writer::new(&schema, &mut record_vec);
+        let mut writer = Writer::new(InvalidPacket::schema(), &mut record_vec);
 
         for (packet, _) in &*GOLDEN_INVALID_PACKETS {
             packet.write(&mut writer).expect("write error");
         }
         writer.flush().unwrap();
 
-        let mut reader = Reader::with_schema(&schema, &record_vec[..]).unwrap();
+        let mut reader = Reader::with_schema(InvalidPacket::schema(), &record_vec[..]).unwrap();
         for (packet, _) in &*GOLDEN_INVALID_PACKETS {
             let packet_again = InvalidPacket::read(&mut reader).expect("read error");
             assert_eq!(packet_again, *packet);

--- a/facilitator/src/idl.rs
+++ b/facilitator/src/idl.rs
@@ -102,7 +102,7 @@ impl BatchSignature {
     /// Reads and parses one BatchSignature from the provided std::io::Read
     /// instance.
     pub fn read<R: Read>(reader: R) -> Result<BatchSignature, Error> {
-        let mut reader = Reader::with_schema(&*BATCH_SIGNATURE_SCHEMA, reader)
+        let mut reader = Reader::with_schema(*BATCH_SIGNATURE_SCHEMA, reader)
             .map_err(|e| Error::AvroError("failed to create Avro reader".to_owned(), e))?;
 
         // We expect exactly one record and for it to be an ingestion signature
@@ -128,7 +128,7 @@ impl BatchSignature {
     /// Serializes this signature into Avro format and writes it to the provided
     /// std::io::Write instance.
     pub fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        let mut writer = Writer::new(&*BATCH_SIGNATURE_SCHEMA, writer);
+        let mut writer = Writer::new(*BATCH_SIGNATURE_SCHEMA, writer);
         writer.append(Value::from(self)).map_err(|e| {
             Error::AvroError("failed to append record to Avro writer".to_owned(), e)
         })?;
@@ -186,7 +186,7 @@ impl From<&BatchSignature> for Value {
         // a `Schema::Record` variant", which shouldn't ever happen, so
         // panic for debugging
         // https://docs.rs/avro-rs/0.11.0/avro_rs/types/struct.Record.html#method.new
-        let mut record = Record::new(&*BATCH_SIGNATURE_SCHEMA)
+        let mut record = Record::new(*BATCH_SIGNATURE_SCHEMA)
             .expect("Unable to create record from ingestion signature schema");
         record.put(
             "batch_header_signature",
@@ -231,7 +231,7 @@ impl Header for IngestionHeader {
     }
 
     fn read<R: Read>(reader: R) -> Result<IngestionHeader, Error> {
-        let mut reader = Reader::with_schema(&*INGESTION_HEADER_SCHEMA, reader).map_err(|e| {
+        let mut reader = Reader::with_schema(*INGESTION_HEADER_SCHEMA, reader).map_err(|e| {
             Error::AvroError("failed to create reader for ingestion header".to_owned(), e)
         })?;
 
@@ -334,7 +334,7 @@ impl Header for IngestionHeader {
     }
 
     fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        let mut writer = Writer::new(&*INGESTION_HEADER_SCHEMA, writer);
+        let mut writer = Writer::new(*INGESTION_HEADER_SCHEMA, writer);
 
         // Ideally we would just do `writer.append_ser(self)` to use Serde serialization to write
         // the record but there seems to be some problem with serializing UUIDs, so we have to
@@ -399,7 +399,7 @@ pub struct IngestionDataSharePacket {
 
 impl Packet for IngestionDataSharePacket {
     fn schema() -> &'static Schema {
-        &*INGESTION_DATA_SHARE_PACKET_SCHEMA
+        *INGESTION_DATA_SHARE_PACKET_SCHEMA
     }
 
     fn read<R: Read>(reader: &mut Reader<R>) -> Result<IngestionDataSharePacket, Error> {
@@ -606,7 +606,7 @@ impl Header for ValidationHeader {
     }
 
     fn read<R: Read>(reader: R) -> Result<ValidationHeader, Error> {
-        let mut reader = Reader::with_schema(&*VALIDATION_HEADER_SCHEMA, reader).map_err(|e| {
+        let mut reader = Reader::with_schema(*VALIDATION_HEADER_SCHEMA, reader).map_err(|e| {
             Error::AvroError(
                 "failed to create reader for validation header".to_owned(),
                 e,
@@ -704,7 +704,7 @@ impl Header for ValidationHeader {
     }
 
     fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        let mut writer = Writer::new(&*VALIDATION_HEADER_SCHEMA, writer);
+        let mut writer = Writer::new(*VALIDATION_HEADER_SCHEMA, writer);
 
         let mut record = match Record::new(writer.schema()) {
             Some(r) => r,
@@ -752,7 +752,7 @@ pub struct ValidationPacket {
 
 impl Packet for ValidationPacket {
     fn schema() -> &'static Schema {
-        &*VALIDATION_PACKET_SCHEMA
+        *VALIDATION_PACKET_SCHEMA
     }
 
     fn read<R: Read>(reader: &mut Reader<R>) -> Result<ValidationPacket, Error> {
@@ -841,7 +841,7 @@ impl Header for SumPart {
     }
 
     fn read<R: Read>(reader: R) -> Result<SumPart, Error> {
-        let mut reader = Reader::with_schema(&*SUM_PART_SCHEMA, reader)
+        let mut reader = Reader::with_schema(*SUM_PART_SCHEMA, reader)
             .map_err(|e| Error::AvroError("failed to create reader for sum part".to_owned(), e))?;
 
         // We expect exactly one record in the reader and for it to be a sum
@@ -983,7 +983,7 @@ impl Header for SumPart {
     }
 
     fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        let mut writer = Writer::new(&*SUM_PART_SCHEMA, writer);
+        let mut writer = Writer::new(*SUM_PART_SCHEMA, writer);
 
         // Ideally we would just do `writer.append_ser(self)` to use Serde serialization to write
         // the record but there seems to be some problem with serializing UUIDs, so we have to
@@ -1051,7 +1051,7 @@ pub struct InvalidPacket {
 
 impl Packet for InvalidPacket {
     fn schema() -> &'static Schema {
-        &*INVALID_PACKET_SCHEMA
+        *INVALID_PACKET_SCHEMA
     }
 
     fn read<R: Read>(reader: &mut Reader<R>) -> Result<InvalidPacket, Error> {
@@ -1104,7 +1104,7 @@ pub struct ValidationBatch {
 impl ValidationBatch {
     /// Reads and parses one Header from the provided std::io::Read instance.
     pub fn read<R: Read>(reader: R) -> Result<Self, Error> {
-        let mut reader = Reader::with_schema(&*VALIDATION_BATCH_SCHEMA, reader)
+        let mut reader = Reader::with_schema(*VALIDATION_BATCH_SCHEMA, reader)
             .map_err(|e| Error::AvroError("failed to create Avro reader".to_owned(), e))?;
         // We expect exactly one record and for it to be an ingestion signature
         let value = match reader.next() {
@@ -1129,7 +1129,7 @@ impl ValidationBatch {
     /// Serializes this message into Avro format and writes it to the provided
     /// std::io::Write instance.
     pub fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
-        let mut writer = Writer::new(&*VALIDATION_BATCH_SCHEMA, writer);
+        let mut writer = Writer::new(*VALIDATION_BATCH_SCHEMA, writer);
         writer.append(Value::from(self)).map_err(|e| {
             Error::AvroError("failed to append record to Avro writer".to_owned(), e)
         })?;
@@ -1178,7 +1178,7 @@ impl TryFrom<Value> for ValidationBatch {
 
 impl From<&ValidationBatch> for Value {
     fn from(batch: &ValidationBatch) -> Self {
-        let mut record = Record::new(&*VALIDATION_BATCH_SCHEMA)
+        let mut record = Record::new(*VALIDATION_BATCH_SCHEMA)
             .expect("Unable to create record from validation batch schema");
         record.put("sig", Value::from(&batch.sig));
         record.put("header", Value::Bytes(batch.header.clone()));

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -33,6 +33,8 @@ pub enum Error {
     MalformedHeaderError(String),
     #[error("malformed data packet: {0}")]
     MalformedDataPacketError(String),
+    #[error("malformed batch: {0}")]
+    MalformedBatchError(String),
     #[error("end of file")]
     EofError,
     #[error("HTTP resource error")]


### PR DESCRIPTION
`PrioValidityBatch` is comprised of a `PrioBatchSignature`, a `PrioValidityHeader`, and a sequence of `PrioValidityPacket`s (i.e. the three messages comprising a validation batch). The latter two messages are included as serialized bytes to allow signature verification, and then hash integrity checking, to be done over the same bytes that the signature/hash was generated against.

I also added some read tests that attempt to read "golden" serialized data and match it against what we expect it to deserialize to; this is to protect against the possibility of accidentally-backwards-incompatible changes (i.e. protecting against a change that still allows roundtripping through serialization/deserialization, but does not allow deserialization of data serialized with a previous version of the code). The golden serialized data was generated from the code as it stood before I started making the changes in this PR.