### PR TITLE
facilitator: fix warnings

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -142,7 +142,7 @@ macro_rules! shared_help {
 }
 
 fn upper_snake_case(s: &str) -> String {
-    s.to_uppercase().replace("-", "_")
+    s.to_uppercase().replace('-', "_")
 }
 
 impl<'a, 'b> AppArgumentAdder for App<'a, 'b> {

--- a/facilitator/src/manifest.rs
+++ b/facilitator/src/manifest.rs
@@ -622,7 +622,7 @@ mod tests {
     use prio::encrypt::{PrivateKey, PublicKey};
     use ring::signature::{EcdsaKeyPair, ECDSA_P256_SHA256_ASN1_SIGNING};
     use rusoto_core::Region;
-    use std::{array::IntoIter, str::FromStr};
+    use std::str::FromStr;
 
     fn http_url_fetcher(
         base_url: &str,
@@ -1804,7 +1804,7 @@ mod tests {
             ingestion_identity: Identity::none(),
             peer_validation_bucket: StoragePath::from_str("gs://irrelevant").unwrap(),
             peer_validation_identity: Identity::none(),
-            batch_signing_public_keys: IntoIter::new([
+            batch_signing_public_keys: IntoIterator::into_iter([
                 (
                     "batch-signing-key-1".to_owned(),
                     BatchSigningPublicKey {
@@ -1821,7 +1821,7 @@ mod tests {
                 ),
             ])
             .collect(),
-            packet_encryption_keys: IntoIter::new([
+            packet_encryption_keys: IntoIterator::into_iter([
                 (
                     "packet-encryption-key-1".to_owned(),
                     PacketEncryptionCertificateSigningRequest {

--- a/facilitator/src/transport/local.rs
+++ b/facilitator/src/transport/local.rs
@@ -29,7 +29,7 @@ impl LocalFileTransport {
     /// attempts to convert the provided key into a relative path valid for the
     /// current platform.
     fn relative_path(key: &str) -> PathBuf {
-        PathBuf::from(key.replace("/", &MAIN_SEPARATOR.to_string()))
+        PathBuf::from(key.replace('/', &MAIN_SEPARATOR.to_string()))
     }
 }
 


### PR DESCRIPTION
This fixes a new Clippy warning (stabilized with the release of rust 1.59), clippy::single_char_pattern, and test-only uses of a newly deprecated function, IntoIter::new() (also deprecated in rust 1.59).

(Note that the new Clippy warning would manifest as CI failures once GitHub updates their base images)