### PR TITLE
facilitator: structured error handling

### DIFF
--- a/facilitator/Cargo.lock
+++ b/facilitator/Cargo.lock
@@ -666,6 +666,7 @@ dependencies = [
  "rusoto_core",
  "rusoto_mock",
  "rusoto_s3",
+ "rusoto_sns",
  "rusoto_sqs",
  "rusoto_sts",
  "serde",
@@ -1898,6 +1899,20 @@ dependencies = [
  "serde",
  "sha2 0.9.8",
  "tokio",
+]
+
+[[package]]
+name = "rusoto_sns"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0bea954002f259d138d87c6b79e0bc02517e8edb31175ac006ad79ce946377"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "rusoto_core",
+ "serde_urlencoded",
+ "xml-rs",
 ]
 
 [[package]]

--- a/facilitator/Cargo.toml
+++ b/facilitator/Cargo.toml
@@ -36,6 +36,7 @@ regex = "^1.5.4"
 ring = { version = "0.16.20", features = ["std"] }
 rusoto_core = { version = "^0.47", default_features = false, features = ["rustls"] }
 rusoto_s3 = { version = "^0.47", default_features = false, features = ["rustls"] }
+rusoto_sns = { version = "^0.47", default_features = false, features = ["rustls"] }
 rusoto_sqs = { version = "^0.47", default_features = false, features = ["rustls"] }
 rusoto_sts = { version = "^0.47", default_features = false, features = ["rustls"] }
 sha2 = "0.10"

--- a/facilitator/src/aggregation.rs
+++ b/facilitator/src/aggregation.rs
@@ -127,7 +127,8 @@ impl<'a> BatchAggregator<'a> {
                 self.trace_id,
                 &self.logger,
             )
-            .read(&self.ingestion_transport.transport.batch_signing_public_keys)?;
+            .read(&self.ingestion_transport.transport.batch_signing_public_keys)
+            .map_err(|e| Error::AnyhowError(e.into()))?;
             let mut peer_validation_batch_reader = BatchReader::new(
                 Batch::new_validation(self.aggregation_name, batch_id, batch_date, !self.is_first),
                 &*self.peer_validation_transport.transport,
@@ -140,7 +141,8 @@ impl<'a> BatchAggregator<'a> {
                     .set_metrics_collector(&collector.peer_validation_batches_reader_metrics);
             }
             let (peer_validation_hdr, peer_validation_packets) = peer_validation_batch_reader
-                .read(&self.peer_validation_transport.batch_signing_public_keys)?;
+                .read(&self.peer_validation_transport.batch_signing_public_keys)
+                .map_err(|e| Error::AnyhowError(e.into()))?;
 
             if servers.is_none() {
                 // Ideally, we would use the encryption_key_id in the ingestion packet
@@ -241,7 +243,7 @@ impl<'a> BatchAggregator<'a> {
                 },
                 invalid_uuids.into_iter().map(|u| InvalidPacket { uuid: u }),
             )
-            .map_err(Error::AnyhowError)
+            .map_err(|e| Error::AnyhowError(e.into()))
     }
 
     /// Aggregate the batch for the provided batch_id into the provided server.

--- a/facilitator/src/aggregation.rs
+++ b/facilitator/src/aggregation.rs
@@ -285,7 +285,7 @@ impl<'a> BatchAggregator<'a> {
             match ingestion_packet.generate_validation_packet(servers) {
                 Ok(p) => ingestion_and_own_validation_packets.push((ingestion_packet, p)),
                 Err(e) => {
-                    if let IntakeError::PacketDecryptionError(packet_uuid) = e {
+                    if let IntakeError::PacketDecryption(packet_uuid) = e {
                         // This ingestion batch contains a packet that can't be
                         // decrypted. Ignore the entire ingestion batch, on the
                         // assumption that our peer will do the same, since we

--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -7,10 +7,10 @@ use crate::{
     metrics::ApiClientMetricsCollector,
     retries,
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::{prelude::Utc, DateTime};
-use hmac::{Hmac, Mac};
+use hmac::{digest::InvalidLength, Hmac, Mac};
 use http::header::{HeaderMap, HeaderName};
 use rusoto_core::{
     credential::{
@@ -21,6 +21,7 @@ use rusoto_core::{
         error::XmlErrorDeserializer,
         util::{find_start_element, XmlResponse},
     },
+    region::ParseRegionError,
     Region, RusotoError, RusotoResult,
 };
 #[cfg(test)]
@@ -611,6 +612,31 @@ fn retryable<T>(error: &RusotoError<T>) -> bool {
     }
 }
 
+/// Errors encountered when creating a sts:GetCallerIdentity token.
+#[derive(Debug, thiserror::Error)]
+pub enum StsError {
+    #[error("no security token in AWS credentials")]
+    MissingAccessToken,
+    #[error("no host in provided URL {0}")]
+    MissingHost(Url),
+    #[error("no query params in request URL")]
+    MissingQuery,
+    #[error("failed to parse host as header value")]
+    BadHeaderHost,
+    #[error("failed to parse formatted date as header value")]
+    BadHeaderDate,
+    #[error("failed to parse Amazon security token as header value")]
+    BadHeaderToken,
+    #[error("failed to parse workload identity pool provider as header value")]
+    BadHeaderTarget,
+    #[error(transparent)]
+    ParseRegion(#[from] ParseRegionError),
+    #[error("failed to construct AWS request signing key: {0}")]
+    KeyConstruction(InvalidLength),
+    #[error("failed to construct HMAC from signing key: {0}")]
+    HmacConstruction(InvalidLength),
+}
+
 /// Construct a GetCallerIdentity token, as specified in GCP's workload identity
 /// pool guide. This entails constructing a signed sts:GetCallerIdentity AWS API
 /// request, using the form that has no body (sts.googleapis.com will reject the
@@ -644,7 +670,7 @@ pub(crate) fn get_caller_identity_token(
     workload_identity_pool_provider: &str,
     aws_region: &Region,
     credentials: &AwsCredentials,
-) -> Result<serde_json::Value> {
+) -> Result<serde_json::Value, StsError> {
     get_caller_identity_token_at_time(
         Utc::now(),
         sts_request_url,
@@ -660,7 +686,7 @@ fn get_caller_identity_token_at_time(
     workload_identity_pool_provider: &str,
     aws_region: &Region,
     credentials: &AwsCredentials,
-) -> Result<serde_json::Value> {
+) -> Result<serde_json::Value, StsError> {
     // Rusoto provides a SignedRequest struct that can construct and sign
     // correct sts:GetCallerIdentity requests, but unfortunately it insists on
     // using the form with a body, which sts.googleapis.com rejects. Instead we
@@ -671,10 +697,10 @@ fn get_caller_identity_token_at_time(
     let aws_security_token = credentials
         .token()
         .as_ref()
-        .ok_or_else(|| anyhow!("no security token in AWS credentials"))?;
+        .ok_or(StsError::MissingAccessToken)?;
     let host = sts_request_url
         .host_str()
-        .ok_or_else(|| anyhow!("no host in provided URL {}", sts_request_url))?;
+        .ok_or_else(|| StsError::MissingHost(sts_request_url.clone()))?;
     let request_time_long = request_time.format(LONG_DATETIME).to_string();
 
     // Construct the headers that we will sign over. Arbitrary headers may be
@@ -683,8 +709,7 @@ fn get_caller_identity_token_at_time(
     let mut headers = HeaderMap::new();
     headers.insert(
         HeaderName::from_static(HOST_HEADER),
-        host.parse()
-            .context("failed to parse host as header value")?,
+        host.parse().map_err(|_| StsError::BadHeaderHost)?,
     );
     headers.insert(
         HeaderName::from_static(AMAZON_DATE_HEADER),
@@ -692,19 +717,19 @@ fn get_caller_identity_token_at_time(
             .format(LONG_DATETIME)
             .to_string()
             .parse()
-            .context("failed to parse formatted date as header value")?,
+            .map_err(|_| StsError::BadHeaderDate)?,
     );
     headers.insert(
         HeaderName::from_static(AMAZON_SECURITY_TOKEN_HEADER),
         aws_security_token
             .parse()
-            .context("failed to parse Amazon security token as header value")?,
+            .map_err(|_| StsError::BadHeaderToken)?,
     );
     headers.insert(
         HeaderName::from_static(GOOGLE_TARGET_RESOURCE_HEADER),
         workload_identity_pool_provider
             .parse()
-            .context("failed to parse workload identity pool provider as header value")?,
+            .map_err(|_| StsError::BadHeaderTarget)?,
     );
 
     // Create a canonical signature v4 request.
@@ -715,7 +740,7 @@ fn get_caller_identity_token_at_time(
     let canonical_request = format!(
         "POST\n{uri}\n{query_string}\n{headers}\n\n{signed}\ne3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         uri = sts_request_url.path(),
-        query_string = sts_request_url.query().ok_or_else(|| anyhow!("no query params in request URL"))?,
+        query_string = sts_request_url.query().ok_or(StsError::MissingQuery)?,
         headers = canonical_header_string(&headers),
         signed = signed_header_string(&headers),
     );
@@ -739,17 +764,14 @@ fn get_caller_identity_token_at_time(
     let signing_key = signing_key(
         &request_time,
         credentials.aws_secret_access_key(),
-        &aws_region
-            .name()
-            .parse()
-            .context("failed to parse AWS region")?,
+        &aws_region.name().parse()?,
         "sts",
     )
-    .context("failed to construct AWS request signing key")?;
+    .map_err(StsError::KeyConstruction)?;
 
     // "Sign" (HMAC) the string to sign
-    let mut hmac: Hmac<Sha256> = Hmac::new_from_slice(&signing_key)
-        .map_err(|e| anyhow!("failed to construct HMAC from signing key: {}", e))?;
+    let mut hmac: Hmac<Sha256> =
+        Hmac::new_from_slice(&signing_key).map_err(StsError::HmacConstruction)?;
     hmac.update(string_to_sign.as_bytes());
     let signature = hex::encode(hmac.finalize().into_bytes());
 
@@ -827,20 +849,17 @@ pub fn signing_key(
     secret_key: &str,
     region: &Region,
     service: &str,
-) -> Result<Vec<u8>> {
+) -> Result<Vec<u8>, InvalidLength> {
     let secret = format!("AWS4{}", secret_key);
-    let mut date_hmac: Hmac<Sha256> =
-        Hmac::new_from_slice(secret.as_bytes()).map_err(|e| anyhow! {"{}",e})?;
+    let mut date_hmac: Hmac<Sha256> = Hmac::new_from_slice(secret.as_bytes())?;
     date_hmac.update(datetime.format(SHORT_DATE).to_string().as_bytes());
-    let mut region_hmac: Hmac<Sha256> =
-        Hmac::new_from_slice(&date_hmac.finalize().into_bytes()).map_err(|e| anyhow! {"{}",e})?;
+    let mut region_hmac: Hmac<Sha256> = Hmac::new_from_slice(&date_hmac.finalize().into_bytes())?;
     region_hmac.update(region.name().as_bytes());
     let mut service_hmac: Hmac<Sha256> =
-        Hmac::new_from_slice(&region_hmac.finalize().into_bytes()).map_err(|e| anyhow! {"{}",e})?;
+        Hmac::new_from_slice(&region_hmac.finalize().into_bytes())?;
     service_hmac.update(service.as_bytes());
     let mut signing_hmac: Hmac<Sha256> =
-        Hmac::new_from_slice(&service_hmac.finalize().into_bytes())
-            .map_err(|e| anyhow! {"{}",e})?;
+        Hmac::new_from_slice(&service_hmac.finalize().into_bytes())?;
     signing_hmac.update(b"aws4_request");
     Ok(signing_hmac.finalize().into_bytes().to_vec())
 }

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -4,8 +4,8 @@ use crate::{
         IngestionHeader, InvalidPacket, Packet, SumPart, ValidationHeader, ValidationPacket,
     },
     metrics::BatchReaderMetricsCollector,
-    transport::{Transport, TransportWriter},
-    BatchSigningKey, DigestWriter, Error, DATE_FORMAT,
+    transport::{Transport, TransportError, TransportWriter},
+    BatchSigningKey, DigestWriter, DATE_FORMAT,
 };
 use anyhow::{anyhow, Context, Result};
 use avro_rs::{Reader, Writer};
@@ -222,10 +222,8 @@ impl<'a, H: Header, P: Packet> BatchReader<'a, H, P> {
                         // empty when we check the digest below, so this won't
                         // let someone get away with something sneaky by
                         // deleting a packet file.
-                        if let Some(lib_err) = err.downcast_ref::<Error>() {
-                            if !matches!(lib_err, Error::ObjectNotFoundError(_, _)) {
-                                packet_get_result?;
-                            }
+                        if let TransportError::ObjectNotFoundError(_, _) = &err {
+                            packet_get_result?;
                         };
                     }
                 }

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -222,7 +222,7 @@ impl<'a, H: Header, P: Packet> BatchReader<'a, H, P> {
                         // empty when we check the digest below, so this won't
                         // let someone get away with something sneaky by
                         // deleting a packet file.
-                        if let TransportError::ObjectNotFoundError(_, _) = &err {
+                        if !matches!(&err, TransportError::ObjectNotFoundError(_, _)) {
                             packet_get_result?;
                         };
                     }

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -145,9 +145,9 @@ impl Display for BatchFileKind {
 /// Errors that may occur when reading a batch.
 #[derive(Debug, thiserror::Error)]
 pub enum BatchReadError {
-    #[error("failed to get {1} from transport: {0}")]
+    #[error("failed to get {1} file from transport: {0}")]
     Transport(Box<TransportError>, BatchFileKind),
-    #[error("failed to read {1} from transport: {0}")]
+    #[error("failed to read {1} file from transport: {0}")]
     Io(io::Error, BatchFileKind),
     #[error(transparent)]
     Idl(#[from] IdlError),

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -47,7 +47,7 @@ use facilitator::{
         GcsTransport, LocalFileTransport, S3Transport, SignableTransport, Transport,
         VerifiableAndDecryptableTransport, VerifiableTransport,
     },
-    BatchSigningKey, Error, DATE_FORMAT,
+    BatchSigningKey, Error, ErrorClassification, DATE_FORMAT,
 };
 
 fn num_validator<F: FromStr>(s: String) -> Result<(), String> {

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -1996,7 +1996,8 @@ where
         &mut peer_validation_transport,
         &mut aggregation_transport,
         logger,
-    )?;
+    )
+    .map_err(|e| Error::AnyhowError(e.into()))?;
 
     if let Some(collector) = metrics_collector {
         aggregator.set_metrics_collector(collector);
@@ -2021,7 +2022,7 @@ where
         }
     }
 
-    result
+    result.map_err(|e| Error::AnyhowError(e.into()))
 }
 
 fn aggregate_subcommand(

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -1579,7 +1579,8 @@ fn validate_sample(
         trace_id,
         logger,
     )
-    .read(pha_pubkey_map)?;
+    .read(pha_pubkey_map)
+    .map_err(|e| Error::AnyhowError(e.into()))?;
 
     let (facilitator_sum_part, _) = BatchReader::new(
         Batch::new_sum(
@@ -1594,7 +1595,8 @@ fn validate_sample(
         trace_id,
         logger,
     )
-    .read(facilitator_pubkey_map)?;
+    .read(facilitator_pubkey_map)
+    .map_err(|e| Error::AnyhowError(e.into()))?;
 
     let pha_accumulated_share: Vec<FieldPriov2> = pha_sum_part
         .sum
@@ -1741,7 +1743,7 @@ where
         }
     }
 
-    result
+    Ok(result?)
 }
 
 fn intake_batch_subcommand(

--- a/facilitator/src/config.rs
+++ b/facilitator/src/config.rs
@@ -64,10 +64,6 @@ impl Identity {
     pub fn is_some(&self) -> bool {
         self.inner.is_some()
     }
-
-    pub(crate) fn is_none(&self) -> bool {
-        self.inner.is_none()
-    }
 }
 
 /// Parameters necessary to configure federation from AWS IAM to GCP IAM using
@@ -391,7 +387,7 @@ mod tests {
 
     #[test]
     fn identity() {
-        assert!(Identity::from_str("").unwrap().is_none());
+        assert!(Identity::from_str("").unwrap().as_str().is_none());
 
         assert_eq!(
             Identity::from_str("identity").unwrap().as_str(),

--- a/facilitator/src/http.rs
+++ b/facilitator/src/http.rs
@@ -100,8 +100,7 @@ impl RetryingAgent {
 
     /// Prepares a request for the given `Url` and `Method`. Returns a
     /// `ureq::Request`. The caller may customize this request further
-    /// before sending it. No access token is used. Note that this
-    /// method is infalliable.
+    /// before sending it. No access token is used.
     pub(crate) fn prepare_anonymous_request(&self, url: Url, method: Method) -> Request {
         self.agent.request_url(method.to_primitive_string(), &url)
     }

--- a/facilitator/src/idl.rs
+++ b/facilitator/src/idl.rs
@@ -662,7 +662,7 @@ impl IngestionDataSharePacket {
         }
         // If we arrive here, this packet could not be decrypted by any key we have.
         // All we can do is report this to the caller.
-        Err(IntakeError::PacketDecryptionError(self.uuid))
+        Err(IntakeError::PacketDecryption(self.uuid))
     }
 }
 

--- a/facilitator/src/idl.rs
+++ b/facilitator/src/idl.rs
@@ -1,7 +1,7 @@
 use crate::{intake::IntakeError, ErrorClassification};
 use avro_rs::{
     from_value,
-    types::{Record, Value, ValueKind},
+    types::{Record, Value},
     Reader, Schema, Writer,
 };
 use lazy_static::lazy_static;
@@ -12,7 +12,6 @@ use prio::{
 use serde::{Deserialize, Serialize};
 use std::{
     convert::TryFrom,
-    fmt::Display,
     io::{Read, Write},
     num::TryFromIntError,
 };
@@ -57,112 +56,21 @@ lazy_static! {
     static ref INVALID_PACKET_SCHEMA: &'static Schema = &_SCHEMAS[6];
 }
 
-/// Provides additional information on what kind of Avro-related operation raised an error.
-#[derive(Debug)]
-pub enum AvroErrorContext {
-    /// Error while constructing a `Reader`, and reading the Avro header.
-    ReadHeader,
-    /// Error while reading a record.
-    ReadRecord,
-    /// Error while writing a record out to a `Writer`.
-    Append,
-    /// Error while flushing a `Writer`.
-    Flush,
-    /// Error while deserializing from a `Value` to an application-specific data model.
-    Deserialization,
-}
-
-impl Display for AvroErrorContext {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            AvroErrorContext::ReadHeader => write!(f, "reading avro header"),
-            AvroErrorContext::ReadRecord => write!(f, "reading record"),
-            AvroErrorContext::Append => write!(f, "writing"),
-            AvroErrorContext::Flush => write!(f, "flushing"),
-            AvroErrorContext::Deserialization => write!(f, "deserializing"),
-        }
-    }
-}
-
-/// Identifies which application-level validation rule resulted in a malformed header error.
-#[derive(Debug)]
-pub enum MalformedHeaderCause {
-    /// The `batch_header_signature` field was missing.
-    MissingBatchHeaderSignature,
-    /// The `key_identifier` field was missing.
-    MissingKeyIdentifier,
-    /// The `hamming_weight` union contained a value of an invalid type.
-    HammingWeightWrongType(ValueKind),
-    /// There was an extra field in the header record (or a field of the wrong type).
-    ExtraField(String, ValueKind),
-    /// A required field was missing from the header record.
-    MissingField,
-    /// The `sum` array field contained a value of an invalid type.
-    SumArrayElementWrongType(ValueKind),
-    /// The `batch_uuids` array field contained a value of an invalid type.
-    BatchUuidsElementWrongType(ValueKind),
-}
-
-impl Display for MalformedHeaderCause {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            MalformedHeaderCause::MissingBatchHeaderSignature => {
-                write!(f, "missing batch_header_signature")
-            }
-            MalformedHeaderCause::MissingKeyIdentifier => write!(f, "missing key_identifier"),
-            MalformedHeaderCause::HammingWeightWrongType(value_kind) => {
-                write!(f, "unexpected value {:?} for hamming weight", value_kind)
-            }
-            MalformedHeaderCause::ExtraField(name, value_kind) => {
-                write!(f, "unexpected field {} -> {:?} in record", name, value_kind)
-            }
-            MalformedHeaderCause::MissingField => write!(f, "missing field(s) in record"),
-            MalformedHeaderCause::SumArrayElementWrongType(value_kind) => {
-                write!(f, "unexpected value in sum array {:?}", value_kind)
-            }
-            MalformedHeaderCause::BatchUuidsElementWrongType(value_kind) => {
-                write!(f, "unexpected value in batch_uuids array {:?}", value_kind)
-            }
-        }
-    }
-}
-
-/// Identifies which application-level validation rule resulted in a malformed data packet error.
-#[derive(Debug)]
-pub enum MalformedPacketCause {
-    /// The `uuid` field was missing from the data packet record.
-    MissingUuid,
-    /// The `encrypted_payload` field was missing from the data packet record.
-    MissingEncryptedPayload,
-    /// The `r_pit` field was missing from the data packet record.
-    MissingRPit,
-}
-
-impl Display for MalformedPacketCause {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            MalformedPacketCause::MissingUuid => write!(f, "missing uuid"),
-            MalformedPacketCause::MissingEncryptedPayload => write!(f, "missing encrypted_payload"),
-            MalformedPacketCause::MissingRPit => write!(f, "missing r_pit"),
-        }
-    }
-}
-
 /// Errors related to the ENPA IDL layer, including Avro decoding, required headers, etc.
 #[derive(Debug, thiserror::Error)]
 pub enum IdlError {
     /// Parsing or I/O error from the Avro library.
     #[error("avro error upon {1}: {0}")]
-    Avro(avro_rs::Error, AvroErrorContext),
+    Avro(avro_rs::Error, &'static str),
     /// A record was expected in the Avro file, but the end of the file was found first.
     #[error("end of file")]
     Eof,
     /// A header could not be parsed, due to missing record fields or record fields of the wrong type.
     #[error("malformed header: {0}")]
-    MalformedHeader(MalformedHeaderCause),
+    MalformedHeader(String),
     /// A data packet could not be parsed, due to missing record fields.
     #[error("malformed data packet: {0}")]
-    MalformedPacket(MalformedPacketCause),
+    MalformedPacket(&'static str),
     /// Unexpected extra values were found in an Avro file.
     #[error("excess value")]
     ExtraData,
@@ -233,13 +141,13 @@ impl BatchSignature {
     /// instance.
     pub fn read<R: Read>(reader: R) -> Result<BatchSignature, IdlError> {
         let mut reader = Reader::with_schema(*BATCH_SIGNATURE_SCHEMA, reader)
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::ReadHeader))?;
+            .map_err(|e| IdlError::Avro(e, "reading avro header"))?;
 
         // We expect exactly one record and for it to be an ingestion signature
         let value = match reader.next() {
             Some(Ok(value)) => value,
             Some(Err(e)) => {
-                return Err(IdlError::Avro(e, AvroErrorContext::ReadRecord));
+                return Err(IdlError::Avro(e, "reading record"));
             }
             None => return Err(IdlError::Eof),
         };
@@ -256,11 +164,9 @@ impl BatchSignature {
         let mut writer = Writer::new(*BATCH_SIGNATURE_SCHEMA, writer);
         writer
             .append(self.clone())
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::Append))?;
+            .map_err(|e| IdlError::Avro(e, "writing"))?;
 
-        writer
-            .flush()
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::Flush))?;
+        writer.flush().map_err(|e| IdlError::Avro(e, "flushing"))?;
 
         Ok(())
     }
@@ -305,12 +211,11 @@ impl TryFrom<Value> for BatchSignature {
         }
 
         Ok(BatchSignature {
-            batch_header_signature: batch_header_signature.ok_or(IdlError::MalformedHeader(
-                MalformedHeaderCause::MissingBatchHeaderSignature,
-            ))?,
-            key_identifier: key_identifier.ok_or(IdlError::MalformedHeader(
-                MalformedHeaderCause::MissingKeyIdentifier,
-            ))?,
+            batch_header_signature: batch_header_signature.ok_or_else(|| {
+                IdlError::MalformedHeader("missing batch_header_signature".to_owned())
+            })?,
+            key_identifier: key_identifier
+                .ok_or_else(|| IdlError::MalformedHeader("missing key_identifier".to_owned()))?,
             batch_header_bytes,
             packet_bytes,
         })
@@ -385,7 +290,7 @@ impl Header for IngestionHeader {
 
     fn read<R: Read>(reader: R) -> Result<IngestionHeader, IdlError> {
         let mut reader = Reader::with_schema(*INGESTION_HEADER_SCHEMA, reader)
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::ReadHeader))?;
+            .map_err(|e| IdlError::Avro(e, "reading avro header"))?;
 
         // We expect exactly one record in the reader and for it to be an ingestion header
         let record = match reader.next() {
@@ -393,7 +298,7 @@ impl Header for IngestionHeader {
             Some(Ok(_)) => {
                 return Err(IdlError::WrongValueType);
             }
-            Some(Err(e)) => return Err(IdlError::Avro(e, AvroErrorContext::ReadRecord)),
+            Some(Err(e)) => return Err(IdlError::Avro(e, "reading record")),
             None => return Err(IdlError::Eof),
         };
         if reader.next().is_some() {
@@ -428,9 +333,10 @@ impl Header for IngestionHeader {
                         Value::Int(v) => Some(v),
                         Value::Null => None,
                         v => {
-                            return Err(IdlError::MalformedHeader(
-                                MalformedHeaderCause::HammingWeightWrongType(v.into()),
-                            ));
+                            return Err(IdlError::MalformedHeader(format!(
+                                "unexpected value {:?} for hamming weight",
+                                v
+                            )));
                         }
                     }
                 }
@@ -438,9 +344,9 @@ impl Header for IngestionHeader {
                 ("batch_end_time", Value::TimestampMillis(v)) => batch_end_time = Some(v),
                 ("packet_file_digest", Value::Bytes(v)) => packet_file_digest = Some(v),
                 (f, v) => {
-                    return Err(IdlError::MalformedHeader(MalformedHeaderCause::ExtraField(
-                        f.to_owned(),
-                        v.into(),
+                    return Err(IdlError::MalformedHeader(format!(
+                        "unexpected field {} -> {:?} in record",
+                        f, v
                     )))
                 }
             }
@@ -457,7 +363,7 @@ impl Header for IngestionHeader {
             || packet_file_digest.is_none()
         {
             return Err(IdlError::MalformedHeader(
-                MalformedHeaderCause::MissingField,
+                "missing field(s) in record".to_owned(),
             ));
         }
 
@@ -516,11 +422,9 @@ impl Header for IngestionHeader {
 
         writer
             .append(record)
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::Append))?;
+            .map_err(|e| IdlError::Avro(e, "writing"))?;
 
-        writer
-            .flush()
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::Flush))?;
+        writer.flush().map_err(|e| IdlError::Avro(e, "flushing"))?;
 
         Ok(())
     }
@@ -585,7 +489,7 @@ impl Packet for IngestionDataSharePacket {
 
         writer
             .append(record)
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::Append))?;
+            .map_err(|e| IdlError::Avro(e, "writing"))?;
 
         Ok(())
     }
@@ -635,12 +539,11 @@ impl TryFrom<Value> for IngestionDataSharePacket {
         }
 
         Ok(IngestionDataSharePacket {
-            uuid: uuid.ok_or(IdlError::MalformedPacket(MalformedPacketCause::MissingUuid))?,
-            encrypted_payload: encrypted_payload.ok_or(IdlError::MalformedPacket(
-                MalformedPacketCause::MissingEncryptedPayload,
-            ))?,
+            uuid: uuid.ok_or(IdlError::MalformedPacket("missing uuid"))?,
+            encrypted_payload: encrypted_payload
+                .ok_or(IdlError::MalformedPacket("missing encrypted_payload"))?,
             encryption_key_id,
-            r_pit: r_pit.ok_or(IdlError::MalformedPacket(MalformedPacketCause::MissingRPit))?,
+            r_pit: r_pit.ok_or(IdlError::MalformedPacket("missing r_pit"))?,
             version_configuration,
             device_nonce,
         })
@@ -723,7 +626,7 @@ impl Header for ValidationHeader {
 
     fn read<R: Read>(reader: R) -> Result<ValidationHeader, IdlError> {
         let mut reader = Reader::with_schema(*VALIDATION_HEADER_SCHEMA, reader)
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::ReadHeader))?;
+            .map_err(|e| IdlError::Avro(e, "reading avro header"))?;
 
         // We expect exactly one record in the reader and for it to be an ingestion header
         let record = match reader.next() {
@@ -731,7 +634,7 @@ impl Header for ValidationHeader {
             Some(Ok(_)) => {
                 return Err(IdlError::WrongValueType);
             }
-            Some(Err(e)) => return Err(IdlError::Avro(e, AvroErrorContext::ReadRecord)),
+            Some(Err(e)) => return Err(IdlError::Avro(e, "reading record")),
             None => return Err(IdlError::Eof),
         };
         if reader.next().is_some() {
@@ -764,17 +667,18 @@ impl Header for ValidationHeader {
                         Value::Int(v) => Some(v),
                         Value::Null => None,
                         v => {
-                            return Err(IdlError::MalformedHeader(
-                                MalformedHeaderCause::HammingWeightWrongType(v.into()),
-                            ));
+                            return Err(IdlError::MalformedHeader(format!(
+                                "unexpected value {:?} for hamming weight",
+                                v
+                            )));
                         }
                     }
                 }
                 ("packet_file_digest", Value::Bytes(v)) => packet_file_digest = Some(v),
                 (f, v) => {
-                    return Err(IdlError::MalformedHeader(MalformedHeaderCause::ExtraField(
-                        f.to_owned(),
-                        v.into(),
+                    return Err(IdlError::MalformedHeader(format!(
+                        "unexpected field {} -> {:?} in record",
+                        f, v
                     )))
                 }
             }
@@ -789,7 +693,7 @@ impl Header for ValidationHeader {
             || packet_file_digest.is_none()
         {
             return Err(IdlError::MalformedHeader(
-                MalformedHeaderCause::MissingField,
+                "missing field(s) in record".to_owned(),
             ));
         }
 
@@ -834,11 +738,9 @@ impl Header for ValidationHeader {
 
         writer
             .append(record)
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::Append))?;
+            .map_err(|e| IdlError::Avro(e, "writing"))?;
 
-        writer
-            .flush()
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::Flush))?;
+        writer.flush().map_err(|e| IdlError::Avro(e, "flushing"))?;
 
         Ok(())
     }
@@ -878,7 +780,7 @@ impl Packet for ValidationPacket {
 
         writer
             .append(record)
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::Append))?;
+            .map_err(|e| IdlError::Avro(e, "writing"))?;
 
         Ok(())
     }
@@ -888,7 +790,7 @@ impl TryFrom<Value> for ValidationPacket {
     type Error = IdlError;
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
-        from_value(&value).map_err(|e| IdlError::Avro(e, AvroErrorContext::Deserialization))
+        from_value(&value).map_err(|e| IdlError::Avro(e, "deserializing"))
     }
 }
 
@@ -940,7 +842,7 @@ impl Header for SumPart {
 
     fn read<R: Read>(reader: R) -> Result<SumPart, IdlError> {
         let mut reader = Reader::with_schema(*SUM_PART_SCHEMA, reader)
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::ReadHeader))?;
+            .map_err(|e| IdlError::Avro(e, "reading avro header"))?;
 
         // We expect exactly one record in the reader and for it to be a sum
         // part.
@@ -949,7 +851,7 @@ impl Header for SumPart {
             Some(Ok(_)) => {
                 return Err(IdlError::WrongValueType);
             }
-            Some(Err(e)) => return Err(IdlError::Avro(e, AvroErrorContext::ReadRecord)),
+            Some(Err(e)) => return Err(IdlError::Avro(e, "reading record")),
             None => return Err(IdlError::Eof),
         };
         if reader.next().is_some() {
@@ -979,11 +881,10 @@ impl Header for SumPart {
                                 if let Value::Uuid(u) = value {
                                     Ok(u)
                                 } else {
-                                    Err(IdlError::MalformedHeader(
-                                        MalformedHeaderCause::BatchUuidsElementWrongType(
-                                            value.into(),
-                                        ),
-                                    ))
+                                    Err(IdlError::MalformedHeader(format!(
+                                        "unexpected value in batch_uuids array {:?}",
+                                        value
+                                    )))
                                 }
                             })
                             .collect::<Result<Vec<_>, _>>()?,
@@ -999,9 +900,10 @@ impl Header for SumPart {
                         Value::Int(v) => Some(v),
                         Value::Null => None,
                         v => {
-                            return Err(IdlError::MalformedHeader(
-                                MalformedHeaderCause::HammingWeightWrongType(v.into()),
-                            ));
+                            return Err(IdlError::MalformedHeader(format!(
+                                "unexpected value {:?} for hamming weight",
+                                v
+                            )));
                         }
                     }
                 }
@@ -1013,11 +915,10 @@ impl Header for SumPart {
                                 if let Value::Long(l) = value {
                                     Ok(l)
                                 } else {
-                                    Err(IdlError::MalformedHeader(
-                                        MalformedHeaderCause::SumArrayElementWrongType(
-                                            value.into(),
-                                        ),
-                                    ))
+                                    Err(IdlError::MalformedHeader(format!(
+                                        "unexpected value in sum array {:?}",
+                                        value
+                                    )))
                                 }
                             })
                             .collect::<Result<Vec<_>, _>>()?,
@@ -1032,9 +933,9 @@ impl Header for SumPart {
                 ("packet_file_digest", Value::Bytes(v)) => packet_file_digest = Some(v),
                 ("total_individual_clients", Value::Long(v)) => total_individual_clients = Some(v),
                 (f, v) => {
-                    return Err(IdlError::MalformedHeader(MalformedHeaderCause::ExtraField(
-                        f.to_owned(),
-                        v.into(),
+                    return Err(IdlError::MalformedHeader(format!(
+                        "unexpected field {} -> {:?} in record",
+                        f, v
                     )))
                 }
             }
@@ -1052,7 +953,7 @@ impl Header for SumPart {
             || packet_file_digest.is_none()
         {
             return Err(IdlError::MalformedHeader(
-                MalformedHeaderCause::MissingField,
+                "missing field(s) in record".to_owned(),
             ));
         }
 
@@ -1124,11 +1025,9 @@ impl Header for SumPart {
 
         writer
             .append(record)
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::Append))?;
+            .map_err(|e| IdlError::Avro(e, "writing"))?;
 
-        writer
-            .flush()
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::Flush))?;
+        writer.flush().map_err(|e| IdlError::Avro(e, "flushing"))?;
 
         Ok(())
     }
@@ -1162,7 +1061,7 @@ impl Packet for InvalidPacket {
 
         writer
             .append(record)
-            .map_err(|e| IdlError::Avro(e, AvroErrorContext::Append))?;
+            .map_err(|e| IdlError::Avro(e, "writing"))?;
 
         Ok(())
     }
@@ -1172,7 +1071,7 @@ impl TryFrom<Value> for InvalidPacket {
     type Error = IdlError;
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
-        from_value(&value).map_err(|e| IdlError::Avro(e, AvroErrorContext::Deserialization))
+        from_value(&value).map_err(|e| IdlError::Avro(e, "deserializing"))
     }
 }
 

--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -25,7 +25,7 @@ pub enum IntakeError {
     #[error(transparent)]
     Idl(IdlError),
     #[error("packet decryption failure for packet {0}")]
-    PacketDecryptionError(Uuid),
+    PacketDecryption(Uuid),
     #[error("error generating verification message: {0}")]
     PrioVerification(prio::server::ServerError),
     #[error("error setting up Prio server: {0}")]
@@ -461,7 +461,7 @@ mod tests {
         .unwrap();
 
         let err = pha_ingestor.generate_validation_share(|_| {}).unwrap_err();
-        assert_matches!(err, Error::Intake(IntakeError::PacketDecryptionError(_)));
+        assert_matches!(err, Error::Intake(IntakeError::PacketDecryption(_)));
     }
 
     #[test]

--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -1,12 +1,14 @@
 use crate::{
     batch::{Batch, BatchReader, BatchWriter},
-    idl::{IngestionDataSharePacket, IngestionHeader, ValidationHeader, ValidationPacket},
+    idl::{
+        IdlError, IngestionDataSharePacket, IngestionHeader, ValidationHeader, ValidationPacket,
+    },
     logging::event,
     metrics::IntakeMetricsCollector,
     transport::{SignableTransport, VerifiableAndDecryptableTransport},
-    BatchSigningKey, DATE_FORMAT,
+    BatchSigningKey, Error, DATE_FORMAT,
 };
-use anyhow::{ensure, Context, Result};
+use anyhow::{anyhow, Result};
 use chrono::NaiveDateTime;
 use prio::{
     encrypt::{PrivateKey, PublicKey},
@@ -17,6 +19,18 @@ use ring::signature::UnparsedPublicKey;
 use slog::{debug, info, o, Logger};
 use std::{collections::HashMap, iter::Iterator};
 use uuid::Uuid;
+
+#[derive(Debug, thiserror::Error)]
+pub enum IntakeError {
+    #[error(transparent)]
+    Idl(IdlError),
+    #[error("packet decryption failure for packet {0}")]
+    PacketDecryptionError(Uuid),
+    #[error("error generating verification message: {0}")]
+    PrioVerification(prio::server::ServerError),
+    #[error("error setting up Prio server: {0}")]
+    PrioSetup(prio::server::ServerError),
+}
 
 /// BatchIntaker is responsible for validating a batch of data packet shares
 /// sent by the ingestion server and emitting validation shares to the other
@@ -115,7 +129,7 @@ impl<'a> BatchIntaker<'a> {
     /// and packet file, then computes validation shares and sends them to the
     /// peer share processor. The provided callback is invoked once for every
     /// thousand processed packets, unless set_callback_cadence has been called.
-    pub fn generate_validation_share<F>(&mut self, mut callback: F) -> Result<()>
+    pub fn generate_validation_share<F>(&mut self, mut callback: F) -> Result<(), Error>
     where
         F: FnMut(&Logger),
     {
@@ -123,11 +137,12 @@ impl<'a> BatchIntaker<'a> {
 
         let (ingestion_header, ingestion_packets) =
             self.intake_batch.read(self.intake_public_keys)?;
-        ensure!(
-            ingestion_header.bins > 0,
-            "invalid bin count {}",
-            ingestion_header.bins
-        );
+        if ingestion_header.bins <= 0 {
+            return Err(Error::AnyhowError(anyhow!(
+                "invalid bin count {}",
+                ingestion_header.bins
+            )));
+        }
 
         // Ideally, we would use the encryption_key_id in the ingestion packet
         // to figure out which private key to use for decryption, but that field
@@ -144,7 +159,7 @@ impl<'a> BatchIntaker<'a> {
                     PublicKey::from(k)
                 );
                 Server::new(ingestion_header.bins as usize, self.is_first, k.clone())
-                    .context("failed to construct Prio server")
+                    .map_err(IntakeError::PrioSetup)
             })
             .collect::<Result<_, _>>()?;
 
@@ -167,8 +182,7 @@ impl<'a> BatchIntaker<'a> {
                 processed_bytes += p.encrypted_payload.len() as u64;
                 p.generate_validation_packet(&mut servers)
             })
-            .collect::<Result<Vec<ValidationPacket>>>()
-            .context("couldn't generate validation packets")?;
+            .collect::<Result<Vec<ValidationPacket>, IntakeError>>()?;
 
         self.peer_validation_batch.write(
             self.peer_validation_batch_signing_key,
@@ -447,10 +461,7 @@ mod tests {
         .unwrap();
 
         let err = pha_ingestor.generate_validation_share(|_| {}).unwrap_err();
-        assert_matches!(
-            err.downcast_ref::<Error>(),
-            Some(Error::PacketDecryptionError(_))
-        );
+        assert_matches!(err, Error::Intake(IntakeError::PacketDecryptionError(_)));
     }
 
     #[test]
@@ -543,10 +554,10 @@ mod tests {
 
         let err = pha_ingestor.generate_validation_share(|_| {}).unwrap_err();
         assert_matches!(
-            err.downcast(),
-            Ok(ServerError::Serialize(
+            err,
+            Error::Intake(IntakeError::PrioVerification(ServerError::Serialize(
                 SerializeError::UnpackInputSizeMismatch
-            ))
+            )))
         );
     }
 }

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -46,6 +46,12 @@ pub enum Error {
     Aggregation(AggError),
 }
 
+impl Error {
+    pub fn is_retryable(&self) -> bool {
+        !matches!(self, Error::Intake(IntakeError::PacketDecryption(_)))
+    }
+}
+
 /// A wrapper-writer that computes a SHA256 digest over the content it is provided.
 pub struct DigestWriter<W: Write> {
     writer: W,

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -33,8 +33,6 @@ pub enum Error {
     AnyhowError(#[from] anyhow::Error),
     #[error("HTTP resource error: {0}")]
     HttpError(#[from] ureq::Error),
-    #[error("object {0} not found: {1}")]
-    ObjectNotFoundError(String, anyhow::Error),
     #[error("error parsing time: {0}")]
     TimeParse(#[from] chrono::ParseError),
     #[error("command line parsing error: {0}")]
@@ -47,6 +45,8 @@ pub enum Error {
     Aggregation(AggError),
     #[error(transparent)]
     Url(#[from] UrlParseError),
+    #[error("failed to deserialize JSON key file: {0}")]
+    BadKeyFile(serde_json::Error),
 }
 
 impl Error {

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -29,16 +29,6 @@ pub const DATE_FORMAT: &str = "%Y/%m/%d/%H/%M";
 pub enum Error {
     #[error(transparent)]
     AnyhowError(#[from] anyhow::Error),
-    #[error("avro error: {0}")]
-    AvroError(String, #[source] avro_rs::Error),
-    #[error("malformed header: {0}")]
-    MalformedHeaderError(String),
-    #[error("malformed data packet: {0}")]
-    MalformedDataPacketError(String),
-    #[error("malformed batch: {0}")]
-    MalformedBatchError(String),
-    #[error("end of file")]
-    EofError,
     #[error("HTTP resource error")]
     HttpError(#[from] ureq::Error),
     #[error("packet decryption failure for packet {0}")]

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -1,9 +1,10 @@
 #![allow(clippy::too_many_arguments)]
 
+use aggregation::AggError;
 use anyhow::Result;
+use intake::IntakeError;
 use ring::{digest, signature::EcdsaKeyPair};
 use std::io::Write;
-use uuid::Uuid;
 
 pub mod aggregation;
 pub mod aws_credentials;
@@ -29,12 +30,20 @@ pub const DATE_FORMAT: &str = "%Y/%m/%d/%H/%M";
 pub enum Error {
     #[error(transparent)]
     AnyhowError(#[from] anyhow::Error),
-    #[error("HTTP resource error")]
+    #[error("HTTP resource error: {0}")]
     HttpError(#[from] ureq::Error),
-    #[error("packet decryption failure for packet {0}")]
-    PacketDecryptionError(Uuid),
     #[error("object {0} not found: {1}")]
     ObjectNotFoundError(String, anyhow::Error),
+    #[error("error parsing time: {0}")]
+    TimeParse(#[from] chrono::ParseError),
+    #[error("command line parsing error: {0}")]
+    Clap(#[from] clap::Error),
+    #[error("missing arguments: {0}")]
+    MissingArguments(&'static str),
+    #[error(transparent)]
+    Intake(#[from] IntakeError),
+    #[error(transparent)]
+    Aggregation(AggError),
 }
 
 /// A wrapper-writer that computes a SHA256 digest over the content it is provided.

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::too_many_arguments)]
 
-use aggregation::AggError;
+use aggregation::AggregationError;
 use anyhow::Result;
 use intake::IntakeError;
 use ring::{digest, signature::EcdsaKeyPair};
@@ -42,7 +42,7 @@ pub enum Error {
     #[error(transparent)]
     Intake(#[from] IntakeError),
     #[error(transparent)]
-    Aggregation(AggError),
+    Aggregation(AggregationError),
     #[error(transparent)]
     Url(#[from] UrlParseError),
     #[error("failed to deserialize JSON key file: {0}")]

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -17,13 +17,12 @@ use ring::{
 use serde::Deserialize;
 use slog::Logger;
 use std::{collections::HashMap, fmt::Debug};
-use url::Url;
 
 use crate::{
     config::{Identity, StoragePath},
     http,
     metrics::ApiClientMetricsCollector,
-    BatchSigningKey, Error,
+    parse_url, BatchSigningKey, Error,
 };
 
 // See discussion in SpecificManifest::batch_signing_public_key
@@ -548,13 +547,7 @@ fn fetch_manifest_without_https(
 ) -> Result<String, Error> {
     let manifest_url = format!("{}/{}", base_url, path);
 
-    http::simple_get_request(
-        Url::parse(&manifest_url)
-            .context(format!("failed to parse manifest url: {}", manifest_url))?,
-        logger,
-        service,
-        api_metrics,
-    )
+    http::simple_get_request(parse_url(manifest_url)?, logger, service, api_metrics)
 }
 
 /// Attempts to parse the provided string as a PEM encoded PKIX

--- a/facilitator/src/task.rs
+++ b/facilitator/src/task.rs
@@ -35,9 +35,9 @@ pub trait TaskQueue<T: Task>: Debug + DynClone + Send + Sync {
     /// retried later.
     fn nacknowledge_task(&self, handle: TaskHandle<T>) -> Result<()>;
 
-    /// Immediately forward a task to the associated dead letter queue, and
+    /// Immediately forward a task to the associated rejected queue, and
     /// remove it from the task queue.
-    fn forward_to_dead_letter_queue(&self, handle: TaskHandle<T>) -> Result<()>;
+    fn forward_to_rejected_queue(&self, handle: TaskHandle<T>) -> Result<()>;
 
     /// Signal to the task queue that more time is needed to handle the task.
     fn extend_task_deadline(&self, handle: &TaskHandle<T>, increment: &Duration) -> Result<()>;

--- a/facilitator/src/task.rs
+++ b/facilitator/src/task.rs
@@ -35,6 +35,10 @@ pub trait TaskQueue<T: Task>: Debug + DynClone + Send + Sync {
     /// retried later.
     fn nacknowledge_task(&self, handle: TaskHandle<T>) -> Result<()>;
 
+    /// Immediately forward a task to the associated dead letter queue, and
+    /// remove it from the task queue.
+    fn forward_to_dead_letter_queue(&self, handle: TaskHandle<T>) -> Result<()>;
+
     /// Signal to the task queue that more time is needed to handle the task.
     fn extend_task_deadline(&self, handle: &TaskHandle<T>, increment: &Duration) -> Result<()>;
 
@@ -161,6 +165,8 @@ pub struct TaskHandle<T: Task> {
     pub published_time: Option<NaiveDateTime>,
     /// The task
     pub task: T,
+    /// The original JSON body
+    raw_body: String,
 }
 
 // Implementing slog::Value allows us to put TaskHandles in structured events

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -107,7 +107,7 @@ pub struct GcpPubSubTaskQueue<T: Task> {
     pubsub_api_endpoint: String,
     gcp_project_id: String,
     subscription_id: String,
-    dead_letter_topic: Option<String>,
+    rejected_topic: Option<String>,
     access_token_provider: GcpAccessTokenProvider,
     phantom_task: PhantomData<T>,
     agent: RetryingAgent,
@@ -119,7 +119,7 @@ impl<T: Task> GcpPubSubTaskQueue<T> {
         pubsub_api_endpoint: Option<&str>,
         gcp_project_id: &str,
         subscription_id: &str,
-        dead_letter_topic: Option<&str>,
+        rejected_topic: Option<&str>,
         identity: Identity,
         gcp_access_token_provider_factory: &mut GcpAccessTokenProviderFactory,
         parent_logger: &Logger,
@@ -153,7 +153,7 @@ impl<T: Task> GcpPubSubTaskQueue<T> {
                 .to_owned(),
             gcp_project_id: gcp_project_id.to_string(),
             subscription_id: subscription_id.to_string(),
-            dead_letter_topic: dead_letter_topic.map(str::to_owned),
+            rejected_topic: rejected_topic.map(str::to_owned),
             access_token_provider: gcp_access_token_provider_factory.get(
                 AccessScope::PubSub,
                 identity,
@@ -289,21 +289,21 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
             .context("failed to extend deadline on task")
     }
 
-    fn forward_to_dead_letter_queue(&self, handle: TaskHandle<T>) -> Result<()> {
+    fn forward_to_rejected_queue(&self, handle: TaskHandle<T>) -> Result<()> {
         let logger = self.logger.new(o!(
             event::TASK_ACKNOWLEDGEMENT_ID => handle.acknowledgment_id.to_owned(),
         ));
 
-        let topic = if let Some(topic) = &self.dead_letter_topic {
+        let topic = if let Some(topic) = &self.rejected_topic {
             topic
         } else {
             info!(
-                logger, "not forwarding to dead letter queue, topic not configured";
+                logger, "not forwarding to rejected queue, topic not configured";
             );
             return self.nacknowledge_task(handle);
         };
 
-        info!(logger, "forwarding to dead letter queue");
+        info!(logger, "forwarding to rejected queue");
 
         let request = self.agent.prepare_request(RequestParameters {
             url: gcp_pubsub_publish_url(&self.pubsub_api_endpoint, &self.gcp_project_id, topic)?,

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -220,9 +220,9 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
         // The JSON task is encoded as Base64 in the pubsub message
         let received_message = &received_messages[0];
         let task_bytes = base64::decode(&received_message.message.data)
-            .context("failed to decode PubSub message")?;
+            .context("failed to decode PubSub message from base64")?;
         let task_json =
-            String::from_utf8(task_bytes).context("utf-8 decoding error with PubSub message")?;
+            String::from_utf8(task_bytes).context("failed to decode PubSub message from UTF-8")?;
         let task: T = serde_json::from_reader(task_json.as_bytes())
             .context(format!("failed to decode task {:?} from JSON", task_json))?;
 

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -325,7 +325,7 @@ impl<T: Task> TaskQueue<T> for GcpPubSubTaskQueue<T> {
                     &request,
                     "publish",
                     &ureq::json!({
-                        "messages": [{"data": handle.raw_body}]
+                        "messages": [{"data": base64::encode(&handle.raw_body)}]
                     }),
                 )
                 .context(format!("failed to forward task {:?}", handle))?;

--- a/facilitator/src/task/pubsub.rs
+++ b/facilitator/src/task/pubsub.rs
@@ -4,7 +4,9 @@ use crate::{
     http::{Method, RequestParameters, RetryingAgent},
     logging::event,
     metrics::ApiClientMetricsCollector,
+    parse_url,
     task::{Task, TaskHandle, TaskQueue},
+    UrlParseError,
 };
 use anyhow::{anyhow, Context, Result};
 use chrono::DateTime;
@@ -21,15 +23,12 @@ fn gcp_pubsub_pull_url(
     pubsub_api_endpoint: &str,
     gcp_project_id: &str,
     subscription_id: &str,
-) -> Result<Url> {
+) -> Result<Url, UrlParseError> {
     let request_url = format!(
         "{}/v1/projects/{}/subscriptions/{}:pull",
         pubsub_api_endpoint, gcp_project_id, subscription_id
     );
-    Url::parse(&request_url).context(format!(
-        "faield to parse gcp_pubsub_pull_url: {}",
-        request_url
-    ))
+    parse_url(request_url)
 }
 
 // API reference: https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/acknowledge
@@ -37,15 +36,12 @@ fn gcp_pubsub_ack_url(
     pubsub_api_endpoint: &str,
     gcp_project_id: &str,
     subscription_id: &str,
-) -> Result<Url> {
+) -> Result<Url, UrlParseError> {
     let request_url = format!(
         "{}/v1/projects/{}/subscriptions/{}:acknowledge",
         pubsub_api_endpoint, gcp_project_id, subscription_id
     );
-    Url::parse(&request_url).context(format!(
-        "failed to parse gcp_pubsub_ack_url: {}",
-        request_url
-    ))
+    parse_url(request_url)
 }
 
 // API reference: https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions/modifyAckDeadline
@@ -53,15 +49,12 @@ fn gcp_pubsub_modify_ack_deadline(
     pubsub_api_endpoint: &str,
     gcp_project_id: &str,
     subscription_id: &str,
-) -> Result<Url> {
+) -> Result<Url, UrlParseError> {
     let request_url = format!(
         "{}/v1/projects/{}/subscriptions/{}:modifyAckDeadline",
         pubsub_api_endpoint, gcp_project_id, subscription_id
     );
-    Url::parse(&request_url).context(format!(
-        "faield to parse gcp_pubsub_modify_ack_deadline: {}",
-        request_url
-    ))
+    parse_url(request_url)
 }
 
 // API reference: https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/publish
@@ -69,15 +62,12 @@ fn gcp_pubsub_publish_url(
     pubsub_api_endpoint: &str,
     gcp_project_id: &str,
     topic: &str,
-) -> Result<Url> {
+) -> Result<Url, UrlParseError> {
     let request_url = format!(
         "{}/v1/projects/{}/topics/{}:publish",
         pubsub_api_endpoint, gcp_project_id, topic
     );
-    Url::parse(&request_url).context(format!(
-        "failed to parse gcp_pubsub_publish_url: {}",
-        request_url
-    ))
+    parse_url(request_url)
 }
 
 /// Represents the response to a subscription.pull request. See API doc for

--- a/facilitator/src/task/sqs.rs
+++ b/facilitator/src/task/sqs.rs
@@ -7,6 +7,7 @@ use crate::{
 use anyhow::{anyhow, Context, Result};
 use chrono::NaiveDateTime;
 use rusoto_core::Region;
+use rusoto_sns::{PublishInput, Sns, SnsClient};
 use rusoto_sqs::{
     ChangeMessageVisibilityRequest, DeleteMessageRequest, ReceiveMessageRequest, Sqs, SqsClient,
 };
@@ -19,6 +20,7 @@ use tokio::runtime::Handle;
 pub struct AwsSqsTaskQueue<T: Task> {
     region: Region,
     queue_url: String,
+    dead_letter_topic: Option<String>,
     runtime_handle: Handle,
     credentials_provider: aws_credentials::Provider,
     logger: Logger,
@@ -30,6 +32,7 @@ impl<T: Task> AwsSqsTaskQueue<T> {
     pub fn new(
         region: &str,
         queue_url: &str,
+        dead_letter_topic: Option<&str>,
         runtime_handle: &Handle,
         credentials_provider: aws_credentials::Provider,
         parent_logger: &Logger,
@@ -44,6 +47,7 @@ impl<T: Task> AwsSqsTaskQueue<T> {
         Ok(AwsSqsTaskQueue {
             region,
             queue_url: queue_url.to_owned(),
+            dead_letter_topic: dead_letter_topic.map(str::to_owned),
             runtime_handle: runtime_handle.clone(),
             credentials_provider,
             logger,
@@ -128,6 +132,7 @@ impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
 
         Ok(Some(TaskHandle {
             task,
+            raw_body: body.clone(),
             published_time,
             acknowledgment_id: receipt_handle.to_owned(),
         }))
@@ -181,6 +186,48 @@ impl<T: Task> TaskQueue<T> for AwsSqsTaskQueue<T> {
         self.change_message_visibility(task, increment)
             .context("failed to extend deadline on task")
     }
+
+    fn forward_to_dead_letter_queue(&self, task: TaskHandle<T>) -> Result<()> {
+        if let Some(topic) = &self.dead_letter_topic {
+            info!(
+                self.logger, "forwarding to dead letter queue";
+                event::TASK_ACKNOWLEDGEMENT_ID => &task.acknowledgment_id,
+            );
+
+            let client = self.sns_client()?;
+            retry_request(
+                &self
+                    .logger
+                    .new(o!(event::ACTION => "submit forwarded message")),
+                &self.api_metrics,
+                "sns.amazonaws.com",
+                "Publish",
+                &self.runtime_handle,
+                || {
+                    client.publish(PublishInput {
+                        message: task.raw_body.clone(),
+                        message_attributes: None,
+                        message_deduplication_id: None,
+                        message_group_id: None,
+                        message_structure: None,
+                        phone_number: None,
+                        subject: None,
+                        target_arn: None,
+                        topic_arn: Some(topic.clone()),
+                    })
+                },
+            )
+            .context("failed to forward message to SNS")?;
+
+            self.acknowledge_task(task)
+        } else {
+            info!(
+                self.logger, "not forwarding to dead letter queue, topic not configured";
+                event::TASK_ACKNOWLEDGEMENT_ID => &task.acknowledgment_id,
+            );
+            self.nacknowledge_task(task)
+        }
+    }
 }
 
 impl<T: Task> AwsSqsTaskQueue<T> {
@@ -195,6 +242,17 @@ impl<T: Task> AwsSqsTaskQueue<T> {
         let http_client = rusoto_core::HttpClient::new().context("failed to create HTTP client")?;
 
         Ok(SqsClient::new_with(
+            http_client,
+            self.credentials_provider.clone(),
+            self.region.clone(),
+        ))
+    }
+
+    /// Returns a configured SnsClient, or an error on failure.
+    fn sns_client(&self) -> Result<SnsClient> {
+        let http_client = rusoto_core::HttpClient::new().context("failed to create HTTP client")?;
+
+        Ok(SnsClient::new_with(
             http_client,
             self.credentials_provider.clone(),
             self.region.clone(),

--- a/facilitator/src/transport/gcs.rs
+++ b/facilitator/src/transport/gcs.rs
@@ -366,11 +366,9 @@ impl StreamingTransferWriter {
             content_range_header_total_length_field
         );
 
-        let mut request = self.agent.prepare_request(RequestParameters {
-            url: self.upload_session_uri.clone(),
-            method: Method::Put,
-            ..Default::default()
-        })?;
+        let mut request = self
+            .agent
+            .prepare_anonymous_request(self.upload_session_uri.clone(), Method::Put);
         request = request.set("Content-Range", &content_range);
 
         let http_response = self
@@ -471,12 +469,7 @@ impl TransportWriter for StreamingTransferWriter {
         // https://cloud.google.com/storage/docs/performing-resumable-uploads#cancel-upload
         let request = self
             .agent
-            .prepare_request(RequestParameters {
-                url: self.upload_session_uri.clone(),
-                method: Method::Delete,
-                ..Default::default()
-            })
-            .map_err(|e| TransportError::Gcs(e.into()))?;
+            .prepare_anonymous_request(self.upload_session_uri.clone(), Method::Delete);
 
         let http_response = self
             .agent

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -110,6 +110,7 @@ variable "intake_queue" {
     topic             = string
     subscription_kind = string
     subscription      = string
+    dead_letter_topic = string
   })
 }
 
@@ -120,6 +121,7 @@ variable "aggregate_queue" {
     topic             = string
     subscription_kind = string
     subscription      = string
+    dead_letter_topic = string
   })
 }
 
@@ -375,6 +377,7 @@ resource "kubernetes_deployment" "intake_batch" {
             "--peer-gcp-sa-to-impersonate-before-assuming-role=${var.remote_peer_validation_bucket_identity.gcp_sa_to_impersonate_while_assuming_identity}",
             "--task-queue-kind=${var.intake_queue.subscription_kind}",
             "--task-queue-name=${var.intake_queue.subscription}",
+            "--dead-letter-topic=${var.intake_queue.dead_letter_topic}",
             "--aws-sqs-region=${var.use_aws ? var.aws_region : ""}",
             "--gcp-project-id=${var.use_aws ? "" : data.google_project.project.project_id}",
             "--gcp-workload-identity-pool-provider=${var.gcp_workload_identity_pool_provider}",
@@ -605,6 +608,7 @@ resource "kubernetes_deployment" "aggregate" {
             "--portal-manifest-base-url=https://${var.portal_server_manifest_base_url}",
             "--task-queue-kind=${var.aggregate_queue.subscription_kind}",
             "--task-queue-name=${var.aggregate_queue.subscription}",
+            "--dead-letter-topic=${var.aggregate_queue.dead_letter_topic}",
             "--gcp-project-id=${var.use_aws ? "" : data.google_project.project.project_id}",
             "--aws-sqs-region=${var.use_aws ? var.aws_region : ""}",
             "--permit-malformed-batch=true",

--- a/terraform/modules/kubernetes/kubernetes.tf
+++ b/terraform/modules/kubernetes/kubernetes.tf
@@ -110,7 +110,7 @@ variable "intake_queue" {
     topic             = string
     subscription_kind = string
     subscription      = string
-    dead_letter_topic = string
+    rejected_topic    = string
   })
 }
 
@@ -121,7 +121,7 @@ variable "aggregate_queue" {
     topic             = string
     subscription_kind = string
     subscription      = string
-    dead_letter_topic = string
+    rejected_topic    = string
   })
 }
 
@@ -377,7 +377,7 @@ resource "kubernetes_deployment" "intake_batch" {
             "--peer-gcp-sa-to-impersonate-before-assuming-role=${var.remote_peer_validation_bucket_identity.gcp_sa_to_impersonate_while_assuming_identity}",
             "--task-queue-kind=${var.intake_queue.subscription_kind}",
             "--task-queue-name=${var.intake_queue.subscription}",
-            "--dead-letter-topic=${var.intake_queue.dead_letter_topic}",
+            "--rejected-topic=${var.intake_queue.rejected_topic}",
             "--aws-sqs-region=${var.use_aws ? var.aws_region : ""}",
             "--gcp-project-id=${var.use_aws ? "" : data.google_project.project.project_id}",
             "--gcp-workload-identity-pool-provider=${var.gcp_workload_identity_pool_provider}",
@@ -608,7 +608,7 @@ resource "kubernetes_deployment" "aggregate" {
             "--portal-manifest-base-url=https://${var.portal_server_manifest_base_url}",
             "--task-queue-kind=${var.aggregate_queue.subscription_kind}",
             "--task-queue-name=${var.aggregate_queue.subscription}",
-            "--dead-letter-topic=${var.aggregate_queue.dead_letter_topic}",
+            "--rejected-topic=${var.aggregate_queue.rejected_topic}",
             "--gcp-project-id=${var.use_aws ? "" : data.google_project.project.project_id}",
             "--aws-sqs-region=${var.use_aws ? var.aws_region : ""}",
             "--permit-malformed-batch=true",

--- a/terraform/modules/pubsub/pubsub.tf
+++ b/terraform/modules/pubsub/pubsub.tf
@@ -75,7 +75,8 @@ resource "google_pubsub_topic_iam_binding" "dead_letter" {
   topic = google_pubsub_topic.dead_letter.name
   role  = "roles/pubsub.publisher"
   members = [
-    local.pubsub_service_account
+    local.pubsub_service_account,
+    "serviceAccount:${var.subscriber_service_account}"
   ]
 }
 
@@ -98,5 +99,6 @@ output "queue" {
     topic             = google_pubsub_topic.task.name
     subscription_kind = "gcp-pubsub"
     subscription      = google_pubsub_subscription.task.name
+    dead_letter_topic = google_pubsub_topic.dead_letter.name
   }
 }

--- a/terraform/modules/sns_sqs/sns_sqs.tf
+++ b/terraform/modules/sns_sqs/sns_sqs.tf
@@ -150,7 +150,7 @@ resource "aws_sqs_queue_policy" "dead_letter" {
           Service = "sns.amazonaws.com"
         }
         Action = [
-          "sqs::SendMessage"
+          "sqs:SendMessage"
         ]
         Resource = aws_sqs_queue.dead_letter.arn
         Condition = {


### PR DESCRIPTION
This introduces enum-based error handling in the IDL module. It eliminates all but one use of anyhow in `src/idl.rs`, and effectively moves several variants of the crate-level `Error` to this module.

This doesn't introduce any behavior changes for packet decryption failures, etc. yet. I figured this module would be good to start with, as it has the highest density of `anyhow::Context::context()` calls. In the interest of eating an elephant one bite at a time, I'm putting this up for early feedback, and we can treat it as a draft if we like.