### PR TITLE
Terraform fixes

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -104,7 +104,7 @@ plan-bootstrap: prep ## Show what terraform thinks it will do
 		-var-file="$(VARS)" \
 		-target=module.manifest_gcp \
 		-target=module.manifest_aws \
-		-target=module.fake_server_resources \
+		-target=module.fake_server_resources[0].google_storage_bucket_object.global_manifest \
 		-target=module.portal_server_resources \
 		-target=module.gke \
 		-target=module.eks \
@@ -119,7 +119,7 @@ apply-bootstrap: prep ## Have terraform bring up the minimal resources needed to
 		-var-file="$(VARS)" \
 		-target=module.manifest_gcp \
 		-target=module.manifest_aws \
-		-target=module.fake_server_resources \
+		-target=module.fake_server_resources[0].google_storage_bucket_object.global_manifest \
 		-target=module.portal_server_resources \
 		-target=module.gke \
 		-target=module.eks \
@@ -134,7 +134,7 @@ destroy-bootstrap: prep ## Have terraform destroy the resources brought up by ap
 		-var-file="$(VARS)" \
 		-target=module.manifest_gcp \
 		-target=module.manifest_aws \
-		-target=module.fake_server_resources \
+		-target=module.fake_server_resources[0].google_storage_bucket_object.global_manifest \
 		-target=module.portal_server_resources \
 		-target=module.gke \
 		-target=module.eks \

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -348,6 +348,11 @@ provider "google" {
   project = var.gcp_project
 }
 
+provider "google-beta" {
+  region  = var.gcp_region
+  project = var.gcp_project
+}
+
 # AWS provider credentials come from environment variables set by the `aws-mfa`
 # script
 provider "aws" {


### PR DESCRIPTION
This fixes a few issues I encountered while setting up my development environment.

- The `google-beta` provider needs to be configured in addition to the `google` provider. Without this, the two resources that use it were failing for want of a region on my computer.
- The bootstrap make targets needs its `-target` flags to be scoped down further, so that we can get the first manifests created, without touching anything that depends on reading them via the `http` provider.
- I added resources to flip on two GCP services, and added dependencies to GCP services in two cases where I saw error messages on the first run.