### PR TITLE
prod-us: deploy key-rotator to `ta-ta` (integration test) environment.

### DIFF
--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -161,13 +161,16 @@ is_first                                  = false
 use_aws                                   = false
 default_aggregation_period                = "8h"
 default_aggregation_grace_period          = "4h"
-workflow_manager_version                  = "0.6.18"
-facilitator_version                       = "0.6.18"
+workflow_manager_version                  = "0.6.19"
+facilitator_version                       = "0.6.19"
+key_rotator_version                       = "0.6.19"
 prometheus_server_persistent_disk_size_gb = 1000
 victorops_routing_key                     = "prio-prod-us"
 
 default_peer_share_processor_manifest_base_url = "en-analytics.cancer.gov"
 default_portal_server_manifest_base_url        = "manifest.enpa-pha.io"
+
+enable_key_rotation_localities = ["ta-ta"]
 
 prometheus_helm_chart_version           = "11.12.1"
 grafana_helm_chart_version              = "6.1.16"

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -161,9 +161,9 @@ is_first                                  = false
 use_aws                                   = false
 default_aggregation_period                = "8h"
 default_aggregation_grace_period          = "4h"
-workflow_manager_version                  = "0.6.19"
-facilitator_version                       = "0.6.19"
-key_rotator_version                       = "0.6.19"
+workflow_manager_version                  = "0.6.20"
+facilitator_version                       = "0.6.20"
+key_rotator_version                       = "0.6.20"
 prometheus_server_persistent_disk_size_gb = 1000
 victorops_routing_key                     = "prio-prod-us"
 

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -70,9 +70,9 @@ test_peer_environment = {
 }
 is_first                 = false
 use_aws                  = false
-workflow_manager_version = "0.6.19"
-facilitator_version      = "0.6.19"
-key_rotator_version      = "0.6.19"
+workflow_manager_version = "0.6.20"
+facilitator_version      = "0.6.20"
+key_rotator_version      = "0.6.20"
 victorops_routing_key    = "prio-staging"
 
 intake_max_age             = "75m"


### PR DESCRIPTION
This will trigger a Packet Encryption Key rotation with the next daily run of the Key Rotator.

The diff looks acceptable (though it's so long it managed to fill the scrollback buffer, but all the localities are roughly the same). If https://github.com/abetterinternet/prio-server/pull/1201 makes it in quickly, I'll update this PR to include it.