### PR TITLE
Terraform: config to allow single-object validation batches to be used.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -267,6 +267,16 @@ variable "stackdriver_exporter_helm_chart_version" {
   default = ""
 }
 
+variable "single_object_validation_batch_localities" {
+  type        = list(string)
+  default     = []
+  description = <<DESCRIPTION
+A set of localities where single-object validation batches are generated.
+(Other localities use the "old" three-object format.) The special value "*"
+indicates that all localities should generate single-object validation batches.
+DESCRIPTION
+}
+
 terraform {
   backend "gcs" {}
 
@@ -618,6 +628,7 @@ module "data_share_processors" {
   max_aggregate_worker_count                     = each.value.max_aggregate_worker_count
   eks_oidc_provider                              = var.use_aws ? module.eks[0].oidc_provider : { url = "", arn = "" }
   gcp_workload_identity_pool_provider            = local.gcp_workload_identity_pool_provider
+  single_object_validation_batch_localities      = toset(var.single_object_validation_batch_localities)
 }
 
 # The portal owns two sum part buckets (one for each data share processor) and

--- a/terraform/modules/data_share_processor/data_share_processor.tf
+++ b/terraform/modules/data_share_processor/data_share_processor.tf
@@ -133,6 +133,15 @@ variable "gcp_workload_identity_pool_provider" {
   type = string
 }
 
+variable "single_object_validation_batch_localities" {
+  type        = set(string)
+  description = <<DESCRIPTION
+A set of localities where single-object validation batches are generated.
+(Other localities use the "old" three-object format.) The special value "*"
+indicates that all localities should generate single-object validation batches.
+DESCRIPTION
+}
+
 # We need the ingestion server's manifest so that we can discover the GCP
 # service account it will use to upload ingestion batches. Some ingestors
 # (Apple) are singletons, and advertise a single global manifest which contains
@@ -374,40 +383,41 @@ module "sns_sqs" {
 }
 
 module "kubernetes" {
-  source                                  = "../../modules/kubernetes/"
-  data_share_processor_name               = var.data_share_processor_name
-  ingestor                                = var.ingestor
-  environment                             = var.environment
-  kubernetes_namespace                    = var.kubernetes_namespace
-  ingestion_bucket                        = local.ingestion_bucket_url
-  ingestor_manifest_base_url              = var.ingestor_manifest_base_url
-  packet_decryption_key_kubernetes_secret = var.packet_decryption_key_kubernetes_secret
-  peer_manifest_base_url                  = var.peer_share_processor_manifest_base_url
-  remote_peer_validation_bucket_identity  = local.remote_validation_bucket_writer
-  peer_validation_bucket                  = local.peer_validation_bucket_url
-  own_validation_bucket                   = local.own_validation_bucket_url
-  sum_part_bucket_service_account_email   = var.remote_bucket_writer_gcp_service_account_email
-  portal_server_manifest_base_url         = var.portal_server_manifest_base_url
-  is_first                                = var.is_first
-  intake_max_age                          = var.intake_max_age
-  aggregation_period                      = var.aggregation_period
-  aggregation_grace_period                = var.aggregation_grace_period
-  pushgateway                             = var.pushgateway
-  container_registry                      = var.container_registry
-  workflow_manager_image                  = var.workflow_manager_image
-  workflow_manager_version                = var.workflow_manager_version
-  facilitator_image                       = var.facilitator_image
-  facilitator_version                     = var.facilitator_version
-  intake_queue                            = local.intake_queue
-  aggregate_queue                         = local.aggregate_queue
-  min_intake_worker_count                 = var.min_intake_worker_count
-  max_intake_worker_count                 = var.max_intake_worker_count
-  min_aggregate_worker_count              = var.min_aggregate_worker_count
-  max_aggregate_worker_count              = var.max_aggregate_worker_count
-  use_aws                                 = var.use_aws
-  eks_oidc_provider                       = var.eks_oidc_provider
-  aws_region                              = var.aws_region
-  gcp_workload_identity_pool_provider     = var.gcp_workload_identity_pool_provider
+  source                                    = "../../modules/kubernetes/"
+  data_share_processor_name                 = var.data_share_processor_name
+  ingestor                                  = var.ingestor
+  environment                               = var.environment
+  kubernetes_namespace                      = var.kubernetes_namespace
+  ingestion_bucket                          = local.ingestion_bucket_url
+  ingestor_manifest_base_url                = var.ingestor_manifest_base_url
+  packet_decryption_key_kubernetes_secret   = var.packet_decryption_key_kubernetes_secret
+  peer_manifest_base_url                    = var.peer_share_processor_manifest_base_url
+  remote_peer_validation_bucket_identity    = local.remote_validation_bucket_writer
+  peer_validation_bucket                    = local.peer_validation_bucket_url
+  own_validation_bucket                     = local.own_validation_bucket_url
+  sum_part_bucket_service_account_email     = var.remote_bucket_writer_gcp_service_account_email
+  portal_server_manifest_base_url           = var.portal_server_manifest_base_url
+  is_first                                  = var.is_first
+  intake_max_age                            = var.intake_max_age
+  aggregation_period                        = var.aggregation_period
+  aggregation_grace_period                  = var.aggregation_grace_period
+  pushgateway                               = var.pushgateway
+  container_registry                        = var.container_registry
+  workflow_manager_image                    = var.workflow_manager_image
+  workflow_manager_version                  = var.workflow_manager_version
+  facilitator_image                         = var.facilitator_image
+  facilitator_version                       = var.facilitator_version
+  intake_queue                              = local.intake_queue
+  aggregate_queue                           = local.aggregate_queue
+  min_intake_worker_count                   = var.min_intake_worker_count
+  max_intake_worker_count                   = var.max_intake_worker_count
+  min_aggregate_worker_count                = var.min_aggregate_worker_count
+  max_aggregate_worker_count                = var.max_aggregate_worker_count
+  use_aws                                   = var.use_aws
+  eks_oidc_provider                         = var.eks_oidc_provider
+  aws_region                                = var.aws_region
+  gcp_workload_identity_pool_provider       = var.gcp_workload_identity_pool_provider
+  single_object_validation_batch_localities = var.single_object_validation_batch_localities
 }
 
 output "data_share_processor_name" {

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -162,6 +162,15 @@ variable "gcp_workload_identity_pool_provider" {
   type = string
 }
 
+variable "single_object_validation_batch_localities" {
+  type        = set(string)
+  description = <<DESCRIPTION
+A set of localities where single-object validation batches are generated.
+(Other localities use the "old" three-object format.) The special value "*"
+indicates that all localities should generate single-object validation batches.
+DESCRIPTION
+}
+
 # We repeat this declaration from main.tf to work around an issue where
 # Terraform will look for hashicorp/kubectl instead of gavinbunney/kubectl
 # https://github.com/gavinbunney/terraform-provider-kubectl/issues/39
@@ -369,7 +378,8 @@ resource "kubernetes_deployment" "intake_batch" {
             "--aws-sqs-region=${var.use_aws ? var.aws_region : ""}",
             "--gcp-project-id=${var.use_aws ? "" : data.google_project.project.project_id}",
             "--gcp-workload-identity-pool-provider=${var.gcp_workload_identity_pool_provider}",
-            "--worker-maximum-lifetime=3600"
+            "--worker-maximum-lifetime=3600",
+            "--write-single-object-validation-batches=${contains(var.single_object_validation_batch_localities, "*") || contains(var.single_object_validation_batch_localities, var.kubernetes_namespace)}"
           ]
           # Prometheus metrics scrape endpoint
           port {


### PR DESCRIPTION
Defaults to disabled (as needed currently, until all production
deployments are released to a recent-enough version to be able to parse
single-object validation batches).