### PR TITLE
terraform: release 0.6.25 containers to prod-us

### DIFF
--- a/terraform/variables/prod-intl.tfvars
+++ b/terraform/variables/prod-intl.tfvars
@@ -94,9 +94,9 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-facilitator_version      = "0.6.24"
-workflow_manager_version = "0.6.24"
-key_rotator_version      = "0.6.24"
+facilitator_version      = "0.6.25"
+workflow_manager_version = "0.6.25"
+key_rotator_version      = "0.6.25"
 victorops_routing_key    = "prio-prod-intl"
 
 default_aggregation_period       = "8h"

--- a/terraform/variables/prod-us.tfvars
+++ b/terraform/variables/prod-us.tfvars
@@ -222,9 +222,9 @@ is_first                                  = false
 use_aws                                   = false
 default_aggregation_period                = "8h"
 default_aggregation_grace_period          = "4h"
-workflow_manager_version                  = "0.6.24"
-facilitator_version                       = "0.6.24"
-key_rotator_version                       = "0.6.24"
+workflow_manager_version                  = "0.6.25"
+facilitator_version                       = "0.6.25"
+key_rotator_version                       = "0.6.25"
 prometheus_server_persistent_disk_size_gb = 1000
 victorops_routing_key                     = "prio-prod-us"
 


### PR DESCRIPTION
This also updates EKS cluster version in prod-intl. See #1373 for
details.