### PR TITLE
Key rotator: allow automatic turnup of new localities.

### DIFF
--- a/key-rotator/main.go
+++ b/key-rotator/main.go
@@ -40,14 +40,14 @@ var (
 	csrFQDN           = flag.String("csr-fqdn", "", "Required. FQDN to use as common name in generated CSRs")
 
 	// Rotation configuration.
-	batchSigningKeyEnableRotation = flag.Bool("batch-signing-key-enable-rotation", true, "Determines if batch signing keys are rotated")
+	batchSigningKeyEnableRotation = flag.Bool("batch-signing-key-enable-rotation", true, "Determines if batch signing keys are rotated. If no key versions exist, a new one will be created irrespective of this flag's value")
 	batchSigningKeyCreateMinAge   = flag.Duration("batch-signing-key-create-min-age", 9*30*24*time.Hour, "How frequently to create a new batch signing key version")               // default: 9 months
 	batchSigningKeyPrimaryMinAge  = flag.Duration("batch-signing-key-primary-min-age", 7*24*time.Hour, "How old a batch signing key version must be before it can become primary") // default: 1 week
 	batchSigningKeyDeleteMinAge   = flag.Duration("batch-signing-key-delete-min-age", 13*30*24*time.Hour, "How old a batch signing key version must be before it can be deleted")  // default: 13 months
 	batchSigningKeyDeleteMinCount = flag.Int("batch-signing-key-delete-min-count", 2, "The minimum number of batch signing key versions left undeleted after rotation")
 	batchSigningKeyAlwaysWrite    = flag.Bool("batch-signing-key-always-write", false, "If set, always write batch signing key to backing storage, even if no changes are detected")
 
-	packetEncryptionKeyEnableRotation = flag.Bool("packet-encryption-key-enable-rotation", true, "Determines if packet encryption keys are rotated")
+	packetEncryptionKeyEnableRotation = flag.Bool("packet-encryption-key-enable-rotation", true, "Determines if packet encryption keys are rotated. If no key versions exist, a new one will be created irrespective of this flag's value")
 	packetEncryptionKeyCreateMinAge   = flag.Duration("packet-encryption-key-create-min-age", 9*30*24*time.Hour, "How frequently to create a new packet encryption key version")              // default: 9 months
 	packetEncryptionKeyPrimaryMinAge  = flag.Duration("packet-encryption-key-primary-min-age", 0, "How old a packet encryption key version must be before it can become primary")             // default: 0
 	packetEncryptionKeyDeleteMinAge   = flag.Duration("packet-encryption-key-delete-min-age", 13*30*24*time.Hour, "How old a packet encryption key version must be before it can be deleted") // default: 13 months
@@ -301,7 +301,7 @@ func rotateKeys(ctx context.Context, cfg rotateKeysConfig) error {
 	// Rotate keys.
 	log.Info().Msgf("Rotating keys & updating manifests")
 	var newPacketEncryptionKey key.Key
-	if cfg.packetCFG.enableRotation {
+	if oldPacketEncryptionKey.IsEmpty() || cfg.packetCFG.enableRotation {
 		k, err := oldPacketEncryptionKey.Rotate(cfg.now, cfg.packetCFG.rotationCFG)
 		if err != nil {
 			return fmt.Errorf("couldn't rotate packet encryption key for %q: %w", cfg.locality, err)
@@ -314,7 +314,7 @@ func rotateKeys(ctx context.Context, cfg rotateKeysConfig) error {
 
 	newBatchSigningKeyByIngestor := map[string]key.Key{}
 	for ingestor, oldKey := range oldBatchSigningKeyByIngestor {
-		if cfg.batchCFG.enableRotation {
+		if oldKey.IsEmpty() || cfg.batchCFG.enableRotation {
 			newKey, err := oldKey.Rotate(cfg.now, cfg.batchCFG.rotationCFG)
 			if err != nil {
 				return fmt.Errorf("couldn't rotate batch signing key for (%q, %q): %w",

--- a/key-rotator/storage/manifest_test.go
+++ b/key-rotator/storage/manifest_test.go
@@ -92,7 +92,9 @@ func TestManifest(t *testing.T) {
 				t.Run("valid manifest (default specified)", func(t *testing.T) {
 					t.Parallel()
 					m, kvs := newKVStoreManifest(test.keyPrefix)
-					m.defaultDSPManifest = &manifest.DataShareProcessorSpecificManifest{Format: 13}
+					m.defaultManifestByDSP = map[string]manifest.DataShareProcessorSpecificManifest{
+						dspName: {Format: 13},
+					}
 					kvs[path.Join(test.keyPrefix, "dsp-manifest.json")] = dspManifestBytes
 					gotManifest, err := m.GetDataShareProcessorSpecificManifest(ctx, dspName)
 					if err != nil {
@@ -115,7 +117,9 @@ func TestManifest(t *testing.T) {
 					t.Parallel()
 					m, _ := newKVStoreManifest(test.keyPrefix)
 					wantManifest := manifest.DataShareProcessorSpecificManifest{Format: 13}
-					m.defaultDSPManifest = &wantManifest
+					m.defaultManifestByDSP = map[string]manifest.DataShareProcessorSpecificManifest{
+						dspName: wantManifest,
+					}
 					gotManifest, err := m.GetDataShareProcessorSpecificManifest(ctx, dspName)
 					if err != nil {
 						t.Fatalf("Unexpected error from GetDataShareProcessorSpecificManifest: %v", err)

--- a/key-rotator/storage/manifest_test.go
+++ b/key-rotator/storage/manifest_test.go
@@ -89,11 +89,39 @@ func TestManifest(t *testing.T) {
 					}
 				})
 
+				t.Run("valid manifest (default specified)", func(t *testing.T) {
+					t.Parallel()
+					m, kvs := newKVStoreManifest(test.keyPrefix)
+					m.defaultDSPManifest = &manifest.DataShareProcessorSpecificManifest{Format: 13}
+					kvs[path.Join(test.keyPrefix, "dsp-manifest.json")] = dspManifestBytes
+					gotManifest, err := m.GetDataShareProcessorSpecificManifest(ctx, dspName)
+					if err != nil {
+						t.Fatalf("Unexpected error from GetDataShareProcessorSpecificManifest: %v", err)
+					}
+					if diff := cmp.Diff(dspManifest, gotManifest); diff != "" {
+						t.Errorf("Unexpected manifest (-want +got):\n%s", diff)
+					}
+				})
+
 				t.Run("no manifest", func(t *testing.T) {
 					t.Parallel()
 					m, _ := newKVStoreManifest(test.keyPrefix)
 					if _, err := m.GetDataShareProcessorSpecificManifest(ctx, dspName); !errors.Is(err, ErrObjectNotExist) {
 						t.Errorf("Unexpected error from GetDataShareProcessorSpecificManifest: %v", err)
+					}
+				})
+
+				t.Run("no manifest (default specified)", func(t *testing.T) {
+					t.Parallel()
+					m, _ := newKVStoreManifest(test.keyPrefix)
+					wantManifest := manifest.DataShareProcessorSpecificManifest{Format: 13}
+					m.defaultDSPManifest = &wantManifest
+					gotManifest, err := m.GetDataShareProcessorSpecificManifest(ctx, dspName)
+					if err != nil {
+						t.Fatalf("Unexpected error from GetDataShareProcessorSpecificManifest: %v", err)
+					}
+					if diff := cmp.Diff(wantManifest, gotManifest); diff != "" {
+						t.Errorf("Unexpected manifest (-want +got):\n%s", diff)
 					}
 				})
 
@@ -152,7 +180,10 @@ func TestManifest(t *testing.T) {
 // map, and modifications to the map will be reflected by the manifest.
 func newKVStoreManifest(keyPrefix string) (_ kvStoreManifest, kvs map[string][]byte) {
 	kvs = map[string][]byte{}
-	return kvStoreManifest{memKV{kvs}, keyPrefix}, kvs
+	return kvStoreManifest{
+		kv:        memKV{kvs},
+		keyPrefix: keyPrefix,
+	}, kvs
 }
 
 // memKV is an in-memory implementation of kvStore, suitable for testing.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -596,6 +596,7 @@ module "kubernetes_locality" {
   packet_encryption_key_rotation_policy = var.packet_encryption_key_rotation_policy
   enable_key_rotator_localities         = toset(var.enable_key_rotation_localities)
   key_rotator_schedule                  = var.key_rotator_schedule
+  specific_manifest_templates           = { for v in module.data_share_processors : v.data_share_processor_name => v.specific_manifest }
 }
 
 module "data_share_processors" {


### PR DESCRIPTION
This change allows the `key-rotator` to automatically handle provisioning new keys, without the need for an operator to manually run `deploy-tool`. Once this is deployed to production, I think we can delete `deploy-tool` entirely.

The main change in this PR is to wire the `key-rotator` to have "manifest templates" so that it knows all the right non-key data to include in a new manifest, and update the logic to use the templates if no manifest has been written to the appropriate cloud storage bucket.

I also had to make a small change to key-rotation: we decided to disable rotation of the BSK, but we still need to "rotate" the initial empty key to provision a first version for new localities. I think this is small enough to sneak into this PR.

Other than unit tests, I deployed a new locality to my dev environment and observed that the key-rotator generated keys/manifests appropriately. As of writing I am still waiting for data to flow all the way through the system, but I think this is ready for review.

See individual commit messages for further details.