### PR TITLE
Re-remove version-based validation from DSP locality-specific manifest.

### DIFF
--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -250,16 +250,7 @@ impl DataShareProcessorSpecificManifest {
 
         // Validate.
         match manifest.format {
-            1 => {
-                if manifest.peer_validation_identity.is_some() {
-                    return Err(anyhow!(
-                        "manifest format 1 cannot have peer_validation_identity, has {}",
-                        manifest.peer_validation_identity
-                    )
-                    .into());
-                }
-            }
-            2 => (), // no additional validation needed
+            1 | 2 => (), // no additional validation needed
             _ => return Err(anyhow!("unsupported manifest format {}", manifest.format).into()),
         }
 


### PR DESCRIPTION
This enforces that the two versions can actually be expressed as one
version. Unlike the DSP global manifest, I believe there is no
equivalent validation to be written: the only difference between the two
versions was the addition of an optional field
(peer_validation_identity), so the two message versions are essentially
identical.