### PR TITLE
facilitator: gracefully handle Err in fmt::Display

### DIFF
--- a/facilitator/src/aws_credentials.rs
+++ b/facilitator/src/aws_credentials.rs
@@ -354,23 +354,19 @@ impl Display for Provider {
                 // discard whatever Variable.resolve() might return. In
                 // practice, it will always be Variable::static and so no error
                 // is possible.
-                let role_arn = p
-                    .get_ref()
-                    .get_ref()
-                    .get_ref()
-                    .role_arn
-                    .resolve()
-                    .map_err(|_| fmt::Error)?;
+                let role_arn_res = p.get_ref().get_ref().get_ref().role_arn.resolve();
+                let role_arn = role_arn_res
+                    .as_ref()
+                    .map(String::as_str)
+                    .unwrap_or_else(|_| "(error resolving variable)");
                 write!(f, "{} via OIDC web identity", role_arn)
             }
             Self::WebIdentityFromKubernetesEnvironment(p) => {
-                let role_arn = p
-                    .get_ref()
-                    .get_ref()
-                    .get_ref()
-                    .role_arn
-                    .resolve()
-                    .map_err(|_| fmt::Error)?;
+                let role_arn_res = p.get_ref().get_ref().get_ref().role_arn.resolve();
+                let role_arn = role_arn_res
+                    .as_ref()
+                    .map(String::as_str)
+                    .unwrap_or_else(|_| "(error resolving variable)");
                 write!(
                     f,
                     "{} via web identity from Kubernetes environment",


### PR DESCRIPTION
Returning a newly constructed std::fmt::Error from here is incorrect, as format implementations should only return errors through propagation. In particular, format!() will panic if it receives an error from this code.