### PR TITLE
terraform: speed up prep targets in Makefile

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -31,7 +31,7 @@ help:
 
 .PHONY: prep
 prep: ## Prepare a new workspace (environment) if needed, configure the tfstate backend, update any modules, and switch to the workspace
-	@rm -rf .terraform/
+	@rm .terraform/terraform.tfstate
 	@if [ ! -f "$(VARS)" ]; then \
 		echo "$(BOLD)$(RED)Could not find variables file: $(VARS)$(RESET)"; \
 		exit 1; \
@@ -174,7 +174,7 @@ destroy-target: prep ## Destroy a specific resource. Caution though, this destro
 
 .PHONY: prep-cluster-bootstrap
 prep-cluster-bootstrap: ## Prepare a new workspace (environment) if needed, configure the tfstate backend, update any modules, and switch to the workspace
-	@rm -rf cluster_bootstrap/.terraform/
+	@rm cluster_bootstrap/.terraform/terraform.tfstate
 	@if [ ! -f "$(VARS)" ]; then \
 		echo "$(BOLD)$(RED)Could not find variables file: $(VARS)$(RESET)"; \
 		exit 1; \


### PR DESCRIPTION
Historically, we blow away `.terraform` (or
`cluster_bootstrap/.terraform`, depending on which `prep` target is
invoked) before initializing `terraform`. The idea is to avoid the risk
of one environment's `.tfstate` bleeding into another, which `terraform
init` can sometimes sneakily do to you.

While working on #1274, I found myself switching between remote and
local Terraform backends a lot. My implementation plans had a lot of `rm
-rf .terraform` in them, in accordance with the `prep` and
`prep-cluster-bootstrap` targets in `terraform/Makefile`. The downside
of destroying the entire directory is that you have to reinstall the
Terraform providers every time you `plan` or `apply`. I learned that
what's really important is the file `.terraform/terraform.tfstate`, and
that if we destroy just that file in the `prep` targets, we avoid the
risk of cross-contamination of backends but can speed up `prep`
considerably by not re-downloading providers.