### PR TITLE
Add `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @abetterinternet/ppm-committers


### PR DESCRIPTION
Once we have set `CODEOWNERS`, we can configure the GitHub repo to require review from code owners, which IIUC should automatically tag all members of [ppm-committers](https://github.com/orgs/abetterinternet/teams/ppm-committers/members) on PRs to this repo.