### PR TITLE
facilitator: correctly report included batch UUIDs

### DIFF
--- a/facilitator/src/test_utils.rs
+++ b/facilitator/src/test_utils.rs
@@ -16,6 +16,10 @@ pub const DEFAULT_PHA_ECIES_PRIVATE_KEY: &str =
 pub const DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY: &str =
     "BNNOqoU54GPo+1gTPv+hCgA9U2ZCKd76yOMrWa1xTWgeb4LhFLMQIQoRwDVaW64g\
     /WTdcxT4rDULoycUNFB60LER6hPEHg/ObBnRPV1rwS3nj9Bj0tbjVPPyL9p8QW8B+w==";
+const BOGUS_ECIES_PRIVATE_KEY: &str =
+    "BMbqB/fIy8fVJEKlrE7e0XusKF4KaUO7GPBc0WEGSqCPKAcujBmq8IfjuUS1fTLo\
+    rzGGNVDt5Vq5GWnR8lSwL016Rm88BqVTzF49kGeAUm7TTK11eAAvEG6zd/dU8A8lQg==";
+
 pub const DEFAULT_INGESTOR_PRIVATE_KEY: &str =
     "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQggoa08rQR90Asvhy5b\
     WIgFBDeGaO8FnVEF3PVpNVmDGChRANCAAQ2mZfm4UC73PkWsYz3Uub6UTIAFQCPGxo\
@@ -147,12 +151,28 @@ pub fn default_pha_signing_public_key() -> UnparsedPublicKey<Vec<u8>> {
     )
 }
 
+pub fn default_pha_packet_decryption_private_key() -> PrivateKey {
+    PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap()
+}
+
 pub fn default_pha_packet_encryption_public_key() -> PublicKey {
-    PublicKey::from(&PrivateKey::from_base64(DEFAULT_PHA_ECIES_PRIVATE_KEY).unwrap())
+    PublicKey::from(&default_pha_packet_decryption_private_key())
+}
+
+pub fn default_facilitator_packet_decryption_private_key() -> PrivateKey {
+    PrivateKey::from_base64(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY).unwrap()
 }
 
 pub fn default_facilitator_packet_encryption_public_key() -> PublicKey {
-    PublicKey::from(&PrivateKey::from_base64(DEFAULT_FACILITATOR_ECIES_PRIVATE_KEY).unwrap())
+    PublicKey::from(&default_facilitator_packet_decryption_private_key())
+}
+
+pub fn bogus_packet_decryption_private_key() -> PrivateKey {
+    PrivateKey::from_base64(BOGUS_ECIES_PRIVATE_KEY).unwrap()
+}
+
+pub fn bogus_packet_encryption_public_key() -> PublicKey {
+    PublicKey::from(&bogus_packet_decryption_private_key())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
If an ingestion batch contains a packet that cannot be decrypted, then
the intake task for it will fail, currently producing a dead letter.
However, we gracefully handle this case at aggregation time, because if
one batch out of `n` contains an undecryptable packet, we still want to
aggregate over the other `n - 1` batches. However, when discarding a
batch from the aggregate, we were still including its batch UUID in the
sum part message sent to the portal server, which causes our
aggregator's list of batch UUIDs to not match up with the peer's, which
the portal server rightfully considers an error.
    
This commit makes the aggregator only include a batch UUID if the
batch's packets were aggregated into the sum part.
    
Resolves #1414