### PR TITLE
terraform: bring all envs to 0.6.24 containers

### DIFF
--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -89,9 +89,9 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-facilitator_version      = "0.6.22"
-workflow_manager_version = "0.6.22"
-key_rotator_version      = "0.6.22"
+facilitator_version      = "0.6.24"
+workflow_manager_version = "0.6.24"
+key_rotator_version      = "0.6.24"
 victorops_routing_key    = "prio-prod-intl"
 
 default_aggregation_period       = "8h"

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -222,9 +222,9 @@ is_first                                  = false
 use_aws                                   = false
 default_aggregation_period                = "8h"
 default_aggregation_grace_period          = "4h"
-workflow_manager_version                  = "0.6.21"
-facilitator_version                       = "0.6.21"
-key_rotator_version                       = "0.6.21"
+workflow_manager_version                  = "0.6.24"
+facilitator_version                       = "0.6.24"
+key_rotator_version                       = "0.6.24"
 prometheus_server_persistent_disk_size_gb = 1000
 victorops_routing_key                     = "prio-prod-us"
 

--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -39,9 +39,9 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-workflow_manager_version = "0.6.22"
-facilitator_version      = "0.6.22"
-key_rotator_version      = "0.6.22"
+workflow_manager_version = "0.6.24"
+facilitator_version      = "0.6.24"
+key_rotator_version      = "0.6.24"
 victorops_routing_key    = "prio-staging"
 
 default_aggregation_period       = "30m"

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -66,7 +66,7 @@ cluster_settings = {
   min_node_count     = 1
   max_node_count     = 3
   gcp_machine_type   = "e2-standard-2"
-  aws_machine_types  = []
+  aws_machine_types  = ["t3.medium"]
 }
 test_peer_environment = {
   env_with_ingestor    = "stg-us-facil"


### PR DESCRIPTION
Also specifies a machine type for VMs in the `stg-us-pha` env.