### PR TITLE
Add expected_sample_sum_for_batches.

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -1334,7 +1334,7 @@ fn generate_sample(
         api_metrics,
     )?;
 
-    let mut peer_transport = SampleOutput {
+    let peer_transport = SampleOutput {
         transport: SignableTransport {
             transport: transport_for_path(
                 peer_output_path,
@@ -1381,7 +1381,7 @@ fn generate_sample(
         api_metrics,
     )?;
 
-    let mut facilitator_transport = SampleOutput {
+    let facilitator_transport = SampleOutput {
         transport: SignableTransport {
             transport: transport_for_path(
                 facilitator_output,
@@ -1406,8 +1406,8 @@ fn generate_sample(
         value_t!(sub_matches.value_of("epsilon"), f64)?,
         value_t!(sub_matches.value_of("batch-start-time"), i64)?,
         value_t!(sub_matches.value_of("batch-end-time"), i64)?,
-        &mut peer_transport,
-        &mut facilitator_transport,
+        &peer_transport,
+        &facilitator_transport,
         logger,
     );
 

--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -244,7 +244,7 @@ mod tests {
 
         let packet_encryption_csr = default_packet_encryption_certificate_signing_request();
 
-        let mut pha_output = SampleOutput {
+        let pha_output = SampleOutput {
             transport: SignableTransport {
                 transport: Box::new(LocalFileTransport::new(pha_tempdir.path().to_path_buf())),
                 batch_signing_key: default_ingestor_private_key(),
@@ -256,7 +256,7 @@ mod tests {
             drop_nth_packet: None,
         };
 
-        let mut facilitator_output = SampleOutput {
+        let facilitator_output = SampleOutput {
             transport: SignableTransport {
                 transport: Box::new(LocalFileTransport::new(
                     facilitator_tempdir.path().to_path_buf(),
@@ -276,8 +276,8 @@ mod tests {
             0.11,
             100,
             100,
-            &mut pha_output,
-            &mut facilitator_output,
+            &pha_output,
+            &facilitator_output,
             &logger,
         );
 
@@ -373,7 +373,7 @@ mod tests {
 
         let packet_encryption_csr = default_packet_encryption_certificate_signing_request();
 
-        let mut pha_output = SampleOutput {
+        let pha_output = SampleOutput {
             transport: SignableTransport {
                 transport: Box::new(LocalFileTransport::new(pha_tempdir.path().to_path_buf())),
                 batch_signing_key: default_ingestor_private_key(),
@@ -385,7 +385,7 @@ mod tests {
             drop_nth_packet: None,
         };
 
-        let mut facilitator_output = SampleOutput {
+        let facilitator_output = SampleOutput {
             transport: SignableTransport {
                 transport: Box::new(LocalFileTransport::new(
                     facilitator_tempdir.path().to_path_buf(),
@@ -405,8 +405,8 @@ mod tests {
             0.11,
             100,
             100,
-            &mut pha_output,
-            &mut facilitator_output,
+            &pha_output,
+            &facilitator_output,
             &logger,
         );
 
@@ -466,7 +466,7 @@ mod tests {
 
         let packet_encryption_csr = default_packet_encryption_certificate_signing_request();
 
-        let mut pha_output = SampleOutput {
+        let pha_output = SampleOutput {
             transport: SignableTransport {
                 transport: Box::new(LocalFileTransport::new(pha_tempdir.path().to_path_buf())),
                 batch_signing_key: default_ingestor_private_key(),
@@ -478,7 +478,7 @@ mod tests {
             drop_nth_packet: None,
         };
 
-        let mut facilitator_output = SampleOutput {
+        let facilitator_output = SampleOutput {
             transport: SignableTransport {
                 transport: Box::new(LocalFileTransport::new(
                     facilitator_tempdir.path().to_path_buf(),
@@ -498,8 +498,8 @@ mod tests {
             0.11,
             100,
             100,
-            &mut pha_output,
-            &mut facilitator_output,
+            &pha_output,
+            &facilitator_output,
             &logger,
         );
         sample_generator.set_generate_short_packet(5);

--- a/facilitator/tests/integration_tests.rs
+++ b/facilitator/tests/integration_tests.rs
@@ -60,7 +60,7 @@ fn aggregation_including_invalid_batch() {
         default_ingestor_public_key(),
     );
 
-    let mut pha_output = SampleOutput {
+    let pha_output = SampleOutput {
         transport: SignableTransport {
             transport: Box::new(LocalFileTransport::new(
                 pha_tempdir.path().join("ingestion"),
@@ -71,7 +71,7 @@ fn aggregation_including_invalid_batch() {
         drop_nth_packet: None,
     };
 
-    let mut facilitator_output = SampleOutput {
+    let facilitator_output = SampleOutput {
         transport: SignableTransport {
             transport: Box::new(LocalFileTransport::new(
                 facilitator_tempdir.path().join("ingestion"),
@@ -104,8 +104,8 @@ fn aggregation_including_invalid_batch() {
         0.11,
         100,
         100,
-        &mut pha_output,
-        &mut facilitator_output,
+        &pha_output,
+        &facilitator_output,
         &logger,
     );
 
@@ -332,7 +332,7 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         default_ingestor_public_key(),
     );
 
-    let mut pha_output = SampleOutput {
+    let pha_output = SampleOutput {
         transport: SignableTransport {
             transport: Box::new(LocalFileTransport::new(pha_tempdir.path().to_path_buf())),
             batch_signing_key: default_ingestor_private_key(),
@@ -342,7 +342,7 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         drop_nth_packet: drop_nth_pha,
     };
 
-    let mut facilitator_output = SampleOutput {
+    let facilitator_output = SampleOutput {
         transport: SignableTransport {
             transport: Box::new(LocalFileTransport::new(
                 facilitator_tempdir.path().to_path_buf(),
@@ -361,8 +361,8 @@ fn end_to_end_test(drop_nth_pha: Option<usize>, drop_nth_facilitator: Option<usi
         0.11,
         100,
         100,
-        &mut pha_output,
-        &mut facilitator_output,
+        &pha_output,
+        &facilitator_output,
         &logger,
     );
 


### PR DESCRIPTION
This function produces the expected sum from a SumPart comprised of the
given batch UUIDs. This turned out to be a lot simpler than I expected:
I didn't need to read the validation batches in the sum part to get
their UUIDs because the validation batch uses the same UUID as the
ingestion UUID (and the ingestion UUID is what determines the data
included in the ingestion batch, along with the "static"
dimension/packet_count parameters).

The test is a "weak" test in that it only tests that the result of
expected_sample_sum_for_batches matches up with the sum of a few
repeated calls to generate_ingestion_sample -- it does not test the full
intake -> ingest -> aggregate flow from end-to-end. The goal of this
test is to make sure these two functions agree on the sums they believe
they are generating.