### PR TITLE
Workflow manager: consider batch complete if signature exists.

### DIFF
--- a/workflow-manager/batchpath/batchpath.go
+++ b/workflow-manager/batchpath/batchpath.go
@@ -20,9 +20,8 @@ type BatchPath struct {
 	dateComponents []string
 	ID             string
 	Time           time.Time
-	metadata       bool
-	avro           bool
-	sig            bool
+
+	sigExists bool
 }
 
 // List is a type alias for a slice of BatchPath pointers
@@ -110,7 +109,7 @@ func New(batchName string) (*BatchPath, error) {
 }
 
 func (b *BatchPath) String() string {
-	return fmt.Sprintf("{%s %s %s files:%d%d%d}", b.AggregationID, b.dateComponents, b.ID, utils.Index(!b.metadata), utils.Index(!b.avro), utils.Index(!b.sig))
+	return fmt.Sprintf("{%s %s %s files:%d}", b.AggregationID, b.dateComponents, b.ID, utils.Index(!b.sigExists))
 }
 
 func (b *BatchPath) path() string {
@@ -122,10 +121,10 @@ func (b *BatchPath) DateString() string {
 	return strings.Join(b.dateComponents, "/")
 }
 
-// isComplete returns true if all three files in the batch are present (header,
+// isComplete returns true if the batch exists (header,
 // signature and packet file), and false otherwise.
 func (b *BatchPath) isComplete() bool {
-	return b.metadata && b.avro && b.sig
+	return b.sigExists
 }
 
 type ReadyBatchesResult struct {
@@ -154,14 +153,8 @@ func ReadyBatches(files []string, infix string) (*ReadyBatchesResult, error) {
 			}
 			batches[basename] = b
 		}
-		if strings.HasSuffix(name, fmt.Sprintf(".%s", infix)) {
-			b.metadata = true
-		}
-		if strings.HasSuffix(name, fmt.Sprintf(".%s.avro", infix)) {
-			b.avro = true
-		}
 		if strings.HasSuffix(name, fmt.Sprintf(".%s.sig", infix)) {
-			b.sig = true
+			b.sigExists = true
 		}
 	}
 

--- a/workflow-manager/main.go
+++ b/workflow-manager/main.go
@@ -382,7 +382,7 @@ func scheduleTasks(config scheduleTasksConfig) error {
 		return err
 	}
 
-	intakeBatches, err := batchpath.ReadyBatches(intakeFiles, "batch")
+	intakeBatches, err := batchpath.ReadyBatches(intakeFiles, "batch", false /* acceptSignatureOnly */)
 	if err != nil {
 		return err
 	}
@@ -425,7 +425,7 @@ func scheduleTasks(config scheduleTasksConfig) error {
 		return fmt.Errorf("couldn't list intake batches for aggregation task generation: %w", err)
 	}
 
-	intakeBatches, err = batchpath.ReadyBatches(intakeFiles, "batch")
+	intakeBatches, err = batchpath.ReadyBatches(intakeFiles, "batch", false /* acceptSignatureOnly */)
 	if err != nil {
 		return fmt.Errorf("couldn't determine ready intake batches for aggregation task generation: %w", err)
 	}
@@ -443,7 +443,7 @@ func scheduleTasks(config scheduleTasksConfig) error {
 	}
 
 	peerValidityInfix := fmt.Sprintf("validity_%d", utils.Index(!config.isFirst))
-	peerValidationBatches, err := batchpath.ReadyBatches(peerValidationFiles, peerValidityInfix)
+	peerValidationBatches, err := batchpath.ReadyBatches(peerValidationFiles, peerValidityInfix, true /* acceptSignatureOnly */)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I think this is safe for both new-style (single-object) & old-style
(multi-object) batches. Single-object batches are safe because they
really are just a single object, so checking for that one object is the
correct thing to do. Multi-object batches are safe because the signature
object was always written last (& only if writing the header & packet
objects succeeded), and both AWS & GCP offer strong read-after-write &
list consistency [1][2], so if the signature object was written we know
the batch & packet objects will also be written.

[1] https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html#ConsistencyModel
[2] https://cloud.google.com/storage/docs/consistency