### PR TITLE
Fix flapping of fake-ingestor identity in sum-part-writer bucket.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -712,7 +712,10 @@ resource "google_service_account_iam_binding" "data_share_processors_to_sum_part
   count              = var.use_aws ? 0 : 1
   service_account_id = google_service_account.sum_part_bucket_writer.name
   role               = "roles/iam.serviceAccountTokenCreator"
-  members            = [for v in module.data_share_processors : "serviceAccount:${v.gcp_service_account_email}"]
+  members = concat(
+    [for v in module.data_share_processors : "serviceAccount:${v.gcp_service_account_email}"],
+    local.is_env_with_ingestor ? ["serviceAccount:${module.fake_server_resources[0].gcp_service_account_email}"] : []
+  )
 }
 
 # GCP services we must enable to use Workload Identity Pool
@@ -797,7 +800,6 @@ module "fake_server_resources" {
   facilitator_version           = var.facilitator_version
   manifest_bucket               = local.manifest.bucket
   other_environment             = var.test_peer_environment.env_without_ingestor
-  sum_part_bucket_writer_name   = google_service_account.sum_part_bucket_writer.name
   sum_part_bucket_writer_email  = google_service_account.sum_part_bucket_writer.email
   aggregate_queues              = { for v in module.data_share_processors : v.data_share_processor_name => v.aggregate_queue }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -708,14 +708,11 @@ resource "google_service_account" "sum_part_bucket_writer" {
 # If running in GCP, permit the service accounts for all the data share
 # processors to request access and identity tokens allowing them to impersonate
 # the sum part bucket writer.
-resource "google_service_account_iam_binding" "data_share_processors_to_sum_part_bucket_writer_token_creator" {
-  count              = var.use_aws ? 0 : 1
+resource "google_service_account_iam_member" "data_share_processors_to_sum_part_bucket_writer_token_creator" {
+  for_each           = var.use_aws ? {} : module.data_share_processors
   service_account_id = google_service_account.sum_part_bucket_writer.name
   role               = "roles/iam.serviceAccountTokenCreator"
-  members = concat(
-    [for v in module.data_share_processors : "serviceAccount:${v.gcp_service_account_email}"],
-    local.is_env_with_ingestor ? ["serviceAccount:${module.fake_server_resources[0].gcp_service_account_email}"] : []
-  )
+  member             = "serviceAccount:${each.value.gcp_service_account_email}"
 }
 
 # GCP services we must enable to use Workload Identity Pool
@@ -800,6 +797,7 @@ module "fake_server_resources" {
   facilitator_version           = var.facilitator_version
   manifest_bucket               = local.manifest.bucket
   other_environment             = var.test_peer_environment.env_without_ingestor
+  sum_part_bucket_writer_name   = google_service_account.sum_part_bucket_writer.name
   sum_part_bucket_writer_email  = google_service_account.sum_part_bucket_writer.email
   aggregate_queues              = { for v in module.data_share_processors : v.data_share_processor_name => v.aggregate_queue }
 }

--- a/terraform/modules/fake_server_resources/fake_server_resources.tf
+++ b/terraform/modules/fake_server_resources/fake_server_resources.tf
@@ -45,6 +45,10 @@ variable "other_environment" {
   type = string
 }
 
+variable "sum_part_bucket_writer_name" {
+  type = string
+}
+
 variable "sum_part_bucket_writer_email" {
   type = string
 }
@@ -136,6 +140,15 @@ module "account_mapping" {
   gcp_project                     = var.gcp_project
   kubernetes_service_account_name = "ingestion-identity"
   kubernetes_namespace            = kubernetes_namespace.tester.metadata[0].name
+}
+
+# Allow the integration-test identity to impersonate the sum part bucket writer
+# service accounts to allow reading sum parts. (It would be more precise to
+# make this read-only, but this is for testing infrastructure.)
+resource "google_service_account_iam_member" "integration_test_identity_to_my_sum_part_bucket_writer_token_creator" {
+  service_account_id = var.sum_part_bucket_writer_name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${module.account_mapping.gcp_service_account_email}"
 }
 
 locals {

--- a/terraform/modules/fake_server_resources/fake_server_resources.tf
+++ b/terraform/modules/fake_server_resources/fake_server_resources.tf
@@ -45,10 +45,6 @@ variable "other_environment" {
   type = string
 }
 
-variable "sum_part_bucket_writer_name" {
-  type = string
-}
-
 variable "sum_part_bucket_writer_email" {
   type = string
 }
@@ -140,15 +136,6 @@ module "account_mapping" {
   gcp_project                     = var.gcp_project
   kubernetes_service_account_name = "ingestion-identity"
   kubernetes_namespace            = kubernetes_namespace.tester.metadata[0].name
-}
-
-# Allow the integration-test identity to impersonate the sum part bucket writer
-# service accounts to allow reading sum parts. (It would be more precise to
-# make this read-only, but this is for testing infrastructure.)
-resource "google_service_account_iam_member" "integration_test_identity_to_my_sum_part_bucket_writer_token_creator" {
-  service_account_id = var.sum_part_bucket_writer_name
-  role               = "roles/iam.serviceAccountTokenCreator"
-  member             = "serviceAccount:${module.account_mapping.gcp_service_account_email}"
 }
 
 locals {


### PR DESCRIPTION
This was due to main.tf's
data_share_processors_to_sum_part_writer_token_creator interfering with
the fake_server_resources.tf's
integration_test_identity_to_my_sum_part_bucket_writer_token_creator. I
fix this by specifying the membership in
data_share_processors_to_sum_part_writer_token_creator directly; the
downside is this "leaks" some integration-test configuration outside of
fake_server_resources.tf.