### PR TITLE
Randomize KMS Keyring name

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -31,7 +31,7 @@ help:
 
 .PHONY: prep
 prep: ## Prepare a new workspace (environment) if needed, configure the tfstate backend, update any modules, and switch to the workspace
-	@rm .terraform/terraform.tfstate
+	@rm -f .terraform/terraform.tfstate
 	@if [ ! -f "$(VARS)" ]; then \
 		echo "$(BOLD)$(RED)Could not find variables file: $(VARS)$(RESET)"; \
 		exit 1; \
@@ -172,7 +172,7 @@ destroy-target: prep ## Destroy a specific resource. Caution though, this destro
 
 .PHONY: prep-cluster-bootstrap
 prep-cluster-bootstrap: ## Prepare a new workspace (environment) if needed, configure the tfstate backend, update any modules, and switch to the workspace
-	@rm cluster_bootstrap/.terraform/terraform.tfstate
+	@rm -f cluster_bootstrap/.terraform/terraform.tfstate
 	@if [ ! -f "$(VARS)" ]; then \
 		echo "$(BOLD)$(RED)Could not find variables file: $(VARS)$(RESET)"; \
 		exit 1; \

--- a/terraform/cluster_bootstrap/.terraform.lock.hcl
+++ b/terraform/cluster_bootstrap/.terraform.lock.hcl
@@ -58,6 +58,24 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.1.0"
+  hashes = [
+    "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
+    "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
+    "zh:3cd456047805bf639fbf2c761b1848880ea703a054f76db51852008b11008626",
+    "zh:4f251b0eda5bb5e3dc26ea4400dba200018213654b69b4a5f96abee815b4f5ff",
+    "zh:7011332745ea061e517fe1319bd6c75054a314155cb2c1199a5b01fe1889a7e2",
+    "zh:738ed82858317ccc246691c8b85995bc125ac3b4143043219bd0437adc56c992",
+    "zh:7dbe52fac7bb21227acd7529b487511c91f4107db9cc4414f50d04ffc3cab427",
+    "zh:a3a9251fb15f93e4cfc1789800fc2d7414bbc18944ad4c5c98f466e6477c42bc",
+    "zh:a543ec1a3a8c20635cf374110bd2f87c07374cf2c50617eee2c669b3ceeeaa9f",
+    "zh:d9ab41d556a48bd7059f0810cf020500635bfc696c9fc3adab5ea8915c1d886b",
+    "zh:d9e13427a7d011dbd654e591b0337e6074eef8c3b9bb11b2e39eaaf257044fd7",
+    "zh:f7605bd1437752114baf601bdf6931debe6dc6bfe3006eb7e9bb9080931dca8a",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/tls" {
   version = "3.1.0"
   hashes = [

--- a/terraform/cluster_bootstrap/main.tf
+++ b/terraform/cluster_bootstrap/main.tf
@@ -138,3 +138,7 @@ module "eks" {
   resource_prefix  = "prio-${var.environment}"
   cluster_settings = var.cluster_settings
 }
+
+output "google_kms_key_ring_id" {
+  value = var.use_aws ? "" : module.gke[0].google_kms_key_ring_id
+}

--- a/terraform/cluster_bootstrap/modules/gke/gke.tf
+++ b/terraform/cluster_bootstrap/modules/gke/gke.tf
@@ -141,7 +141,7 @@ resource "google_container_node_pool" "worker_nodes" {
 
   depends_on = [google_project_service.compute]
 }
-      
+
 resource "random_string" "kms_id" {
   length  = 8
   upper   = false

--- a/terraform/cluster_bootstrap/modules/gke/gke.tf
+++ b/terraform/cluster_bootstrap/modules/gke/gke.tf
@@ -151,7 +151,7 @@ resource "random_string" "kms_id" {
 
 # KMS keyring to store etcd encryption key
 resource "google_kms_key_ring" "keyring" {
-  name = "${var.resource_prefix}-${random_string.kms_id.result}-kms-keyring"
+  name = "${var.resource_prefix}-kms-keyring-${random_string.kms_id.result}"
   # Keyrings can also be zonal, but ours must be regional to match the GKE
   # cluster.
   location = var.gcp_region

--- a/terraform/cluster_bootstrap/modules/gke/gke.tf
+++ b/terraform/cluster_bootstrap/modules/gke/gke.tf
@@ -203,3 +203,7 @@ resource "google_artifact_registry_repository" "artifact_registry" {
 
   depends_on = [google_project_service.artifact_registry]
 }
+
+output "google_kms_key_ring_id" {
+  value = google_kms_key_ring.keyring.id
+}

--- a/terraform/cluster_bootstrap/modules/gke/gke.tf
+++ b/terraform/cluster_bootstrap/modules/gke/gke.tf
@@ -141,10 +141,17 @@ resource "google_container_node_pool" "worker_nodes" {
 
   depends_on = [google_project_service.compute]
 }
+      
+resource "random_string" "kms_id" {
+  length  = 8
+  upper   = false
+  number  = false
+  special = false
+}
 
 # KMS keyring to store etcd encryption key
 resource "google_kms_key_ring" "keyring" {
-  name = "${var.resource_prefix}-kms-keyring"
+  name = "${var.resource_prefix}-${random_string.kms_id.result}-kms-keyring"
   # Keyrings can also be zonal, but ours must be regional to match the GKE
   # cluster.
   location = var.gcp_region

--- a/terraform/cluster_bootstrap/modules/gke/gke.tf
+++ b/terraform/cluster_bootstrap/modules/gke/gke.tf
@@ -157,6 +157,10 @@ resource "google_kms_key_ring" "keyring" {
   location = var.gcp_region
 
   depends_on = [google_project_service.kms]
+
+  lifecycle {
+    ignore_changes = [name]
+  }
 }
 
 # KMS key used by GKE cluster to encrypt contents of cluster etcd, crucially to

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -566,10 +566,17 @@ data "google_container_cluster" "cluster" {
   location = var.gcp_region
 }
 
+resource "random_string" "kms_id" {
+  length  = 8
+  upper   = false
+  number  = false
+  special = false
+}
+
 data "google_kms_key_ring" "keyring" {
   count = var.use_aws ? 0 : 1
 
-  name     = "prio-${var.environment}-kms-keyring"
+  name     = "prio-${var.environment}-${random_string.kms_id.result}-kms-keyring"
   location = var.gcp_region
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -282,6 +282,14 @@ indicates that all localities should generate single-object validation batches.
 DESCRIPTION
 }
 
+variable "state_bucket" {
+  type        = string
+  description = <<DESCRIPTION
+The name of the GCS bucket that Terraform's state is stored in, for access
+to outputs from the cluster_bootstrap stage.
+DESCRIPTION
+}
+
 terraform {
   backend "gcs" {}
 
@@ -566,18 +574,12 @@ data "google_container_cluster" "cluster" {
   location = var.gcp_region
 }
 
-resource "random_string" "kms_id" {
-  length  = 8
-  upper   = false
-  number  = false
-  special = false
-}
-
-data "google_kms_key_ring" "keyring" {
-  count = var.use_aws ? 0 : 1
-
-  name     = "prio-${var.environment}-${random_string.kms_id.result}-kms-keyring"
-  location = var.gcp_region
+data "terraform_remote_state" "cluster_bootstrap" {
+  backend = "gcs"
+  config = {
+    bucket = var.state_bucket
+    prefix = "cluster-bootstrap"
+  }
 }
 
 resource "google_project_iam_custom_role" "gcp_secret_writer" {
@@ -639,7 +641,7 @@ module "data_share_processors" {
   intake_max_age                                 = var.intake_max_age
   aggregation_period                             = each.value.aggregation_period
   aggregation_grace_period                       = each.value.aggregation_grace_period
-  kms_keyring                                    = var.use_aws ? "" : data.google_kms_key_ring.keyring[0].id
+  kms_keyring                                    = data.terraform_remote_state.cluster_bootstrap.outputs.google_kms_key_ring_id
   pushgateway                                    = var.pushgateway
   workflow_manager_image                         = var.workflow_manager_image
   workflow_manager_version                       = var.workflow_manager_version


### PR DESCRIPTION
This builds on PR #1295. We want to be able to destroy and create infrastructure for development or staging purposes, but currently we always use the same KMS keyring name, and keyrings cannot be deleted. This will add a randomized component to our interpolated keyring names, while leaving any keyrings with old names untouched, and pass the keyring name/ID from the cluster_bootstrap stage to the next stage.

I'll follow up with Terraform plans from a clean run on my development environment in a comment.