### PR TITLE
terraform: include status of working dir. in state

### DIFF
--- a/terraform/cluster_bootstrap/.terraform.lock.hcl
+++ b/terraform/cluster_bootstrap/.terraform.lock.hcl
@@ -20,6 +20,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/external" {
+  version     = "2.2.0"
+  constraints = "2.2.0"
+  hashes = [
+    "h1:iU5OVMibHvIxbj2Dye1q3aYpjYXS3bKL9iZWZyh+xTg=",
+    "zh:094c3cfae140fbb70fb0e272b1df833b4d7467c6c819fbf59a3e8ac0922f95b6",
+    "zh:15c3906abbc1cd03a72afd02bda9caeeb5f6ca421292c32ddeb2acd7a3488669",
+    "zh:388c14bceeb1593bb16cadedc8f5ad7d41d398197db049dc0871bc847aa61083",
+    "zh:5696772136b6763faade0cc065fafc2bf06493021b943826be0144790fae514a",
+    "zh:6427c693b1b750644d5b633395e54617dc36ae717a531a5cde8cb0246b6593ca",
+    "zh:7196d9845eeffa3158f5e3067bf8b7ad489490aa26d29e2da1ad4c8924463469",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8850d3ce9e5f5776b9349890ce4e2c4056defe16ed741dc845045942a6d9e025",
+    "zh:a2c6fc6cf087b35ebd6b6f20272ed32d4217ea9936c1dd630baa46d86718a455",
+    "zh:ac709be4ea5c9a6e1ab80e864d24cd9f8e6aaea29fb5dbe1de0897e2e86c3c17",
+    "zh:dcf806f044801fae5b21ae2754dc3c19c68e458d4584965752ce49be75305ff5",
+    "zh:f875b34be86c3439899828978638ef7e2d41a9e5e32397858a0c31daeaa1abc2",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "4.11.0"
   constraints = "~> 4.11.0"

--- a/terraform/cluster_bootstrap/main.tf
+++ b/terraform/cluster_bootstrap/main.tf
@@ -108,6 +108,10 @@ terraform {
       # Keep this version in sync with provider google
       version = "~> 4.11.0"
     }
+    external = {
+      source  = "hashicorp/external"
+      version = "2.2.0"
+    }
   }
 }
 
@@ -157,4 +161,12 @@ module "eks" {
 
 output "google_kms_key_ring_id" {
   value = var.use_aws ? "" : module.gke[0].google_kms_key_ring_id
+}
+
+data "external" "git-describe" {
+  program = ["bash", "-c", "echo {\\\"result\\\":\\\"$(git describe --always --dirty)\\\"}"]
+}
+
+output "git-describe" {
+  value = data.external.git-describe.result.result
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -381,6 +381,10 @@ terraform {
       source  = "gavinbunney/kubectl"
       version = "~> 1.13.1"
     }
+    external = {
+      source  = "hashicorp/external"
+      version = "2.2.0"
+    }
   }
 }
 
@@ -843,4 +847,12 @@ module "monitoring" {
   grafana_helm_chart_version              = var.grafana_helm_chart_version
   cloudwatch_exporter_helm_chart_version  = var.cloudwatch_exporter_helm_chart_version
   stackdriver_exporter_helm_chart_version = var.stackdriver_exporter_helm_chart_version
+}
+
+data "external" "git-describe" {
+  program = ["bash", "-c", "echo {\\\"result\\\":\\\"$(git describe --always --dirty)\\\"}"]
+}
+
+output "git-describe" {
+  value = data.external.git-describe.result.result
 }


### PR DESCRIPTION
This adds a data source to both Terraform main modules to shell out to git in order to record the checked out commit. The commit hash will be stored in the state, and I included it in an output from the module for convenience.

Sample output:

```diff
Changes to Outputs:
+ git-describe = "52972e5-dirty"
```

What do we think, is this worth having?

(Note that terraform/.terraform.lock.hcl already contains the `external` provider, as it is already used in `data_share_processor`, without inclusion in `required_providers`)