### PR TITLE
Fix failure rate alerting, new alert for rejecting

### DIFF
--- a/facilitator/src/bin/facilitator.rs
+++ b/facilitator/src/bin/facilitator.rs
@@ -1732,14 +1732,18 @@ where
     let result = batch_intaker.generate_validation_share(callback);
 
     if let Some(collector) = metrics_collector {
-        match result {
+        match &result {
             Ok(()) => collector
                 .intake_tasks_finished
                 .with_label_values(&["success", aggregation_id])
                 .inc(),
-            Err(_) => collector
+            Err(e) if e.is_retryable() => collector
                 .intake_tasks_finished
                 .with_label_values(&["error", aggregation_id])
+                .inc(),
+            Err(_) => collector
+                .intake_tasks_finished
+                .with_label_values(&["rejected", aggregation_id])
                 .inc(),
         }
     }
@@ -2011,14 +2015,18 @@ where
     let result = aggregator.generate_sum_part(&parsed_batches, callback);
 
     if let Some(collector) = metrics_collector {
-        match result {
+        match &result {
             Ok(()) => collector
                 .aggregate_tasks_finished
                 .with_label_values(&["success", aggregation_id])
                 .inc(),
-            Err(_) => collector
+            Err(e) if e.is_retryable() => collector
                 .aggregate_tasks_finished
                 .with_label_values(&["error", aggregation_id])
+                .inc(),
+            Err(_) => collector
+                .aggregate_tasks_finished
+                .with_label_values(&["rejected", aggregation_id])
                 .inc(),
         }
     }

--- a/terraform/modules/monitoring/prometheus_alerting_rules.yml
+++ b/terraform/modules/monitoring/prometheus_alerting_rules.yml
@@ -14,8 +14,8 @@ groups:
         instance {{ $labels.locality }}-{{ $labels.ingestor }} in environment
         ${environment} last ran successfully"
   - alert: facilitator_intake_failure_rate
-    expr: rate(facilitator_intake_tasks_finished{status="success"}[1h])
-      / rate(facilitator_intake_tasks_finished[1h]) < 0.95
+    expr: (sum without (status) (rate(facilitator_intake_tasks_finished{status="success"}[1h])))
+      / (sum without (status) (rate(facilitator_intake_tasks_finished[1h]))) < 0.95
     for: 5m
     labels:
       severity: page
@@ -25,11 +25,11 @@ groups:
         {{ $labels.kubernetes_namespace }}-{{ $labels.kubernetes_name }}"
       description: "intake worker instance {{ $labels.kubernetes_namespace }}-
         {{ $labels.kubernetes_name }} in environment ${environment} is failing
-        more than 95% of the time in the last hour"
+        more than 5% of the time in the last hour"
   - alert: facilitator_aggregate_failure_rate
     # aggregations run much less often than intake so use a larger window of time
-    expr: rate(facilitator_aggregate_tasks_finished{status="success"}[${aggregation_period}])
-      / rate(facilitator_aggregate_tasks_finished[${aggregation_period}]) < 0.95
+    expr: (sum without (status) (rate(facilitator_aggregate_tasks_finished{status="success"}[${aggregation_period}])))
+      / (sum without (status) (rate(facilitator_aggregate_tasks_finished[${aggregation_period}]))) < 0.95
     for: 5m
     labels:
       severity: page
@@ -39,7 +39,33 @@ groups:
         {{ $labels.kubernetes_namespace }}-{{ $labels.kubernetes_name }}"
       description: "aggregate worker instance {{ $labels.kubernetes_namespace}}-
         {{ $labels.kubernetes_name }} in environment ${environment} is failing
-        more than 95% of the time in the last 8 hours"
+        more than 5% of the time in the last 8 hours"
+  - alert: facilitator_intake_rejection_rate
+    expr: (sum without (status) (rate(facilitator_intake_tasks_finished{status="rejected"}[1h])))
+      / (sum without (status) (rate(facilitator_intake_tasks_finished[1h]))) > 0.01
+    for: 5m
+    labels:
+      severity: page
+      environment: ${environment}
+    annotations:
+      summary: "High rejection rate for intake worker
+        {{ $labels.kubernetes_namespace }}-{{ $labels.kubernetes_name }}"
+      description: "intake worker instance {{ $labels.kubernetes_namespace }}-
+        {{ $labels.kubernetes_name }} in environment ${environment} has
+        rejected more than 1% of tasks in the last hour"
+  - alert: facilitator_aggregate_rejection_rate
+    expr: (sum without (status) (rate(facilitator_aggregate_tasks_finished{status="rejected"}[${aggregation_period}])))
+      / (sum without (status) (rate(facilitator_aggregate_tasks_finished[${aggregation_period}]))) > 0.01
+    for: 5m
+    labels:
+      severity: page
+      environment: ${environment}
+    annotations:
+      summary: "High rejection rate for aggregate worker
+        {{ $labels.kubernetes_namespace }}-{{ $labels.kubernetes_name }}"
+      description: "aggregate worker instance {{ $labels.kubernetes_namespace }}-
+        {{ $labels.kubernetes_name }} in environment ${environment} has
+        rejected more than 1% of tasks in the last 8 hours"
   - alert: intake_task_queue_growth
     expr: min_over_time(stackdriver_pubsub_subscription_pubsub_googleapis_com_subscription_num_undelivered_messages{subscription_id!~".*-dead-letter",subscription_id=~".*-intake"}[30m]) > 0
     for: 3h


### PR DESCRIPTION
This fixes an issue with the expressions used for failure rate alerting. It also introduces a new value of "rejected" for the label "status", on the "tasks_finished" metrics, for tasks that result in a non-retryable error. We apply the "rejected" value when we divert the task to a separate rejected queue, rather than let it reach the dead letter queue. A new alert is introduced to monitor the fraction of tasks being rejected, and alert if it is too high.

~~Edit: deploy note - this will require deleting the secret monitoring/prometheus-alertmanager-config and running Terraform to re-populate it~~