### PR TITLE
Adding randomized part to KMS Keyring name

### DIFF
--- a/terraform/cluster_bootstrap/modules/gke/gke.tf
+++ b/terraform/cluster_bootstrap/modules/gke/gke.tf
@@ -128,10 +128,17 @@ resource "google_container_node_pool" "worker_nodes" {
 
   depends_on = [google_project_service.compute]
 }
+      
+resource "random_string" "kms_id" {
+  length  = 8
+  upper   = false
+  number  = false
+  special = false
+}
 
 # KMS keyring to store etcd encryption key
 resource "google_kms_key_ring" "keyring" {
-  name = "${var.resource_prefix}-kms-keyring"
+  name = "${var.resource_prefix}-${random_string.kms_id.result}-kms-keyring"
   # Keyrings can also be zonal, but ours must be regional to match the GKE
   # cluster.
   location = var.gcp_region

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -549,10 +549,17 @@ data "google_container_cluster" "cluster" {
   location = var.gcp_region
 }
 
+resource "random_string" "kms_id" {
+  length  = 8
+  upper   = false
+  number  = false
+  special = false
+}
+
 data "google_kms_key_ring" "keyring" {
   count = var.use_aws ? 0 : 1
 
-  name     = "prio-${var.environment}-kms-keyring"
+  name     = "prio-${var.environment}-${random_string.kms_id.result}-kms-keyring"
   location = var.gcp_region
 }
 


### PR DESCRIPTION
Google KMS Keyrings cannot be deleted, just disabled.
This creates a conflict with terraform in a destroy / create cycle
Adding a randomized string to the KMS Keyring name avoids this conflict