### PR TITLE
terraform: adopt `terraform` 1.1

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -73,7 +73,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 0.14.8
+        terraform_version: ~1.1.0
     - name: Terraform fmt
       run: terraform fmt --check --recursive
     - name: Terraform init

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -40,9 +40,7 @@ prep: ## Prepare a new workspace (environment) if needed, configure the tfstate 
 	@terraform init \
 		-input=false \
 		-force-copy \
-		-lock=true \
 		-upgrade \
-		-verify-plugins=true \
 		-backend=true \
 		-backend-config="bucket=$(STATE_BUCKET)"
 
@@ -185,9 +183,7 @@ prep-cluster-bootstrap: ## Prepare a new workspace (environment) if needed, conf
 		init \
 		-input=false \
 		-force-copy \
-		-lock=true \
 		-upgrade \
-		-verify-plugins=true \
 		-backend=true \
 		-backend-config="bucket=$(STATE_BUCKET)" \
 		-backend-config="prefix=cluster-bootstrap"

--- a/terraform/cluster_bootstrap/main.tf
+++ b/terraform/cluster_bootstrap/main.tf
@@ -62,7 +62,7 @@ DESCRIPTION
 terraform {
   backend "gcs" {}
 
-  required_version = ">= 0.14.8"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -280,7 +280,7 @@ DESCRIPTION
 terraform {
   backend "gcs" {}
 
-  required_version = ">= 0.14.8"
+  required_version = ">= 1.1.0"
 
   # https://www.terraform.io/docs/language/expressions/type-constraints.html#experimental-optional-object-type-attributes
   experiments = [module_variable_optional_attrs]


### PR DESCRIPTION
Adopts the latest release of `terraform`, 1.1.

 - Since v0.15, `-lock` and `-verify-plugins` don't do anything in
   `terraform init`
 - bump `required_version` in `main.tf`

Part of #784