### PR TITLE
Enable --write-single-object-validation-batches in staging.

### DIFF
--- a/terraform/variables/stg-us-facil.tfvars
+++ b/terraform/variables/stg-us-facil.tfvars
@@ -94,6 +94,8 @@ batch_signing_key_rotation_policy = {
   delete_min_count = 2
 }
 
+single_object_validation_batch_localities = ["gondor", "narnia"]
+
 prometheus_helm_chart_version           = "15.0.2"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -99,6 +99,8 @@ batch_signing_key_rotation_policy = {
   delete_min_count = 2
 }
 
+single_object_validation_batch_localities = ["gondor", "narnia"]
+
 prometheus_helm_chart_version           = "15.0.2"
 grafana_helm_chart_version              = "6.20.5"
 cloudwatch_exporter_helm_chart_version  = "0.17.2"


### PR DESCRIPTION
This has been enabled & working OK in my dev environment for around a
month now--now that staging is releasable again, I think it is wise to
test upcoming changes in staging rather than in dev-envs only.

I set things up such that the facil & PHA deployments match their
settings here.  This is not a requirement, but it does simplify testing.
I leave one locality using multiple-object validation batches, to ensure
we don't somehow break backwards-compatibility.

`make plan` for stg-us-facil:
<details>
<summary>Click to expand</summary>

```
Terraform will perform the following actions:

  # google_service_account_iam_binding.data_share_processors_to_sum_part_bucket_writer_token_creator[0] will be destroyed
  # (because google_service_account_iam_binding.data_share_processors_to_sum_part_bucket_writer_token_creator is not in configuration)
  - resource "google_service_account_iam_binding" "data_share_processors_to_sum_part_bucket_writer_token_creator" {
      - etag               = "BwXYBR2HsHI=" -> null
      - id                 = "projects/prio-staging-us/serviceAccounts/prio-stg-us-facil-sum-writer@prio-staging-us.iam.gserviceaccount.com/roles/iam.serviceAccountTokenCreator" -> null
      - members            = [
          - "serviceAccount:prio-dmgboscbotaargdz@prio-staging-us.iam.gserviceaccount.com",
          - "serviceAccount:prio-fibkcgwyzbynwdhl@prio-staging-us.iam.gserviceaccount.com",
          - "serviceAccount:prio-navbmjnirvbmoqrm@prio-staging-us.iam.gserviceaccount.com",
          - "serviceAccount:prio-txnjcytexalpkblz@prio-staging-us.iam.gserviceaccount.com",
          - "serviceAccount:prio-xssqlkvsrsxpaqgc@prio-staging-us.iam.gserviceaccount.com",
          - "serviceAccount:prio-yykftffxrtebyoir@prio-staging-us.iam.gserviceaccount.com",
        ] -> null
      - role               = "roles/iam.serviceAccountTokenCreator" -> null
      - service_account_id = "projects/prio-staging-us/serviceAccounts/prio-stg-us-facil-sum-writer@prio-staging-us.iam.gserviceaccount.com" -> null
    }

  # google_service_account_iam_member.data_share_processors_to_sum_part_bucket_writer_token_creator["asgard-ingestor-1"] will be created
  + resource "google_service_account_iam_member" "data_share_processors_to_sum_part_bucket_writer_token_creator" {
      + etag               = (known after apply)
      + id                 = (known after apply)
      + member             = "serviceAccount:prio-yykftffxrtebyoir@prio-staging-us.iam.gserviceaccount.com"
      + role               = "roles/iam.serviceAccountTokenCreator"
      + service_account_id = "projects/prio-staging-us/serviceAccounts/prio-stg-us-facil-sum-writer@prio-staging-us.iam.gserviceaccount.com"
    }

  # google_service_account_iam_member.data_share_processors_to_sum_part_bucket_writer_token_creator["asgard-ingestor-2"] will be created
  + resource "google_service_account_iam_member" "data_share_processors_to_sum_part_bucket_writer_token_creator" {
      + etag               = (known after apply)
      + id                 = (known after apply)
      + member             = "serviceAccount:prio-navbmjnirvbmoqrm@prio-staging-us.iam.gserviceaccount.com"
      + role               = "roles/iam.serviceAccountTokenCreator"
      + service_account_id = "projects/prio-staging-us/serviceAccounts/prio-stg-us-facil-sum-writer@prio-staging-us.iam.gserviceaccount.com"
    }

  # google_service_account_iam_member.data_share_processors_to_sum_part_bucket_writer_token_creator["gondor-ingestor-1"] will be created
  + resource "google_service_account_iam_member" "data_share_processors_to_sum_part_bucket_writer_token_creator" {
      + etag               = (known after apply)
      + id                 = (known after apply)
      + member             = "serviceAccount:prio-dmgboscbotaargdz@prio-staging-us.iam.gserviceaccount.com"
      + role               = "roles/iam.serviceAccountTokenCreator"
      + service_account_id = "projects/prio-staging-us/serviceAccounts/prio-stg-us-facil-sum-writer@prio-staging-us.iam.gserviceaccount.com"
    }

  # google_service_account_iam_member.data_share_processors_to_sum_part_bucket_writer_token_creator["gondor-ingestor-2"] will be created
  + resource "google_service_account_iam_member" "data_share_processors_to_sum_part_bucket_writer_token_creator" {
      + etag               = (known after apply)
      + id                 = (known after apply)
      + member             = "serviceAccount:prio-xssqlkvsrsxpaqgc@prio-staging-us.iam.gserviceaccount.com"
      + role               = "roles/iam.serviceAccountTokenCreator"
      + service_account_id = "projects/prio-staging-us/serviceAccounts/prio-stg-us-facil-sum-writer@prio-staging-us.iam.gserviceaccount.com"
    }

  # google_service_account_iam_member.data_share_processors_to_sum_part_bucket_writer_token_creator["narnia-ingestor-1"] will be created
  + resource "google_service_account_iam_member" "data_share_processors_to_sum_part_bucket_writer_token_creator" {
      + etag               = (known after apply)
      + id                 = (known after apply)
      + member             = "serviceAccount:prio-fibkcgwyzbynwdhl@prio-staging-us.iam.gserviceaccount.com"
      + role               = "roles/iam.serviceAccountTokenCreator"
      + service_account_id = "projects/prio-staging-us/serviceAccounts/prio-stg-us-facil-sum-writer@prio-staging-us.iam.gserviceaccount.com"
    }

  # google_service_account_iam_member.data_share_processors_to_sum_part_bucket_writer_token_creator["narnia-ingestor-2"] will be created
  + resource "google_service_account_iam_member" "data_share_processors_to_sum_part_bucket_writer_token_creator" {
      + etag               = (known after apply)
      + id                 = (known after apply)
      + member             = "serviceAccount:prio-txnjcytexalpkblz@prio-staging-us.iam.gserviceaccount.com"
      + role               = "roles/iam.serviceAccountTokenCreator"
      + service_account_id = "projects/prio-staging-us/serviceAccounts/prio-stg-us-facil-sum-writer@prio-staging-us.iam.gserviceaccount.com"
    }

  # module.fake_server_resources[0].google_service_account_iam_member.integration_test_identity_to_my_sum_part_bucket_writer_token_creator will be created
  + resource "google_service_account_iam_member" "integration_test_identity_to_my_sum_part_bucket_writer_token_creator" {
      + etag               = (known after apply)
      + id                 = (known after apply)
      + member             = "serviceAccount:prio-malbbrakhfmwxzzc@prio-staging-us.iam.gserviceaccount.com"
      + role               = "roles/iam.serviceAccountTokenCreator"
      + service_account_id = "projects/prio-staging-us/serviceAccounts/prio-stg-us-facil-sum-writer@prio-staging-us.iam.gserviceaccount.com"
    }

  # module.monitoring.helm_release.prometheus will be updated in-place
  ~ resource "helm_release" "prometheus" {
        id                         = "prometheus"
        name                       = "prometheus"
        # (27 unchanged attributes hidden)

      - set {
          - name  = "alertmanager.configFileName" -> null
          - value = "alertmanager.yml" -> null
        }
      + set {
          + name  = "alertmanager.configFileName"
          + value = "alertmanager.yml"
        }
      - set {
          - name  = "alertmanager.configFromSecret" -> null
          - value = "prometheus-alertmanager-config" -> null
        }
      + set {
          + name  = "alertmanager.configFromSecret"
          + value = "prometheus-alertmanager-config"
        }
      + set {
          + name  = "alertmanager.strategy.type"
          + value = "Recreate"
        }
      - set {
          - name  = "server.persistentVolume.enabled" -> null
          - value = "true" -> null
        }
      + set {
          + name  = "server.persistentVolume.enabled"
          + value = "true"
        }
      - set {
          - name  = "server.persistentVolume.existingClaim" -> null
          - value = "prometheus-server-claim" -> null
        }
      + set {
          + name  = "server.persistentVolume.existingClaim"
          + value = "prometheus-server-claim"
        }
      - set {
          - name  = "server.retention" -> null
          - value = "30d" -> null
        }
      + set {
          + name  = "server.retention"
          + value = "30d"
        }
      - set {
          - name  = "server.strategy.type" -> null
          - value = "Recreate" -> null
        }
      + set {
          + name  = "server.strategy.type"
          + value = "Recreate"
        }
    }

  # module.data_share_processors["gondor-ingestor-1"].module.kubernetes.kubernetes_deployment.intake_batch will be updated in-place
  ~ resource "kubernetes_deployment" "intake_batch" {
        id               = "gondor/intake-batch-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ args                       = [
                            # (14 unchanged elements hidden)
                            "--worker-maximum-lifetime=3600",
                          - "--write-single-object-validation-batches=false",
                          + "--write-single-object-validation-batches=true",
                        ]
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["gondor-ingestor-2"].module.kubernetes.kubernetes_deployment.intake_batch will be updated in-place
  ~ resource "kubernetes_deployment" "intake_batch" {
        id               = "gondor/intake-batch-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ args                       = [
                            # (14 unchanged elements hidden)
                            "--worker-maximum-lifetime=3600",
                          - "--write-single-object-validation-batches=false",
                          + "--write-single-object-validation-batches=true",
                        ]
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["narnia-ingestor-1"].module.kubernetes.kubernetes_deployment.intake_batch will be updated in-place
  ~ resource "kubernetes_deployment" "intake_batch" {
        id               = "narnia/intake-batch-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ args                       = [
                            # (14 unchanged elements hidden)
                            "--worker-maximum-lifetime=3600",
                          - "--write-single-object-validation-batches=false",
                          + "--write-single-object-validation-batches=true",
                        ]
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["narnia-ingestor-2"].module.kubernetes.kubernetes_deployment.intake_batch will be updated in-place
  ~ resource "kubernetes_deployment" "intake_batch" {
        id               = "narnia/intake-batch-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ args                       = [
                            # (14 unchanged elements hidden)
                            "--worker-maximum-lifetime=3600",
                          - "--write-single-object-validation-batches=false",
                          + "--write-single-object-validation-batches=true",
                        ]
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

Plan: 7 to add, 5 to change, 1 to destroy.
```
</details>

[this contains some irrelevant-but-expected changes due to the recent change to how we do IAM role binding, and a change to prometheus that appears benign]

This is one more step towards #362.