### PR TITLE
Generate sample data deterministically from packet UUID.

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -202,6 +202,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1489fcb93a5bb47da0462ca93ad252ad6af2145cce58d10d46a83931ba9f016b"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "blake3"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +635,7 @@ dependencies = [
  "avro-rs",
  "backoff",
  "base64 0.13.0",
+ "bitvec",
  "bytes",
  "chrono",
  "clap",
@@ -723,6 +736,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1717,6 +1736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2503,6 +2528,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3115,6 +3146,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xml-rs"

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -11,6 +11,7 @@ atty = "0.2"
 avro-rs = { version = "0.13.0", features = ["snappy"] }
 backoff = "0.4.0"
 base64 = "0.13.0"
+bitvec = "1"
 bytes = "1.1.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2.34.0"

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -335,7 +335,7 @@ impl<'a> SampleGenerator<'a> {
     }
 }
 
-/// Returns an iterator over sample datas; each will be a vector of length
+/// Returns an iterator over sample data; each datum will be a vector of length
 /// `dimension`. This iterator will produce an arbitrarily large number of
 /// values, with the expectation that the caller will terminate iteration when
 /// enough values have been taken. The sequence of output values is


### PR DESCRIPTION
The UUID is itself random, so sample data is still random; the upside of
this is that we can now determine a given sample ingestion packet's data
without reading & decrypting the data shares. This will be handy for a
validator which wants to make sure the sums we are emitting match up
with the ingestion packets included in those sums.

[Note that since even "random" v4 UUIDs contain a few deterministic
bytes, part of the data will be deterministic; I think that's OK.]