### PR TITLE
Update key-rotator & workflow-manager to Go 1.17.7.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,20 @@
 version: 2
 
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/deploy-tool"
-    schedule:
-      interval: "weekly"
   - package-ecosystem: "cargo"
     directory: "/facilitator"
     schedule:
       interval: "weekly"
   - package-ecosystem: "docker"
     directory: "/facilitator"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/key-rotator"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/key-rotator"
     schedule:
       interval: "weekly"
   - package-ecosystem: "terraform"
@@ -27,9 +31,5 @@ updates:
       interval: "weekly"
   - package-ecosystem: "docker"
     directory: "/workflow-manager"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "gomod"
-    directory: "/task-replayer"
     schedule:
       interval: "weekly"

--- a/key-rotator/Dockerfile
+++ b/key-rotator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.3 as builder
+FROM golang:1.17.7 as builder
 
 # Copy go modules first, to allow module download to be cached.
 WORKDIR /workspace

--- a/workflow-manager/Dockerfile
+++ b/workflow-manager/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.6 as builder
+FROM golang:1.17.7 as builder
 # set GOPATH to empty since we're building with modules.
 ENV GOPATH=
 WORKDIR /workspace/


### PR DESCRIPTION
Also, update dependabot configuration to automatically update
key-rotator dependencies, and drop a few directories that no longer
exist.