### PR TITLE
Fix bug around task-deadline extension.

### DIFF
--- a/facilitator/rust-toolchain.toml
+++ b/facilitator/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.56.1"
+channel = "stable"
 components = [ "rustc", "rustfmt", "clippy" ]

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -57,7 +57,7 @@ fn num_validator<F: FromStr>(s: String) -> Result<(), String> {
 fn date_validator(s: String) -> Result<(), String> {
     NaiveDateTime::parse_from_str(&s, DATE_FORMAT)
         .map(|_| ())
-        .map_err(|e| format!("{} {}", s, e.to_string()))
+        .map_err(|e| format!("{} {}", s, e))
 }
 
 fn uuid_validator(s: String) -> Result<(), String> {
@@ -989,7 +989,6 @@ fn main() -> Result<(), anyhow::Error> {
     let mut gcp_access_token_provider_factory =
         GcpAccessTokenProviderFactory::new(runtime.handle(), &api_metrics, &root_logger);
     let mut aws_provider_factory = aws_credentials::ProviderFactory::new(
-        runtime.handle(),
         &gcp_access_token_provider_factory,
         &api_metrics,
         &root_logger,

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -26,7 +26,7 @@ fn storage_api_base_url() -> Url {
 fn gcp_object_url(bucket: &str, encoded_key: &str) -> Result<Url> {
     let request_url = &format!(
         "{}storage/v1/b/{}/o/{}",
-        storage_api_base_url().to_string(),
+        storage_api_base_url(),
         bucket,
         encoded_key
     );


### PR DESCRIPTION
Previously, after the first time we extended a task's deadline, we would
attempt to extend the deadline again every time we checked if the
deadline should be updated. Now, every time we extend a task's deadline,
we "reset" the starting point so that we only attempt to reset the
deadline again once enough time has passed.

I had to switch to "stable" channel to get a version of Rust (1.58) recent enough to have const duration-handling functions.

Closes #319.