### PR TITLE
Update staging to 0.6.29.

### DIFF
--- a/terraform/variables/staging-intl.tfvars
+++ b/terraform/variables/staging-intl.tfvars
@@ -44,9 +44,9 @@ cluster_settings = {
 is_first                 = false
 use_aws                  = true
 pure_gcp                 = true
-workflow_manager_version = "0.6.28"
-facilitator_version      = "0.6.28"
-key_rotator_version      = "0.6.28"
+workflow_manager_version = "0.6.29"
+facilitator_version      = "0.6.29"
+key_rotator_version      = "0.6.29"
 victorops_routing_key    = "prio-staging"
 
 default_aggregation_period       = "30m"

--- a/terraform/variables/stg-us-facil.tfvars
+++ b/terraform/variables/stg-us-facil.tfvars
@@ -74,9 +74,9 @@ test_peer_environment = {
 }
 is_first                 = false
 use_aws                  = false
-workflow_manager_version = "0.6.28"
-facilitator_version      = "0.6.28"
-key_rotator_version      = "0.6.28"
+workflow_manager_version = "0.6.29"
+facilitator_version      = "0.6.29"
+key_rotator_version      = "0.6.29"
 victorops_routing_key    = "prio-staging"
 
 intake_max_age             = "75m"

--- a/terraform/variables/stg-us-pha.tfvars
+++ b/terraform/variables/stg-us-pha.tfvars
@@ -79,9 +79,9 @@ test_peer_environment = {
 }
 is_first                 = true
 use_aws                  = true
-workflow_manager_version = "0.6.28"
-facilitator_version      = "0.6.28"
-key_rotator_version      = "0.6.28"
+workflow_manager_version = "0.6.29"
+facilitator_version      = "0.6.29"
+key_rotator_version      = "0.6.29"
 victorops_routing_key    = "prio-staging"
 
 intake_max_age             = "75m"


### PR DESCRIPTION
Diff for stg-facil (it's just container version updates):

<details>
```
Terraform will perform the following actions:

  # module.fake_server_resources[0].kubernetes_deployment.integration-test-sample-generator["asgard-ingestor-1"] will be updated in-place
  ~ resource "kubernetes_deployment" "integration-test-sample-generator" {
        id               = "tester/integration-test-sample-generator-asgard-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "integration-test-sample-generator"
                        # (8 unchanged attributes hidden)


                        # (4 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.fake_server_resources[0].kubernetes_deployment.integration-test-sample-generator["asgard-ingestor-2"] will be updated in-place
  ~ resource "kubernetes_deployment" "integration-test-sample-generator" {
        id               = "tester/integration-test-sample-generator-asgard-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "integration-test-sample-generator"
                        # (8 unchanged attributes hidden)


                        # (4 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.fake_server_resources[0].kubernetes_deployment.integration-test-sample-generator["gondor-ingestor-1"] will be updated in-place
  ~ resource "kubernetes_deployment" "integration-test-sample-generator" {
        id               = "tester/integration-test-sample-generator-gondor-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "integration-test-sample-generator"
                        # (8 unchanged attributes hidden)


                        # (4 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.fake_server_resources[0].kubernetes_deployment.integration-test-sample-generator["gondor-ingestor-2"] will be updated in-place
  ~ resource "kubernetes_deployment" "integration-test-sample-generator" {
        id               = "tester/integration-test-sample-generator-gondor-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "integration-test-sample-generator"
                        # (8 unchanged attributes hidden)


                        # (4 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.fake_server_resources[0].kubernetes_deployment.integration-test-sample-generator["narnia-ingestor-1"] will be updated in-place
  ~ resource "kubernetes_deployment" "integration-test-sample-generator" {
        id               = "tester/integration-test-sample-generator-narnia-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "integration-test-sample-generator"
                        # (8 unchanged attributes hidden)


                        # (4 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.fake_server_resources[0].kubernetes_deployment.integration-test-sample-generator["narnia-ingestor-2"] will be updated in-place
  ~ resource "kubernetes_deployment" "integration-test-sample-generator" {
        id               = "tester/integration-test-sample-generator-narnia-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "integration-test-sample-generator"
                        # (8 unchanged attributes hidden)


                        # (4 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.fake_server_resources[0].kubernetes_deployment.integration-test-sample-validator["asgard-ingestor-1"] will be updated in-place
  ~ resource "kubernetes_deployment" "integration-test-sample-validator" {
        id               = "tester/integration-test-sample-validator-asgard-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "integration-test-sample-validator"
                        # (8 unchanged attributes hidden)


                        # (3 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.fake_server_resources[0].kubernetes_deployment.integration-test-sample-validator["asgard-ingestor-2"] will be updated in-place
  ~ resource "kubernetes_deployment" "integration-test-sample-validator" {
        id               = "tester/integration-test-sample-validator-asgard-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "integration-test-sample-validator"
                        # (8 unchanged attributes hidden)


                        # (3 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.fake_server_resources[0].kubernetes_deployment.integration-test-sample-validator["gondor-ingestor-1"] will be updated in-place
  ~ resource "kubernetes_deployment" "integration-test-sample-validator" {
        id               = "tester/integration-test-sample-validator-gondor-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "integration-test-sample-validator"
                        # (8 unchanged attributes hidden)


                        # (3 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.fake_server_resources[0].kubernetes_deployment.integration-test-sample-validator["gondor-ingestor-2"] will be updated in-place
  ~ resource "kubernetes_deployment" "integration-test-sample-validator" {
        id               = "tester/integration-test-sample-validator-gondor-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "integration-test-sample-validator"
                        # (8 unchanged attributes hidden)


                        # (3 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.fake_server_resources[0].kubernetes_deployment.integration-test-sample-validator["narnia-ingestor-1"] will be updated in-place
  ~ resource "kubernetes_deployment" "integration-test-sample-validator" {
        id               = "tester/integration-test-sample-validator-narnia-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "integration-test-sample-validator"
                        # (8 unchanged attributes hidden)


                        # (3 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.fake_server_resources[0].kubernetes_deployment.integration-test-sample-validator["narnia-ingestor-2"] will be updated in-place
  ~ resource "kubernetes_deployment" "integration-test-sample-validator" {
        id               = "tester/integration-test-sample-validator-narnia-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "integration-test-sample-validator"
                        # (8 unchanged attributes hidden)


                        # (3 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.kubernetes_locality["asgard"].kubernetes_cron_job.key_rotator will be updated in-place
  ~ resource "kubernetes_cron_job" "key_rotator" {
        id = "asgard/stg-us-facil-key-rotator-asgard"


      ~ spec {
            # (6 unchanged attributes hidden)

          ~ job_template {

              ~ spec {
                    # (5 unchanged attributes hidden)

                  ~ template {

                      ~ spec {
                            # (12 unchanged attributes hidden)

                          ~ container {
                              ~ image                      = "letsencrypt/prio-key-rotator:0.6.28" -> "letsencrypt/prio-key-rotator:0.6.29"
                                name                       = "key-rotator"
                                # (8 unchanged attributes hidden)

                                # (1 unchanged block hidden)
                            }
                        }
                        # (1 unchanged block hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
        }
        # (1 unchanged block hidden)
    }

  # module.kubernetes_locality["gondor"].kubernetes_cron_job.key_rotator will be updated in-place
  ~ resource "kubernetes_cron_job" "key_rotator" {
        id = "gondor/stg-us-facil-key-rotator-gondor"


      ~ spec {
            # (6 unchanged attributes hidden)

          ~ job_template {

              ~ spec {
                    # (5 unchanged attributes hidden)

                  ~ template {

                      ~ spec {
                            # (12 unchanged attributes hidden)

                          ~ container {
                              ~ image                      = "letsencrypt/prio-key-rotator:0.6.28" -> "letsencrypt/prio-key-rotator:0.6.29"
                                name                       = "key-rotator"
                                # (8 unchanged attributes hidden)

                                # (1 unchanged block hidden)
                            }
                        }
                        # (1 unchanged block hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
        }
        # (1 unchanged block hidden)
    }

  # module.kubernetes_locality["narnia"].kubernetes_cron_job.key_rotator will be updated in-place
  ~ resource "kubernetes_cron_job" "key_rotator" {
        id = "narnia/stg-us-facil-key-rotator-narnia"


      ~ spec {
            # (6 unchanged attributes hidden)

          ~ job_template {

              ~ spec {
                    # (5 unchanged attributes hidden)

                  ~ template {

                      ~ spec {
                            # (12 unchanged attributes hidden)

                          ~ container {
                              ~ image                      = "letsencrypt/prio-key-rotator:0.6.28" -> "letsencrypt/prio-key-rotator:0.6.29"
                                name                       = "key-rotator"
                                # (8 unchanged attributes hidden)

                                # (1 unchanged block hidden)
                            }
                        }
                        # (1 unchanged block hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["asgard-ingestor-1"].module.kubernetes.kubernetes_cron_job.workflow_manager will be updated in-place
  ~ resource "kubernetes_cron_job" "workflow_manager" {
        id = "asgard/workflow-manager-ingestor-1-stg-us-facil"


      ~ spec {
            # (6 unchanged attributes hidden)

          ~ job_template {

              ~ spec {
                    # (5 unchanged attributes hidden)

                  ~ template {

                      ~ spec {
                            # (12 unchanged attributes hidden)

                          ~ container {
                              ~ image                      = "letsencrypt/prio-workflow-manager:0.6.28" -> "letsencrypt/prio-workflow-manager:0.6.29"
                                name                       = "workflow-manager"
                                # (8 unchanged attributes hidden)

                                # (1 unchanged block hidden)
                            }
                        }
                        # (1 unchanged block hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["asgard-ingestor-1"].module.kubernetes.kubernetes_deployment.aggregate will be updated in-place
  ~ resource "kubernetes_deployment" "aggregate" {
        id               = "asgard/aggregate-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["asgard-ingestor-1"].module.kubernetes.kubernetes_deployment.intake_batch will be updated in-place
  ~ resource "kubernetes_deployment" "intake_batch" {
        id               = "asgard/intake-batch-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["asgard-ingestor-2"].module.kubernetes.kubernetes_cron_job.workflow_manager will be updated in-place
  ~ resource "kubernetes_cron_job" "workflow_manager" {
        id = "asgard/workflow-manager-ingestor-2-stg-us-facil"


      ~ spec {
            # (6 unchanged attributes hidden)

          ~ job_template {

              ~ spec {
                    # (5 unchanged attributes hidden)

                  ~ template {

                      ~ spec {
                            # (12 unchanged attributes hidden)

                          ~ container {
                              ~ image                      = "letsencrypt/prio-workflow-manager:0.6.28" -> "letsencrypt/prio-workflow-manager:0.6.29"
                                name                       = "workflow-manager"
                                # (8 unchanged attributes hidden)

                                # (1 unchanged block hidden)
                            }
                        }
                        # (1 unchanged block hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["asgard-ingestor-2"].module.kubernetes.kubernetes_deployment.aggregate will be updated in-place
  ~ resource "kubernetes_deployment" "aggregate" {
        id               = "asgard/aggregate-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["asgard-ingestor-2"].module.kubernetes.kubernetes_deployment.intake_batch will be updated in-place
  ~ resource "kubernetes_deployment" "intake_batch" {
        id               = "asgard/intake-batch-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["gondor-ingestor-1"].module.kubernetes.kubernetes_cron_job.workflow_manager will be updated in-place
  ~ resource "kubernetes_cron_job" "workflow_manager" {
        id = "gondor/workflow-manager-ingestor-1-stg-us-facil"


      ~ spec {
            # (6 unchanged attributes hidden)

          ~ job_template {

              ~ spec {
                    # (5 unchanged attributes hidden)

                  ~ template {

                      ~ spec {
                            # (12 unchanged attributes hidden)

                          ~ container {
                              ~ image                      = "letsencrypt/prio-workflow-manager:0.6.28" -> "letsencrypt/prio-workflow-manager:0.6.29"
                                name                       = "workflow-manager"
                                # (8 unchanged attributes hidden)

                                # (1 unchanged block hidden)
                            }
                        }
                        # (1 unchanged block hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["gondor-ingestor-1"].module.kubernetes.kubernetes_deployment.aggregate will be updated in-place
  ~ resource "kubernetes_deployment" "aggregate" {
        id               = "gondor/aggregate-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["gondor-ingestor-1"].module.kubernetes.kubernetes_deployment.intake_batch will be updated in-place
  ~ resource "kubernetes_deployment" "intake_batch" {
        id               = "gondor/intake-batch-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["gondor-ingestor-2"].module.kubernetes.kubernetes_cron_job.workflow_manager will be updated in-place
  ~ resource "kubernetes_cron_job" "workflow_manager" {
        id = "gondor/workflow-manager-ingestor-2-stg-us-facil"


      ~ spec {
            # (6 unchanged attributes hidden)

          ~ job_template {

              ~ spec {
                    # (5 unchanged attributes hidden)

                  ~ template {

                      ~ spec {
                            # (12 unchanged attributes hidden)

                          ~ container {
                              ~ image                      = "letsencrypt/prio-workflow-manager:0.6.28" -> "letsencrypt/prio-workflow-manager:0.6.29"
                                name                       = "workflow-manager"
                                # (8 unchanged attributes hidden)

                                # (1 unchanged block hidden)
                            }
                        }
                        # (1 unchanged block hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["gondor-ingestor-2"].module.kubernetes.kubernetes_deployment.aggregate will be updated in-place
  ~ resource "kubernetes_deployment" "aggregate" {
        id               = "gondor/aggregate-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["gondor-ingestor-2"].module.kubernetes.kubernetes_deployment.intake_batch will be updated in-place
  ~ resource "kubernetes_deployment" "intake_batch" {
        id               = "gondor/intake-batch-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["narnia-ingestor-1"].module.kubernetes.kubernetes_cron_job.workflow_manager will be updated in-place
  ~ resource "kubernetes_cron_job" "workflow_manager" {
        id = "narnia/workflow-manager-ingestor-1-stg-us-facil"


      ~ spec {
            # (6 unchanged attributes hidden)

          ~ job_template {

              ~ spec {
                    # (5 unchanged attributes hidden)

                  ~ template {

                      ~ spec {
                            # (12 unchanged attributes hidden)

                          ~ container {
                              ~ image                      = "letsencrypt/prio-workflow-manager:0.6.28" -> "letsencrypt/prio-workflow-manager:0.6.29"
                                name                       = "workflow-manager"
                                # (8 unchanged attributes hidden)

                                # (1 unchanged block hidden)
                            }
                        }
                        # (1 unchanged block hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["narnia-ingestor-1"].module.kubernetes.kubernetes_deployment.aggregate will be updated in-place
  ~ resource "kubernetes_deployment" "aggregate" {
        id               = "narnia/aggregate-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["narnia-ingestor-1"].module.kubernetes.kubernetes_deployment.intake_batch will be updated in-place
  ~ resource "kubernetes_deployment" "intake_batch" {
        id               = "narnia/intake-batch-ingestor-1"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["narnia-ingestor-2"].module.kubernetes.kubernetes_cron_job.workflow_manager will be updated in-place
  ~ resource "kubernetes_cron_job" "workflow_manager" {
        id = "narnia/workflow-manager-ingestor-2-stg-us-facil"


      ~ spec {
            # (6 unchanged attributes hidden)

          ~ job_template {

              ~ spec {
                    # (5 unchanged attributes hidden)

                  ~ template {

                      ~ spec {
                            # (12 unchanged attributes hidden)

                          ~ container {
                              ~ image                      = "letsencrypt/prio-workflow-manager:0.6.28" -> "letsencrypt/prio-workflow-manager:0.6.29"
                                name                       = "workflow-manager"
                                # (8 unchanged attributes hidden)

                                # (1 unchanged block hidden)
                            }
                        }
                        # (1 unchanged block hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["narnia-ingestor-2"].module.kubernetes.kubernetes_deployment.aggregate will be updated in-place
  ~ resource "kubernetes_deployment" "aggregate" {
        id               = "narnia/aggregate-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

  # module.data_share_processors["narnia-ingestor-2"].module.kubernetes.kubernetes_deployment.intake_batch will be updated in-place
  ~ resource "kubernetes_deployment" "intake_batch" {
        id               = "narnia/intake-batch-ingestor-2"
        # (1 unchanged attribute hidden)


      ~ spec {
            # (5 unchanged attributes hidden)



          ~ template {

              ~ spec {
                    # (12 unchanged attributes hidden)

                  ~ container {
                      ~ image                      = "letsencrypt/prio-facilitator:0.6.28" -> "letsencrypt/prio-facilitator:0.6.29"
                        name                       = "facile-container"
                        # (8 unchanged attributes hidden)



                        # (7 unchanged blocks hidden)
                    }
                }
                # (1 unchanged block hidden)
            }
            # (2 unchanged blocks hidden)
        }
        # (1 unchanged block hidden)
    }

Plan: 0 to add, 33 to change, 0 to destroy.
```
</details>