### PR TITLE
Disable clippy::too_many_arguments lint.

### DIFF
--- a/facilitator/src/aggregation.rs
+++ b/facilitator/src/aggregation.rs
@@ -37,7 +37,6 @@ pub struct BatchAggregator<'a> {
 }
 
 impl<'a> BatchAggregator<'a> {
-    #[allow(clippy::too_many_arguments)] // Grandfathered in
     pub fn new(
         trace_id: &'a Uuid,
         instance_name: &str,

--- a/facilitator/src/batch.rs
+++ b/facilitator/src/batch.rs
@@ -620,7 +620,6 @@ mod tests {
         ];
     }
 
-    #[allow(clippy::too_many_arguments)] // Grandfathered in
     fn roundtrip_batch<'a, H, P>(
         header: &H,
         packets: &[P],

--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use anyhow::{anyhow, Context, Result};
 use chrono::{prelude::Utc, NaiveDateTime};
 use clap::{value_t, App, Arg, ArgGroup, ArgMatches, SubCommand};
@@ -1532,7 +1534,6 @@ fn validate_sample_worker(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 fn validate_sample(
     logger: &Logger,
     sample_generator_mismatched_sum_count: &IntCounterVec,
@@ -1608,7 +1609,6 @@ fn validate_sample(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 fn intake_batch<F>(
     trace_id: &Uuid,
     aggregation_id: &str,
@@ -1825,7 +1825,6 @@ fn intake_batch_worker(
     Ok(())
 }
 
-#[allow(clippy::too_many_arguments)]
 fn aggregate<F>(
     trace_id: &Uuid,
     aggregation_id: &str,
@@ -2339,7 +2338,6 @@ enum PathOrInOut {
     InOut(InOut),
 }
 
-#[allow(clippy::too_many_arguments)]
 fn transport_from_args(
     identity: Identity,
     entity: Entity,
@@ -2376,7 +2374,6 @@ fn transport_from_args(
     )
 }
 
-#[allow(clippy::too_many_arguments)]
 fn transport_for_path(
     path: StoragePath,
     identity: Identity,

--- a/facilitator/src/intake.rs
+++ b/facilitator/src/intake.rs
@@ -35,7 +35,6 @@ pub struct BatchIntaker<'a> {
 }
 
 impl<'a> BatchIntaker<'a> {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         trace_id: &'a Uuid,
         aggregation_name: &'a str,

--- a/facilitator/src/lib.rs
+++ b/facilitator/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_arguments)]
+
 use anyhow::Result;
 use ring::{digest, signature::EcdsaKeyPair};
 use std::io::Write;

--- a/facilitator/src/sample.rs
+++ b/facilitator/src/sample.rs
@@ -96,7 +96,6 @@ pub struct SampleGenerator<'a> {
 impl<'a> SampleGenerator<'a> {
     /// Creates a new SampleGenerator. See the documentation on struct
     /// SampleGenerator for discussion of each parameter.
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         aggregation_name: &'a str,
         dimension: i32,


### PR DESCRIPTION
As a team, we decided that this lint added more noise than value.

I had to add the "top-level" annotation to both `facilitator.rs` & `lib.rs` -- I believe the `facilitator.rs` annotation covers lints for the binary (i.e. in `facilitator.rs` specifically), while `lib.rs` annotation covers the rest of the crate (i.e. the "library" portion).