### PR TITLE
terraform: Fix prometheus-alertmanager updates

### DIFF
--- a/terraform/modules/monitoring/monitoring.tf
+++ b/terraform/modules/monitoring/monitoring.tf
@@ -281,6 +281,10 @@ resource "helm_release" "prometheus" {
     name  = "server.strategy.type"
     value = "Recreate"
   }
+  set {
+    name  = "alertmanager.strategy.type"
+    value = "Recreate"
+  }
 
   # Alerting rules are defined in their own YAML file. We then need to provide
   # them to the Helm chart, under the key serverFiles."alerting_rules.yml".


### PR DESCRIPTION
The prometheus-alertmanager deployment should use the Recreate update strategy, just as prometheus-server does, because its
PersistentVolumeClaim cannot be mounted by pods on two different nodes during a rolling update if it is backed by EBS.

Fixes #1375