### PR TITLE
terraform: Use aws provider's allowed_account_ids

### DIFF
--- a/terraform/cluster_bootstrap/main.tf
+++ b/terraform/cluster_bootstrap/main.tf
@@ -26,6 +26,19 @@ The AWS region in which resources should be created.
 DESCRIPTION
 }
 
+variable "allowed_aws_account_ids" {
+  type        = list(string)
+  default     = null
+  description = <<DESCRIPTION
+A list of AWS account IDs that are allowed to be used. Set this in an
+environment's variables to prevent accidentally using the environment with
+the wrong AWS configuration profile. This variable may be omitted, in which
+case no AWS account ID check is performed. If a list of account IDs is
+given, the provider will check the account of the active credentials, and
+return an error if it is not listed here.
+DESCRIPTION
+}
+
 variable "use_aws" {
   type        = bool
   description = <<DESCRIPTION
@@ -85,7 +98,8 @@ terraform {
 # AWS provider is configured via environment variables that get set by aws-mfa
 # script
 provider "aws" {
-  region = var.aws_region
+  region              = var.aws_region
+  allowed_account_ids = var.allowed_aws_account_ids
 
   default_tags {
     tags = {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,6 +28,11 @@ variable "aws_region" {
   type = string
 }
 
+variable "allowed_aws_account_ids" {
+  type    = list(string)
+  default = null
+}
+
 variable "localities" {
   type = list(string)
 }
@@ -365,7 +370,8 @@ provider "aws" {
   # aws_s3_bucket resources will be created in the region specified in this
   # provider.
   # https://github.com/hashicorp/terraform/issues/12512
-  region = var.aws_region
+  region              = var.aws_region
+  allowed_account_ids = var.allowed_aws_account_ids
 
   default_tags {
     tags = {

--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -105,6 +105,4 @@ grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
 stackdriver_exporter_helm_chart_version = "1.12.0"
 
-# Uncomment and fill in this variable to require that this file always be used
-# with the same AWS account.
-# allowed_aws_account_ids = ["123456789012"]
+allowed_aws_account_ids = ["718214359651"]

--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -104,3 +104,7 @@ prometheus_helm_chart_version           = "15.0.2"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
 stackdriver_exporter_helm_chart_version = "1.12.0"
+
+# Uncomment and fill in this variable to require that this file always be used
+# with the same AWS account.
+# allowed_aws_account_ids = ["123456789012"]

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -238,6 +238,4 @@ grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
 stackdriver_exporter_helm_chart_version = "1.12.0"
 
-# Uncomment and fill in this variable to require that this file always be used
-# with the same AWS account.
-# allowed_aws_account_ids = ["123456789012"]
+allowed_aws_account_ids = ["338276578713"]

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -237,3 +237,7 @@ prometheus_helm_chart_version           = "15.0.2"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
 stackdriver_exporter_helm_chart_version = "1.12.0"
+
+# Uncomment and fill in this variable to require that this file always be used
+# with the same AWS account.
+# allowed_aws_account_ids = ["123456789012"]

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -96,6 +96,4 @@ grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
 stackdriver_exporter_helm_chart_version = "1.12.0"
 
-# Uncomment and fill in this variable to require that this file always be used
-# with the same AWS account.
-# allowed_aws_account_ids = ["123456789012"]
+allowed_aws_account_ids = ["338276578713"]

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -95,3 +95,7 @@ prometheus_helm_chart_version           = "15.0.2"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
 stackdriver_exporter_helm_chart_version = "1.12.0"
+
+# Uncomment and fill in this variable to require that this file always be used
+# with the same AWS account.
+# allowed_aws_account_ids = ["123456789012"]

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -54,3 +54,7 @@ prometheus_helm_chart_version           = "15.0.2"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
 stackdriver_exporter_helm_chart_version = "1.12.0"
+
+# Uncomment and fill in this variable to require that this file always be used
+# with the same AWS account.
+# allowed_aws_account_ids = ["123456789012"]

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -55,6 +55,4 @@ grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"
 stackdriver_exporter_helm_chart_version = "1.12.0"
 
-# Uncomment and fill in this variable to require that this file always be used
-# with the same AWS account.
-# allowed_aws_account_ids = ["123456789012"]
+allowed_aws_account_ids = ["024759592502"]

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -81,6 +81,4 @@ default_aggregation_period = "30m"
 default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
 default_portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
 
-# Uncomment and fill in this variable to require that this file always be used
-# with the same AWS account.
-# allowed_aws_account_ids = ["123456789012"]
+allowed_aws_account_ids = ["338276578713"]

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -80,3 +80,7 @@ default_aggregation_period = "30m"
 
 default_peer_share_processor_manifest_base_url = "storage.googleapis.com/prio-staging-facil-manifests"
 default_portal_server_manifest_base_url        = "storage.googleapis.com/prio-staging-pha-manifests/portal-server"
+
+# Uncomment and fill in this variable to require that this file always be used
+# with the same AWS account.
+# allowed_aws_account_ids = ["123456789012"]


### PR DESCRIPTION
When this new variable is set, the `aws` provider will refuse to take any actions if it is given credentials to a mismatched account.

For now, I have added a commented-out declaration in each .tfvars file, with an example account ID, assuming we don't want to check in any actual account IDs.