### PR TITLE
Key rotator: add flags to skip manifest pre/post-update validations.

### DIFF
--- a/key-rotator/main.go
+++ b/key-rotator/main.go
@@ -54,6 +54,9 @@ var (
 	packetEncryptionKeyDeleteMinCount = flag.Int("packet-encryption-key-delete-min-count", 2, "The minimum number of packet encryption key versions left undeleted after rotation")
 	packetEncryptionKeyAlwaysWrite    = flag.Bool("packet-encryption-key-always-write", false, "If set, always write packet encryption key to backing storage, even if no changes are detected")
 
+	skipManifestPreUpdateValidations  = flag.Bool("unsafe-skip-manifest-pre-update-validations", false, "If set, skip manifest pre-update validations. This flag is unsafe; do not set unless you know what you are doing")
+	skipManifestPostUpdateValidations = flag.Bool("unsafe-skip-manifest-post-update-validations", false, "If set, skip manifest post-update validations. This flag is unsafe; do not set unless you know what you are doing")
+
 	// Other flags.
 	backup                        = flag.String("backup", "", "Set to 'aws' or 'gcp:gcp-project-id' to back up secrets to the respective cloud's secrets manager")
 	dryRun                        = flag.Bool("dry-run", true, "If set, do not actually write any keys or manifests back (only report what would have changed)")
@@ -257,6 +260,8 @@ func main() {
 				DeleteMinKeyCount: *packetEncryptionKeyDeleteMinCount,
 			},
 		},
+		skipManifestPreUpdateValidations:  *skipManifestPreUpdateValidations,
+		skipManifestPostUpdateValidations: *skipManifestPostUpdateValidations,
 	}); err != nil {
 		fail("Couldn't rotate keys: %v", err)
 	}
@@ -274,13 +279,15 @@ type rotateKeysConfig struct {
 	manifestStore storage.Manifest
 
 	// Configuration.
-	now             time.Time
-	locality        string
-	ingestors       []string
-	prioEnvironment string
-	csrFQDN         string
-	batchCFG        rotateKeyConfig
-	packetCFG       rotateKeyConfig
+	now                               time.Time
+	locality                          string
+	ingestors                         []string
+	prioEnvironment                   string
+	csrFQDN                           string
+	batchCFG                          rotateKeyConfig
+	packetCFG                         rotateKeyConfig
+	skipManifestPreUpdateValidations  bool
+	skipManifestPostUpdateValidations bool
 }
 
 type rotateKeyConfig struct {
@@ -344,6 +351,8 @@ func rotateKeys(ctx context.Context, cfg rotateKeysConfig) error {
 			PacketEncryptionKeyIDPrefix: fmt.Sprintf(
 				"%s-%s-ingestion-packet-decryption-key", cfg.prioEnvironment, cfg.locality),
 			PacketEncryptionKeyCSRFQDN: cfg.csrFQDN,
+			SkipPreUpdateValidations:   cfg.skipManifestPreUpdateValidations,
+			SkipPostUpdateValidations:  cfg.skipManifestPostUpdateValidations,
 		})
 		if err != nil {
 			return fmt.Errorf("couldn't update manifest for (%q, %q): %w",

--- a/key-rotator/main.go
+++ b/key-rotator/main.go
@@ -157,6 +157,12 @@ func main() {
 	}
 
 	log.Info().Msgf("Starting up")
+	if *skipManifestPreUpdateValidations {
+		log.Warn().Msgf("--unsafe-skip-manifest-pre-update-validations is set; this flag is inherently unsafe and should only be set temporarily in order to fix an ongoing incident")
+	}
+	if *skipManifestPostUpdateValidations {
+		log.Warn().Msgf("--unsafe-skip-manifest-post-update-validations is set; this flag is inherently unsafe and should only be set temporarily in order to fix an ongoing incident")
+	}
 	ctx := context.Background()
 	if *timeout > 0 {
 		var cancel context.CancelFunc

--- a/key-rotator/manifest/manifest.go
+++ b/key-rotator/manifest/manifest.go
@@ -191,21 +191,31 @@ func (m DataShareProcessorSpecificManifest) UpdateKeys(cfg UpdateKeysConfig) (Da
 	// Update batch signing key.
 	if err := cfg.BatchSigningKey.Versions(func(v key.Version) error {
 		kid := cfg.batchSigningKeyID(v.CreationTimestamp)
-		var newBSPK BatchSigningPublicKey
+		var newBSPK *BatchSigningPublicKey
 		if bspk, ok := m.BatchSigningPublicKeys[kid]; ok {
-			newBSPK = bspk
-		} else {
+			// If the manifest has a key for this kid, and it matches, use it instead of generating a new PKIX encoding.
+			manifestPubkey, err := bspk.toPublicKey()
+			if err != nil {
+				return fmt.Errorf("couldn't parse batch signing key version %q from manifest: %w", kid, err)
+			}
+			if manifestPubkey.Equal(v.KeyMaterial.Public()) {
+				bspk := bspk
+				newBSPK = &bspk
+			}
+		}
+		if newBSPK == nil {
+			// Manifest either does not have this key version, or it doesn't match up. Generate it.
 			pkix, err := v.KeyMaterial.PublicAsPKIX()
 			if err != nil {
 				return fmt.Errorf("couldn't create PKIX-encoding for batch signing key version with creation timestamp %d: %w", v.CreationTimestamp, err)
 			}
 			const batchSigningPublicKeyValidityPeriod = 100 * 365 * 24 * time.Hour // 100 years
-			newBSPK = BatchSigningPublicKey{
+			newBSPK = &BatchSigningPublicKey{
 				PublicKey:  pkix,
 				Expiration: time.Now().UTC().Add(batchSigningPublicKeyValidityPeriod).Format(time.RFC3339),
 			}
 		}
-		newM.BatchSigningPublicKeys[kid] = newBSPK
+		newM.BatchSigningPublicKeys[kid] = *newBSPK
 		return nil
 	}); err != nil {
 		return DataShareProcessorSpecificManifest{}, err
@@ -214,17 +224,27 @@ func (m DataShareProcessorSpecificManifest) UpdateKeys(cfg UpdateKeysConfig) (Da
 	// Update packet encryption key.
 	primaryPEKVersion := cfg.PacketEncryptionKey.Primary()
 	kid := cfg.packetEncryptionKeyID(primaryPEKVersion.CreationTimestamp)
-	var newPEC PacketEncryptionCertificate
+	var newPEC *PacketEncryptionCertificate
 	if pec, ok := m.PacketEncryptionKeyCSRs[kid]; ok {
-		newPEC = pec
-	} else {
+		// If the manifest has a key for this kid, and it matches, use it instead of generating a new CSR.
+		manifestPubkey, err := pec.toPublicKey()
+		if err != nil {
+			return DataShareProcessorSpecificManifest{}, fmt.Errorf("couldn't parse packet encryption key version %q from manifest: %w", kid, err)
+		}
+		if manifestPubkey.Equal(primaryPEKVersion.KeyMaterial.Public()) {
+			pec := pec
+			newPEC = &pec
+		}
+	}
+	if newPEC == nil {
+		// Manifest either does not have this key version, or it doesn't match up. Generate it.
 		csr, err := primaryPEKVersion.KeyMaterial.PublicAsCSR(cfg.PacketEncryptionKeyCSRFQDN)
 		if err != nil {
 			return DataShareProcessorSpecificManifest{}, fmt.Errorf("couldn't create CSR for packet encryption key version with creation timestamp %d: %w", primaryPEKVersion.CreationTimestamp, err)
 		}
-		newPEC = PacketEncryptionCertificate{CertificateSigningRequest: csr}
+		newPEC = &PacketEncryptionCertificate{CertificateSigningRequest: csr}
 	}
-	newM.PacketEncryptionKeyCSRs[kid] = newPEC
+	newM.PacketEncryptionKeyCSRs[kid] = *newPEC
 
 	// Validate results.
 	if !cfg.SkipPostUpdateValidations {

--- a/key-rotator/manifest/manifest.go
+++ b/key-rotator/manifest/manifest.go
@@ -338,17 +338,35 @@ func validatePostUpdateManifest(cfg UpdateKeysConfig, m, oldM DataShareProcessor
 	}
 
 	// Post-update, manifests' key data for key versions that exist both pre- &
-	// post-update must match exactly.
+	// post-update must match exactly, if their key data matches.
 	for kid, key := range m.BatchSigningPublicKeys {
 		if oldKey, ok := oldM.BatchSigningPublicKeys[kid]; ok {
-			if key != oldKey {
+			oldPubkey, err := oldKey.toPublicKey()
+			if err != nil {
+				return fmt.Errorf("couldn't parse batch signing key version %q from old manifest: %w", kid, err)
+			}
+			newPubkey, err := key.toPublicKey()
+			if err != nil {
+				return fmt.Errorf("couldn't parse batch signing key version %q from new manifest: %w", kid, err)
+			}
+
+			if oldPubkey.Equal(newPubkey) && key != oldKey {
 				return fmt.Errorf("pre-existing batch signing key %q modified", kid)
 			}
 		}
 	}
 	for kid, key := range m.PacketEncryptionKeyCSRs {
 		if oldKey, ok := oldM.PacketEncryptionKeyCSRs[kid]; ok {
-			if key != oldKey {
+			oldPubkey, err := oldKey.toPublicKey()
+			if err != nil {
+				return fmt.Errorf("couldn't parse packet encryption key version %q from old manifest: %w", kid, err)
+			}
+			newPubkey, err := key.toPublicKey()
+			if err != nil {
+				return fmt.Errorf("couldn't parse packet encryption key version %q from new manifest: %w", kid, err)
+			}
+
+			if oldPubkey.Equal(newPubkey) && key != oldKey {
 				return fmt.Errorf("pre-existing packet encryption key %q modified", kid)
 			}
 		}

--- a/key-rotator/manifest/manifest_test.go
+++ b/key-rotator/manifest/manifest_test.go
@@ -796,7 +796,7 @@ func pek(tss ...int64) key.Key {
 }
 
 // manifestBSK creates a manifest BatchSigningPublicKeys with the given
-// timetamps, expiring at the current time. Order does not matter. Key material
+// timestamps, expiring at the current time. Order does not matter. Key material
 // is arbitrary, but will match that of other batch signing keys at the same
 // timestamp, and will very likely not match other key materials.
 func manifestBSK(tss ...int64) BatchSigningPublicKeys {

--- a/key-rotator/manifest/manifest_test.go
+++ b/key-rotator/manifest/manifest_test.go
@@ -804,7 +804,7 @@ func manifestBSK(tss ...int64) BatchSigningPublicKeys {
 }
 
 // manifestBSKWithExpiration creates a manifest BatchSigningPublicKeys with the
-// given timetamps, expiring at the given timestamp. Order does not matter. Key
+// given timestamps, expiring at the given timestamp. Order does not matter. Key
 // material is arbitrary, but will match that of other batch signing keys at
 // the same timestamp, and will very likely not match other key materials.
 func manifestBSKWithExpiration(when time.Time, tss ...int64) BatchSigningPublicKeys {


### PR DESCRIPTION
These are unsafe to use in general--the pre-update validations serve as
a check that the key-rotator is running against a consistent set of
(manifest, k8s secret), the post-update validations serve as a check
that our update logic didn't do something very unexpected. But they may
be necessary if the key-rotator needs to run to fix an environment that
is already out-of-sync (and therefore triggering validation failures).