### PR TITLE
terraform: deploy 0.6.25 containers to staging

### DIFF
--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -44,9 +44,9 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-workflow_manager_version = "0.6.24"
-facilitator_version      = "0.6.24"
-key_rotator_version      = "0.6.24"
+workflow_manager_version = "0.6.25"
+facilitator_version      = "0.6.25"
+key_rotator_version      = "0.6.25"
 victorops_routing_key    = "prio-staging"
 
 default_aggregation_period       = "30m"

--- a/terraform/variables/stg-us-facil.tfvars
+++ b/terraform/variables/stg-us-facil.tfvars
@@ -74,9 +74,9 @@ test_peer_environment = {
 }
 is_first                 = false
 use_aws                  = false
-workflow_manager_version = "0.6.24"
-facilitator_version      = "0.6.24"
-key_rotator_version      = "0.6.24"
+workflow_manager_version = "0.6.25"
+facilitator_version      = "0.6.25"
+key_rotator_version      = "0.6.25"
 victorops_routing_key    = "prio-staging"
 
 intake_max_age             = "75m"

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -79,9 +79,9 @@ test_peer_environment = {
 }
 is_first                 = true
 use_aws                  = true
-workflow_manager_version = "0.6.24"
-facilitator_version      = "0.6.24"
-key_rotator_version      = "0.6.24"
+workflow_manager_version = "0.6.25"
+facilitator_version      = "0.6.25"
+key_rotator_version      = "0.6.25"
 victorops_routing_key    = "prio-staging"
 
 intake_max_age             = "75m"


### PR DESCRIPTION
Deploys 0.6.25 containers to `stg-us-pha`, `stg-us-facil` and
`staging-intl`.

Part of #1373