### PR TITLE
Terraform fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
     directory: "/terraform"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "terraform"
+    directory: "/terraform/cluster_bootstrap"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/workflow-manager"
     schedule:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -291,7 +291,13 @@ terraform {
       version = "~> 3.74.0"
     }
     google = {
-      source  = "hashicorp/google"
+      source = "hashicorp/google"
+      # Keep this version in sync with provider google-beta
+      version = "~> 4.9.0"
+    }
+    google-beta = {
+      source = "hashicorp/google-beta"
+      # Keep this version in sync with provider google
       version = "~> 4.9.0"
     }
     helm = {


### PR DESCRIPTION
I noticed that #1346 reintroduces the `google-beta` provider into the main TF module, but we need to make sure its version is in sync with the regular Google one. Additionally, configures dependabot to manage provider versions in `cluster_bootstrap`.