### PR TITLE
terraform: configure log retention period

### DIFF
--- a/terraform/cluster_bootstrap/modules/eks/eks.tf
+++ b/terraform/cluster_bootstrap/modules/eks/eks.tf
@@ -233,6 +233,13 @@ resource "aws_eks_cluster" "cluster" {
       key_arn = aws_kms_key.etcd_secrets.arn
     }
   }
+
+  depends_on = [aws_cloudwatch_log_group.cluster_logs]
+}
+
+resource "aws_cloudwatch_log_group" "cluster_logs" {
+  name              = "/aws/eks/${var.resource_prefix}/cluster"
+  retention_in_days = 7
 }
 
 data "tls_certificate" "cluster" {

--- a/terraform/cluster_bootstrap/modules/eks/eks.tf
+++ b/terraform/cluster_bootstrap/modules/eks/eks.tf
@@ -239,7 +239,7 @@ resource "aws_eks_cluster" "cluster" {
 
 resource "aws_cloudwatch_log_group" "cluster_logs" {
   name              = "/aws/eks/${var.resource_prefix}/cluster"
-  retention_in_days = 7
+  retention_in_days = 180
 }
 
 data "tls_certificate" "cluster" {

--- a/terraform/modules/eks/config/application-log.conf
+++ b/terraform/modules/eks/config/application-log.conf
@@ -58,5 +58,6 @@
     region              ${AWS_REGION}
     log_group_name      /aws/containerinsights/${CLUSTER_NAME}/application
     log_stream_prefix   ${HOST_NAME}-
+    log_retention_days  180
     auto_create_group   true
     extra_user_agent    container-insights

--- a/terraform/modules/eks/config/dataplane-log.conf
+++ b/terraform/modules/eks/config/dataplane-log.conf
@@ -42,5 +42,6 @@
     region              ${AWS_REGION}
     log_group_name      /aws/containerinsights/${CLUSTER_NAME}/dataplane
     log_stream_prefix   ${HOST_NAME}-
+    log_retention_days  180
     auto_create_group   true
     extra_user_agent    container-insights

--- a/terraform/modules/eks/config/host-log.conf
+++ b/terraform/modules/eks/config/host-log.conf
@@ -42,5 +42,6 @@
     region              ${AWS_REGION}
     log_group_name      /aws/containerinsights/${CLUSTER_NAME}/host
     log_stream_prefix   ${HOST_NAME}.
+    log_retention_days  180
     auto_create_group   true
     extra_user_agent    container-insights


### PR DESCRIPTION
This fixes #1391. We can hold off on merging this until we want to deal with the manual Terraform migration required, (or combine it with other such changes) but I figured I may as well get it written up and tested.

This change will require importing the log group that EKS already created, to keep Terraform from trying to create it again and finding that its name is already in use. For example:

Run at least one makefile target to make sure that cluster_bootstrap/.terraform/terraform.tfstate points to the correct backend bucket for this environment.
`$ ENV=<environment name> make plan-cluster-bootstrap`
Import the log group resource. (The easiest way to get the log group's name is to attempt to apply once, and look at the log group name in the error message)
`$ ENV=<environment name> terraform -chdir=cluster_bootstrap import -var-file=../variables/<environment name>.tfvars -input=false module.eks[0].aws_cloudwatch_log_group.cluster_logs /aws/eks/prio-<environment name>/cluster`
Finally, apply the changes. This should add a prio-env tag to the log group, and set its retention period.
`$ ENV=<environment name> make apply-cluster-bootstrap`