### PR TITLE
During aggregation, skip batches with undecryptable data share packets.

### DIFF
--- a/facilitator/src/idl.rs
+++ b/facilitator/src/idl.rs
@@ -1,5 +1,5 @@
 use crate::Error;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use avro_rs::{
     from_value,
     types::{Record, Value},
@@ -569,7 +569,9 @@ impl IngestionDataSharePacket {
                 h_r: u32::from(validation_message.h_r) as i64,
             });
         }
-        return Err(anyhow!("failed to construct validation message for packet {} because all decryption attempts failed (key mismatch?)", self.uuid));
+        // If we arrive here, this packet could not be decrypted by any key we have.
+        // All we can do is report this to the caller.
+        Err(Error::PacketDecryptionError(self.uuid).into())
     }
 }
 

--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -461,9 +461,10 @@ mod tests {
         .unwrap();
 
         let err = pha_ingestor.generate_validation_share(|_| {}).unwrap_err();
-        assert!(err
-            .to_string()
-            .contains("failed to construct validation message for packet",));
+        assert_matches!(
+            err.downcast_ref::<Error>(),
+            Some(Error::PacketDecryptionError(_))
+        );
     }
 
     #[test]

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use ring::{digest, signature::EcdsaKeyPair};
 use std::io::Write;
+use uuid::Uuid;
 
 pub mod aggregation;
 pub mod aws_credentials;
@@ -39,6 +40,8 @@ pub enum Error {
     EofError,
     #[error("HTTP resource error")]
     HttpError(#[from] ureq::Error),
+    #[error("packet decryption failure for packet {0}")]
+    PacketDecryptionError(Uuid),
 }
 
 /// A wrapper-writer that computes a SHA256 digest over the content it is provided.


### PR DESCRIPTION
Previously, if we received an undecryptable packet, we would fail out
the entire aggregation. Now, we silently skip ingestion batches that
contain undecryptable packets; our peer will also skip such ingestion
batches because we won't have generated a peer validation batch.

This avoids the unfortunate scenario of a single bad client packet
causing an entire aggregation batch to be dropped; instead, effectively
only the ingestion batch is dropped. This restores the behavior from
before we stopped writing own-validation batches.