### PR TITLE
`facilitator` logging improvements

### DIFF
--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -42,12 +42,17 @@ sha2 = "0.10"
 slog = { version = "2.7.0", features = ["max_level_trace"] }
 slog-async = "2.7.0"
 slog-json = "2.4.0"
+slog-scope = "4.4.0"
+slog-stdlog = "4.1.0"
 slog-term = "2.8.0"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.3.0"
 thiserror = "1.0"
 tokio = { version = "^1.15", features = ["full"] }
+tracing = "0.1.29"
+tracing-error = "0.2.0"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter", "json"] }
 ureq = { version = "^2.4", features = ["json"] }
 url = "2.2.2"
 urlencoding = "2.1.0"

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -958,11 +958,12 @@ fn main() -> Result<(), anyhow::Error> {
     let log_level = &env::var("RUST_LOG")
         .unwrap_or_else(|_| "INFO".to_owned())
         .to_uppercase();
-    let root_logger = setup_logging(&LoggingConfiguration {
+    let (root_logger, _guard) = setup_logging(&LoggingConfiguration {
         force_json_output: force_json_log_output,
         version_string: option_env!("BUILD_INFO").unwrap_or("(BUILD_INFO unavailable)"),
         log_level,
     })?;
+
     let args: Vec<String> = std::env::args().collect();
     info!(
         root_logger,


### PR DESCRIPTION
These changes:

- capture `log` and `trace` output from dependencies
- add debug logging around lock management in module `gcp_oauth`

See individual commits for details. Note that having both a global `slog` logger and a `tracing` subscriber isn't ideal. I think the right thing to do would be to use `tracing` everywhere, and configure forwarding of `log` messages into a `tracing` subscriber. But this is the smallest change we can make that achieves what we need to now.