### PR TITLE
Bump go version in CI to 1.18

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -111,7 +111,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.17
+        go-version: 1.18
     - name: Test
       run: go test -race --coverprofile=cover.out --covermode=atomic ./...
     - name: Upload test coverage
@@ -144,7 +144,7 @@ jobs:
     - name: Setup go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.17
+        go-version: 1.18
     - name: Test
       run: go test -race -coverprofile=cover.out --covermode=atomic ./...
     - name: Upload test coverage


### PR DESCRIPTION
This is follow-up to #1471 and #1480, to use go 1.18 in CI tests as well.