### PR TITLE
terraform: manage EKS cluster component versions

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -34,3 +34,21 @@ Our continuous integration is set up to do basic validation of Terraform files o
 ## Debugging
 
 Debugging Terraform problems can be tricky since some providers emit terse and unhelpful error messages. To get more insight into what is going on, set the environment variable `TF_LOG=debug` when invoking `Makefile` targets like `apply` and Terraform will emit a huge amount of data, usually including HTTP requests to cloud platforms. See [Terraform documentation](https://www.terraform.io/docs/cli/config/environment-variables.html) for more on supported environment variables.
+
+## EKS notes
+
+### Updating the `vpc-cni` add-on
+
+In EKS, customers are responsible for keeping the [`vpc-cni` add-on](https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html) up to date. We do this via Terraform, but there is a constraint that makes certain updates impossible for Terraform to handle for us: [you can only update one minor version at a time](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#updating-vpc-cni-eks-add-on). If you find yourself with a Terraform plan that would update the addon from something like `v1.7.5-eksbuild.2` to `v1.10.1-eksbuild.1`, then the apply will fail with an error like this:
+
+    {
+      RespMetadata: {
+        StatusCode: 400,
+        RequestID: "692a4d18-dfc4-4b5e-a875-c72e1f65932e"
+      },
+      AddonName: "vpc-cni",
+      ClusterName: "your-cluster-name",
+      Message_: "Updating VPC-CNI can only go up or down 1 minor version at a time"
+    }
+
+The workaround is to manually apply the addon updates between the version your cluster is on and the version you want to get to. Consult [AWS documentation](https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html#updating-vpc-cni-eks-add-on) for instructions on doing this in either the AWS console or the `aws` CLI.

--- a/terraform/cluster_bootstrap/main.tf
+++ b/terraform/cluster_bootstrap/main.tf
@@ -49,11 +49,14 @@ DESCRIPTION
 
 variable "cluster_settings" {
   type = object({
-    initial_node_count = number
-    min_node_count     = number
-    max_node_count     = number
-    gcp_machine_type   = string
-    aws_machine_types  = list(string)
+    initial_node_count             = number
+    min_node_count                 = number
+    max_node_count                 = number
+    gcp_machine_type               = string
+    aws_machine_types              = list(string)
+    eks_cluster_version            = optional(string)
+    eks_vpc_cni_addon_version      = optional(string)
+    eks_cluster_autoscaler_version = optional(string)
   })
   description = <<DESCRIPTION
 Settings for the Kubernetes cluster.
@@ -65,6 +68,16 @@ Settings for the Kubernetes cluster.
     clusters
   - `aws_machine_types` is the types and sizes of VMs to use as worker nodes in
     EKS clusters
+  - `eks_cluster_version` is the Amazon EKS Kubernetes version to use. See
+    https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
+    for available versions. Only used in EKS clusters.
+  - `eks_vpc_cni_addon_version` is the Amazon VPC CNI add-on version to use. See
+    https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html for
+    available versions. Only used in EKS clusters.
+  - `eks_cluster_autoscaler_version` is the version of the Kubernetes cluster
+    autoscaler to use. The version must match the minor version of Kubernetes.
+    See https://github.com/kubernetes/autoscaler/releases for available
+    versions. Only used in EKS clusters.
 
 Note that on AWS, there will always be at least three worker nodes in an "on
 demand" node pool, and the `{min,max}_node_count` values only govern the size of
@@ -76,6 +89,9 @@ terraform {
   backend "gcs" {}
 
   required_version = ">= 1.1.0"
+
+  # https://www.terraform.io/docs/language/expressions/type-constraints.html#experimental-optional-object-type-attributes
+  experiments = [module_variable_optional_attrs]
 
   required_providers {
     aws = {

--- a/terraform/modules/eks/cluster_autoscaler.tf
+++ b/terraform/modules/eks/cluster_autoscaler.tf
@@ -255,9 +255,7 @@ resource "kubernetes_deployment" "cluster_autoscaler" {
         service_account_name = module.account_mapping.kubernetes_service_account_name
 
         container {
-          # cluster-autoscaler image version should correspond to Kubernetes cluster version
-          # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.20.1
-          image = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.20.1"
+          image = var.cluster_settings.eks_cluster_autoscaler_version
           name  = "cluster-autoscaler"
 
           resources {

--- a/terraform/modules/eks/eks.tf
+++ b/terraform/modules/eks/eks.tf
@@ -6,6 +6,23 @@ variable "aws_region" {
   type = string
 }
 
+variable "cluster_settings" {
+  type = object({
+    initial_node_count             = number
+    min_node_count                 = number
+    max_node_count                 = number
+    gcp_machine_type               = string
+    aws_machine_types              = list(string)
+    eks_cluster_version            = optional(string)
+    eks_vpc_cni_addon_version      = optional(string)
+    eks_cluster_autoscaler_version = optional(string)
+  })
+}
+
+terraform {
+  experiments = [module_variable_optional_attrs]
+}
+
 # This cluster role binding references the built-in cluster role "view" and
 # defines a group that can then be referenced in the kube-system/aws-auth config
 # map.

--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -81,10 +81,15 @@ cluster_settings = {
   initial_node_count = 3
   # note that this size only applies to the spot node group and we will always
   # have 3 nodes in the on demand node group
-  min_node_count    = 0
-  max_node_count    = 6
-  gcp_machine_type  = "e2-standard-2"
-  aws_machine_types = ["t3.large"]
+  min_node_count      = 0
+  max_node_count      = 6
+  gcp_machine_type    = "e2-standard-2"
+  aws_machine_types   = ["t3.large"]
+  eks_cluster_version = "1.21"
+  # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
+  eks_vpc_cni_addon_version = "v1.10.1-eksbuild.1"
+  # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.21.2
+  eks_cluster_autoscaler_version = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2"
 }
 is_first                 = false
 use_aws                  = true

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -30,11 +30,16 @@ ingestors = {
   }
 }
 cluster_settings = {
-  initial_node_count = 1
-  min_node_count     = 0
-  max_node_count     = 3
-  gcp_machine_type   = "e2-standard-2"
-  aws_machine_types  = ["t3.large"]
+  initial_node_count  = 1
+  min_node_count      = 0
+  max_node_count      = 3
+  gcp_machine_type    = "e2-standard-2"
+  aws_machine_types   = ["t3.large"]
+  eks_cluster_version = "1.21"
+  # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
+  eks_vpc_cni_addon_version = "v1.10.1-eksbuild.1"
+  # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.21.2
+  eks_cluster_autoscaler_version = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2"
 }
 is_first                 = false
 use_aws                  = true

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -62,11 +62,16 @@ ingestors = {
   }
 }
 cluster_settings = {
-  initial_node_count = 2
-  min_node_count     = 1
-  max_node_count     = 3
-  gcp_machine_type   = "e2-standard-2"
-  aws_machine_types  = ["t3.medium"]
+  initial_node_count  = 2
+  min_node_count      = 1
+  max_node_count      = 3
+  gcp_machine_type    = "e2-standard-2"
+  aws_machine_types   = ["t3.medium"]
+  eks_cluster_version = "1.21"
+  # https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
+  eks_vpc_cni_addon_version = "v1.10.1-eksbuild.1"
+  # https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.21.2
+  eks_cluster_autoscaler_version = "k8s.gcr.io/autoscaling/cluster-autoscaler:v1.21.2"
 }
 test_peer_environment = {
   env_with_ingestor    = "stg-us-facil"


### PR DESCRIPTION
Plumbs variables for versions of a few EKS cluster components into
environment .tfvars files so that we can perform upgrades via Terraform.
Specifically we configure:
    
  - The version of the EKS cluster itself. The EKS cluster version is derived
    from the upstream Kubernetes version. See [1] for details.
  - The version of the AMI used on worker nodes. The EKS API can figure out an
    appropriate AMI from the cluster Kubernetes version. The `aws` provider
    documentation[2] suggests we could omit this but we explicitly set
    the same version as the cluster, since the EKS documentation[3]
    states that we have to update the node groups after updating the
    cluster.
  - The VPC CNI add-on version. We must pick a version that is
    compatible with the cluster version, per EKS documentation[4].
  - The cluster autoscaler version. We must deploy a version that is
    compatible with the cluster Kubernetes version. See [5] for
    available versions.
    
[1]: https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html
[2]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_node_group
[3]: https://docs.aws.amazon.com/eks/latest/userguide/update-managed-node-group.html
[4]: https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
[5]: https://github.com/kubernetes/autoscaler/releases
    
Resolves #1197