### PR TITLE
During aggregation, require ingestion header parameters to match.

### DIFF
--- a/facilitator/src/idl.rs
+++ b/facilitator/src/idl.rs
@@ -233,7 +233,10 @@ pub struct IngestionHeader {
 
 impl IngestionHeader {
     #[allow(clippy::float_cmp)]
-    pub fn check_parameters(&self, validation_header: &ValidationHeader) -> bool {
+    pub fn check_parameters_against_validation(
+        &self,
+        validation_header: &ValidationHeader,
+    ) -> bool {
         self.batch_uuid == validation_header.batch_uuid
             && self.name == validation_header.name
             && self.bins == validation_header.bins
@@ -241,6 +244,18 @@ impl IngestionHeader {
             && self.prime == validation_header.prime
             && self.number_of_servers == validation_header.number_of_servers
             && self.hamming_weight == validation_header.hamming_weight
+    }
+
+    pub fn check_parameters_against_ingestion(
+        &self,
+        other_ingestion_header: &IngestionHeader,
+    ) -> bool {
+        self.name == other_ingestion_header.name
+            && self.bins == other_ingestion_header.bins
+            && self.epsilon == other_ingestion_header.epsilon
+            && self.prime == other_ingestion_header.prime
+            && self.number_of_servers == other_ingestion_header.number_of_servers
+            && self.hamming_weight == other_ingestion_header.hamming_weight
     }
 }
 


### PR DESCRIPTION
Previously, we didn't check, and would happily aggregate even if some of
the parameters didn't match--but at a higher level, data with different
parameters can't be meaningfully aggreagated, so this produced
non-useful output. All we can do is notice & complain, but we should do
so rather than producing bad output.