### PR TITLE
Trivial cleanup: drop localities_with_sample_maker.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -88,21 +88,20 @@ variable "test_peer_environment" {
   type = object({
     env_with_ingestor            = string
     env_without_ingestor         = string
-    localities_with_sample_maker = list(string)
   })
   default = {
     env_with_ingestor            = ""
     env_without_ingestor         = ""
-    localities_with_sample_maker = []
   }
   description = <<DESCRIPTION
 Describes a pair of data share processor environments set up to test against
-each other. One environment, named in "env_with_ingestor", hosts a fake
-ingestion servers, but only for the localities enumerated in
-"localities_with_sample_makers", which should be a subset of the ones in
-"localities". The other environment, named in "env_without_ingestor", has no
-fake ingestion servers. This variable should not be specified in production
-deployments.
+each other. One environment, named in "env_with_ingestor", hosts fake
+ingestion servers writing ingestion batches to both environments, as well as
+validators that check that the eventual sums match the data in the ingestion
+batches. The other environment, named in "env_without_ingestor", has no fake
+ingestion servers or validators.
+
+This variable should not be specified in production deployments.
 DESCRIPTION
 }
 

--- a/terraform/variables/staging-facil.tfvars
+++ b/terraform/variables/staging-facil.tfvars
@@ -67,7 +67,6 @@ cluster_settings = {
 test_peer_environment = {
   env_with_ingestor            = "staging-facil"
   env_without_ingestor         = "staging-pha"
-  localities_with_sample_maker = ["narnia", "gondor"]
 }
 is_first                 = false
 use_aws                  = false

--- a/terraform/variables/staging-pha.tfvars
+++ b/terraform/variables/staging-pha.tfvars
@@ -67,7 +67,6 @@ cluster_settings = {
 test_peer_environment = {
   env_with_ingestor            = "staging-facil"
   env_without_ingestor         = "staging-pha"
-  localities_with_sample_maker = ["narnia", "gondor"]
 }
 is_first                 = true
 use_aws                  = true


### PR DESCRIPTION
This isn't actually used anywhere -- all localities will include a
sample maker (and I think that's what we want).